### PR TITLE
Enable cargo-deny license check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,6 @@ jobs:
 
     - name: Audit dependencies
       uses: EmbarkStudios/cargo-deny-action@v1
-      # TODO: Check licenses, too.
-      with:
-        command: check bans advisories sources
 
   lint:
     needs: test

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,6 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
-        # TODO: Check licenses, too.
-        with:
-          command: check bans advisories sources
+


### PR DESCRIPTION
This PR addresses https://github.com/cryspen/bertie/pull/24#issuecomment-1149699837.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Automation (?)

## Motivation and Context

Bertie should automatically check that all licenses are compatible. Currently, this is not possible, because some of the used dependencies are unlicensed. This PR should be merged as soon as the license situation has been improved.

## Changes

Enable cargo-deny license check in CI.

## Checklist
- [x] I have linked an issue to this PR
- [x] I have described the changes
- [x] I have read and understood the code of conduct, contribution guidelines, and contributor license agreement
- [x] I have added tests for all changes
- [x] I have tested that all tests pass locally and all checks pass
- [x] I have updated documentation if necessary

## Fixes

No issue created for this.