### PR TITLE
Work on simple_https_client.

### DIFF
--- a/simple_https_client/Cargo.toml
+++ b/simple_https_client/Cargo.toml
@@ -10,15 +10,19 @@ path = "src/tls13client.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.0"
-hex = "0.4.3"
-hacspec-lib = { git = "https://github.com/hacspec/hacspec", package = "hacspec-lib" }
-hacspec-dev = { git = "https://github.com/hacspec/hacspec", package = "hacspec-dev" }
-hacspec_cryptolib = { git = "https://github.com/cryspen/utils", optional = true, package = "hacspec_cryptolib" }
+anyhow = "1"
+bertie = { path = "../" }
 evercrypt_cryptolib = { git = "https://github.com/cryspen/utils", optional = true, package = "evercrypt_cryptolib" }
-bertie = {path = "../"}
+hacspec_cryptolib = { git = "https://github.com/cryspen/utils", optional = true, package = "hacspec_cryptolib" }
+hacspec-dev = { git = "https://github.com/hacspec/hacspec", package = "hacspec-dev" }
+hacspec-lib = { git = "https://github.com/hacspec/hacspec", package = "hacspec-lib" }
+hex = "0.4.3"
+rand = "0.8.0"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = "0.2"
 
 [features]
 default = ["hacspec"]
-hacspec = ["hacspec_cryptolib"]
 evercrypt = ["evercrypt_cryptolib"]
+hacspec = ["hacspec_cryptolib"]

--- a/simple_https_client/src/debug.rs
+++ b/simple_https_client/src/debug.rs
@@ -1,0 +1,49 @@
+use std::fmt::{Display, Formatter};
+
+use bertie::{get_alert_description, get_alert_level, get_content_type, get_hs_type, ContentType};
+use tracing::{error, info};
+
+/// For debugging only.
+pub fn info_record(record: &[u8]) {
+    if record.len() >= 1 {
+        let content_type = get_content_type(record[0]);
+
+        match content_type {
+            Ok(ContentType::Handshake) => {
+                if record.len() >= 6 {
+                    let handshake_type = get_hs_type(record[5]);
+                    info!(?content_type, ?handshake_type, "TLS record.");
+                } else {
+                    error!("Record incomplete.");
+                }
+            }
+            Ok(ContentType::Alert) => {
+                if record.len() >= 7 {
+                    let alert_type = get_alert_level(record[5]);
+                    let alert_description = get_alert_description(record[6]);
+                    info!(
+                        ?content_type,
+                        ?alert_type,
+                        ?alert_description,
+                        "TLS record."
+                    );
+                } else {
+                    error!("Record incomplete.");
+                }
+            }
+            _ => {
+                info!(?content_type, "TLS record.");
+            }
+        }
+    } else {
+        error!("Record incomplete.");
+    }
+}
+
+pub struct Hex<'a>(pub &'a [u8]);
+
+impl<'a> Display for Hex<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}

--- a/simple_https_client/src/lib.rs
+++ b/simple_https_client/src/lib.rs
@@ -1,0 +1,208 @@
+//! # Simple TLS 1.3 HTTP Client Implementation
+//!
+//! It connects to a given host:port, sends an HTTP "GET /", and prints a prefix of the HTTP response.
+//!
+//! WARNING: This code is not in hacspec since it need to use TCP etc.
+
+#![allow(non_upper_case_globals)]
+
+use std::io::{Read, Write};
+
+use anyhow::Result;
+use bertie::{tls13api::*, tls13utils::*};
+#[cfg(feature = "evercrypt")]
+use evercrypt_cryptolib::*;
+#[cfg(not(feature = "evercrypt"))]
+use hacspec_cryptolib::*;
+use hacspec_lib::*;
+use rand::*;
+use thiserror::Error;
+use tracing::{error, info};
+
+use crate::stream::RecordStream;
+
+mod debug;
+mod stream;
+
+const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms(
+    HashAlgorithm::SHA256,
+    AeadAlgorithm::Aes128Gcm,
+    SignatureScheme::EcdsaSecp256r1Sha256,
+    NamedGroup::X25519,
+    false,
+    false,
+);
+
+/*
+const SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519: Algorithms = Algorithms(
+    HashAlgorithm::SHA256,
+    AeadAlgorithm::Chacha20Poly1305,
+    SignatureScheme::RsaPssRsaSha256,
+    NamedGroup::X25519,
+    false,
+    false,
+);
+*/
+
+const default_algs: Algorithms = SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519;
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("I/O error: {0:?}")]
+    Io(std::io::Error),
+    #[error("TLS error: {0:?}")]
+    TLS(TLSError),
+}
+
+impl From<std::io::Error> for ClientError {
+    fn from(error: std::io::Error) -> Self {
+        ClientError::Io(error)
+    }
+}
+
+impl From<TLSError> for ClientError {
+    fn from(error: TLSError) -> Self {
+        ClientError::TLS(error)
+    }
+}
+
+#[tracing::instrument(skip(stream, request))]
+pub fn tls13client<Stream>(
+    host: &str,
+    stream: Stream,
+    request: &str,
+) -> Result<(RecordStream<Stream>, Client, Vec<u8>), ClientError>
+where
+    Stream: Read + Write,
+{
+    // Create a stream that is framed by TLS records.
+    let mut stream = RecordStream::new(stream);
+
+    // # Execute the TLS 1.3 handshake.
+
+    // Initialize TLS 1.3 client.
+    let (client_hello, cstate) = {
+        let sni = ByteSeq::from_public_slice(&host.as_bytes());
+        let ent = {
+            let mut entropy = [0 as u8; 64];
+            thread_rng().fill(&mut entropy);
+            Entropy::from_public_slice(&entropy)
+        };
+
+        client_connect(default_algs, &sni, None, None, ent)?
+    };
+
+    stream.write_record(client_hello)?;
+
+    let server_hello = stream.read_record()?;
+
+    // TODO: Who should do this check?
+    if eq1(server_hello[0], U8(21)) {
+        // Alert
+        error!("Server does not support proposed algorithms.");
+        return Err(UNSUPPORTED_ALGORITHM.into());
+    }
+
+    let (_, cstate) = client_read_handshake(&server_hello, cstate)?;
+
+    let change_cipher_spec = stream.read_record()?;
+    verify_ccs_message(change_cipher_spec)?;
+
+    let mut cf_rec = None;
+    let mut cstate = cstate;
+    while cf_rec == None {
+        let rec = stream.read_record()?;
+
+        let (new_cf_rec, new_cstate) = client_read_handshake(&rec, cstate)?;
+        cf_rec = new_cf_rec;
+        cstate = new_cstate;
+    }
+
+    let change_cipher_spec = ByteSeq::from_hex("140303000101");
+    stream.write_record(change_cipher_spec)?;
+
+    // Safety: Safe to unwrap().
+    let cf_rec = cf_rec.unwrap();
+    stream.write_record(cf_rec)?;
+
+    info!("----- Handshake finished -----");
+
+    /* Send HTTP GET  */
+
+    let (ap, cstate) = {
+        let http_get = ByteSeq::from_public_slice(request.as_bytes());
+
+        client_write(app_data(http_get), cstate)?
+    };
+
+    stream.write_record(ap)?;
+
+    /* Process HTTP response */
+
+    let mut ad = None;
+    let mut cstate = cstate;
+    while ad == None {
+        let rec = stream.read_record()?;
+
+        let (new_ad, new_cstate) = client_read(&rec, cstate)?;
+        ad = new_ad;
+        cstate = new_cstate;
+    }
+
+    let response_prefix = {
+        // Safety: Safe to unwrap().
+        let body = app_data_bytes(ad.unwrap());
+
+        // Safety: Safe to unwrap().
+        // TODO: Provide `Bytes` -> `Vec<u8>` conversion?
+        hex::decode(body.to_hex()).unwrap()
+    };
+
+    Ok((stream, cstate, response_prefix))
+}
+
+pub fn tls13client_continue<Stream>(
+    mut stream: RecordStream<Stream>,
+    cstate: Client,
+) -> Result<(RecordStream<Stream>, Client, Vec<u8>), ClientError>
+where
+    Stream: Read + Write,
+{
+    let mut ad = None;
+    let mut cstate = cstate;
+    while ad == None {
+        let rec = stream.read_record()?;
+
+        let (new_ad, new_cstate) = client_read(&rec, cstate)?;
+        ad = new_ad;
+        cstate = new_cstate;
+    }
+
+    let response_prefix = {
+        // Safety: Safe to unwrap().
+        let body = app_data_bytes(ad.unwrap());
+
+        // Safety: Safe to unwrap().
+        // TODO: Provide `Bytes` -> `Vec<u8>` conversion?
+        hex::decode(body.to_hex()).unwrap()
+    };
+
+    Ok((stream, cstate, response_prefix))
+}
+
+pub(crate) fn verify_ccs_message(rec: ByteSeq) -> Result<(), ClientError> {
+    let rec = rec.declassify();
+
+    if rec.len() == 6
+        && rec[0] == 0x14u8
+        && rec[1] == 0x03u8
+        && rec[2] == 0x03u8
+        && rec[3] == 0x00u8
+        && rec[4] == 0x01u8
+        && rec[5] == 0x01u8
+    {
+        Ok(())
+    } else {
+        Err(PARSE_FAILED.into())
+    }
+}

--- a/simple_https_client/src/stream.rs
+++ b/simple_https_client/src/stream.rs
@@ -1,0 +1,116 @@
+use std::io::{Read, Write};
+
+use bertie::{INSUFFICIENT_DATA, PAYLOAD_TOO_LONG};
+use hacspec_lib::ByteSeq;
+use tracing::{debug, trace};
+
+use crate::{
+    debug::{info_record, Hex},
+    ClientError,
+};
+
+#[derive(Debug)]
+pub struct RecordStream<Stream>
+where
+    Stream: Read + Write,
+{
+    stream: Stream,
+    buffer: Vec<u8>,
+}
+
+impl<Stream> RecordStream<Stream>
+where
+    Stream: Read + Write,
+{
+    pub fn new(stream: Stream) -> Self {
+        Self {
+            stream,
+            buffer: Vec::new(),
+        }
+    }
+}
+
+impl<Stream> RecordStream<Stream>
+where
+    Stream: Read + Write,
+{
+    #[tracing::instrument(skip(self))]
+    pub fn read_record(&mut self) -> Result<ByteSeq, ClientError> {
+        // Buffer to read chunks into.
+        let mut tmp = [0u8; 4096];
+
+        // ```TLS
+        // struct {
+        //     ContentType type;
+        //     ProtocolVersion legacy_record_version;
+        //     uint16 length;
+        //     opaque fragment[TLSPlaintext.length];
+        // } TLSPlaintext;
+        // ```
+        loop {
+            debug!("Search for TLS record in stream buffer.");
+            if self.buffer.len() >= 5 {
+                let length = self.buffer[3] as usize * 256 + self.buffer[4] as usize;
+
+                // TODO: Who does this?
+                // The length (in bytes) of the following TLSPlaintext.fragment. The length MUST NOT
+                // exceed 2^14 bytes. An endpoint that receives a record that exceeds this length
+                // MUST terminate the connection with a "record_overflow" alert.
+                if length > 16384 {
+                    // TODO: Correct error?
+                    return Err(PAYLOAD_TOO_LONG.into());
+                }
+
+                if self.buffer.len() >= 5 + length {
+                    let record = {
+                        let record = &self.buffer[..5 + length];
+                        info_record(record);
+                        ByteSeq::from_public_slice(record)
+                    };
+
+                    self.buffer = self.buffer.split_off(5 + length);
+
+                    if !self.buffer.is_empty() {
+                        debug!("There is still data in the stream buffer.");
+                        trace!(
+                            left = %Hex(&self.buffer),
+                            "There is still data in the stream buffer (content)."
+                        );
+                    }
+
+                    return Ok(record);
+                }
+            }
+
+            debug!("No complete TLS record found in stream buffer.");
+            match self.stream.read(&mut tmp)? {
+                0 => {
+                    debug!("Connection closed.");
+                    // TODO: Correct error?
+                    return Err(INSUFFICIENT_DATA.into());
+                }
+                amt => {
+                    let data = &tmp[..amt];
+
+                    debug!(amt, "Read data into stream buffer.");
+                    trace!(data=%Hex(data), "Read data into stream buffer (content).");
+
+                    self.buffer.extend_from_slice(data);
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self, record))]
+    pub fn write_record(&mut self, record: ByteSeq) -> Result<(), ClientError> {
+        // Safety: Safe to unwrap().
+        let data = hex::decode(record.to_hex()).unwrap();
+        self.stream.write_all(&data)?;
+
+        debug!(amt = data.len(), "Wrote data.");
+        trace!(data=%Hex(&data), "Wrote data (content).");
+        info_record(&data);
+
+        Ok(())
+    }
+}

--- a/simple_https_client/src/tls13client.rs
+++ b/simple_https_client/src/tls13client.rs
@@ -1,215 +1,42 @@
-//! A Simple TLS 1.3 HTTP Client Implementation
-//! It connects to a give host at port 443, sends an HTTP "GET /", and prints a prefix of the HTTP response
-//! WARNING: This code is not in hacspec since it need to use TCP etc.
+use std::{env, net::TcpStream, str::FromStr};
 
-#![allow(non_upper_case_globals)]
+use anyhow::Context;
+use simple_https_client::tls13client;
+use tracing_subscriber;
 
-// Import hacspec and all needed definitions.
-use hacspec_lib::*;
-use rand::*;
-use std::env;
-use std::time::Duration;
+/// This is a demo of a simple HTTPS client.
+///
+/// The client connects to host:port via TCP, executes a TLS 1.3 handshake,
+/// sends an encrypted HTTP GET, and prints the servers HTTP response.
+fn main() -> anyhow::Result<()> {
+    // Setup tracing.
+    tracing_subscriber::fmt::init();
 
-#[cfg(feature = "evercrypt")]
-use evercrypt_cryptolib::*;
-#[cfg(not(feature = "evercrypt"))]
-use hacspec_cryptolib::*;
+    // Obtain host and port from arguments.
+    let (host, port) = {
+        let mut args = env::args();
 
-use bertie::tls13api::*;
-use bertie::tls13utils::*;
+        let _ = args.next().context("Unexpected parameter environment.")?;
 
-use std::io::prelude::*;
-use std::net::TcpStream;
-use std::str;
+        let host = args.next().unwrap_or("www.google.com".to_string());
+        let port = args.next().unwrap_or("443".to_string());
 
-fn read_bytes(stream: &mut TcpStream, buf: &mut [u8], nbytes: usize) -> Result<usize, TLSError> {
-    match stream.read(&mut buf[..]) {
-        Ok(len) => {
-            if len >= nbytes {
-                Ok(len - nbytes)
-            } else {
-                read_bytes(stream, &mut buf[len..], nbytes - len)
-            }
-        }
-        Err(_) => Err(INSUFFICIENT_DATA),
-    }
-}
-
-fn read_record(stream: &mut TcpStream, buf: &mut [u8]) -> Result<usize, TLSError> {
-    let mut b: [u8; 5] = [0; 5];
-    let mut len = 0;
-    while len < 5 {
-        match stream.peek(&mut b) {
-            Result::Ok(l) => len = l,
-            Result::Err(_) => Err(INSUFFICIENT_DATA)?,
-        }
-    }
-    let l0 = b[3] as usize;
-    let l1 = b[4] as usize;
-    let len = l0 * 256 + l1;
-    if len + 5 > buf.len() {
-        Err(INSUFFICIENT_DATA)
-    } else {
-        let extra = read_bytes(stream, &mut buf[0..len + 5], len + 5)?;
-        if extra > 0 {
-            Err(PAYLOAD_TOO_LONG)
-        } else {
-            Ok(len + 5)
-        }
-    }
-}
-
-fn put_record(stream: &mut TcpStream, rec: &Bytes) -> Result<(), TLSError> {
-    let wire = hex::decode(&rec.to_hex()).expect("Record Decoding Failed");
-    match stream.write(&wire) {
-        Err(_) => Err(INSUFFICIENT_DATA),
-        Ok(len) => {
-            if len < wire.len() {
-                Err(PARSE_FAILED)
-            } else {
-                Ok(())
-            }
-        }
-    }
-}
-
-fn get_ccs_message(stream: &mut TcpStream, buf: &mut [u8]) -> Result<(), TLSError> {
-    let len = read_record(stream, buf)?;
-    if len == 6
-        && buf[0] == 0x14
-        && buf[1] == 0x03
-        && buf[2] == 0x03
-        && buf[3] == 0x00
-        && buf[4] == 0x01
-        && buf[5] == 0x01
-    {
-        Ok(())
-    } else {
-        Err(PARSE_FAILED)
-    }
-}
-
-fn put_ccs_message(stream: &mut TcpStream) -> Result<(), TLSError> {
-    let ccs_rec = ByteSeq::from_hex("140303000101");
-    put_record(stream, &ccs_rec)
-}
-
-const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Aes128Gcm,
-    SignatureScheme::EcdsaSecp256r1Sha256,
-    NamedGroup::X25519,
-    false,
-    false,
-);
-
-/*
-const SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519: Algorithms = Algorithms(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Chacha20Poly1305,
-    SignatureScheme::RsaPssRsaSha256,
-    NamedGroup::X25519,
-    false,
-    false,
-);
-*/
-
-const default_algs: Algorithms = SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519;
-
-pub fn tls13client(host: &str, port: &str) -> Result<(), TLSError> {
-    let mut entropy = [0 as u8; 64];
-    let d = Duration::new(1, 0);
-    thread_rng().fill(&mut entropy);
-    let ent_c = Entropy::from_public_slice(&entropy);
-    let sni = ByteSeq::from_public_slice(&host.as_bytes());
-    let http_get_str = format!("GET / HTTP/1.1\r\nHost: {}\r\n\r\n", host);
-    let http_get = ByteSeq::from_public_slice(http_get_str.as_bytes());
-
-    /* Initiate TCP Connection */
-    let addr = [host, port].join(":");
-    let mut stream = TcpStream::connect(&addr).unwrap();
-    stream
-        .set_read_timeout(Some(d))
-        .expect("set_read_timeout call failed");
-    println!("Initiating connection to {}", addr);
-
-    /* Initialize TLS 1.3. Client */
-    let (ch_rec, cstate) = client_connect(default_algs, &sni, None, None, ent_c)?;
-    put_record(&mut stream, &ch_rec)?;
-
-    /* Process Server Response  */
-    let mut in_buf = [0; 8192];
-    let len = read_record(&mut stream, &mut in_buf)?;
-    let sh_rec = ByteSeq::from_public_slice(&in_buf[0..len]);
-    if eq1(sh_rec[0], U8(21)) {
-        // Alert
-        println!("Server does not support proposed algorithms");
-        Err(UNSUPPORTED_ALGORITHM)
-    } else {
-        //println!("Got SH record: {}",sh_rec.len());
-
-        let (_, cstate) = client_read_handshake(&sh_rec, cstate)?;
-
-        //println!("Got SH");
-
-        get_ccs_message(&mut stream, &mut in_buf)?;
-
-        //println!("Got SCCS");
-
-        let mut cf_rec = None;
-        let mut cstate = cstate;
-        while cf_rec == None {
-            let len = read_record(&mut stream, &mut in_buf)?;
-            let rec = ByteSeq::from_public_slice(&in_buf[0..len]);
-            let (cf, st) = client_read_handshake(&rec, cstate)?;
-            cstate = st;
-            cf_rec = cf;
-        }
-        println!("Got SFIN");
-        let cf_rec = cf_rec.unwrap();
-
-        /* Complete Connection */
-        put_ccs_message(&mut stream)?;
-        put_record(&mut stream, &cf_rec)?;
-        println!("Connected to {}:443", host);
-        /* Send HTTP GET  */
-        let (ap, cstate) = client_write(app_data(http_get), cstate)?;
-        put_record(&mut stream, &ap)?;
-        println!("Sent HTTP GET to {}:443", host);
-
-        /* Process HTTP Response */
-        let mut ad = None;
-        let mut cstate = cstate;
-        while ad == None {
-            let len = read_record(&mut stream, &mut in_buf)?;
-            let rec = ByteSeq::from_public_slice(&in_buf[0..len]);
-            let (d, st) = client_read(&rec, cstate)?;
-            cstate = st;
-            ad = d;
-        }
-        let http_resp_by = ad.unwrap();
-        let http_resp = app_data_bytes(http_resp_by);
-        let html_by = hex::decode(&http_resp.to_hex()).expect("Decoding HTTP Response failed");
-        let html = String::from_utf8_lossy(&html_by);
-        println!("Received HTTP Response from {}\n\n{}", host, html);
-        Ok(())
-    }
-}
-
-pub fn main() {
-    let args: Vec<String> = env::args().collect();
-    let host = if args.len() <= 1 {
-        "www.google.com"
-    } else {
-        &args[1]
+        (
+            host,
+            u16::from_str(&port).context("Failed to parse port number.")?,
+        )
     };
-    let port = if args.len() <= 2 { "443" } else { &args[2] };
-    match tls13client(host, port) {
-        Err(x) => {
-            println!("Connection to {} failed with {}\n", host, x);
-        }
-        Ok(()) => {
-            println!("Connection to {} succeeded\n", host);
-        }
-    }
+
+    let request = format!("GET / HTTP/1.1\r\nHost: {}\r\n\r\n", host);
+
+    // Initiate HTTPS connection to host:port.
+    let stream = TcpStream::connect((host.clone(), port))?;
+
+    let (_, _, response_prefix) = tls13client(&host, stream, &request)?;
+
+    println!("[!] Received HTTP response (prefix):");
+    println!("{}", String::from_utf8_lossy(&response_prefix));
+    println!("[!] Connection to \"{}:{}\" succeeded.", host, port);
+
+    Ok(())
 }

--- a/simple_https_client/tests/test_tls13api.rs
+++ b/simple_https_client/tests/test_tls13api.rs
@@ -2,13 +2,12 @@
 #![allow(dead_code)]
 
 use bertie::*;
-use hacspec_dev::rand::random_byte_vec;
-use hacspec_lib::*;
-
 #[cfg(feature = "evercrypt")]
 use evercrypt_cryptolib::*;
 #[cfg(not(feature = "evercrypt"))]
 use hacspec_cryptolib::*;
+use hacspec_dev::rand::random_byte_vec;
+use hacspec_lib::*;
 
 // These are the sample TLS 1.3 traces taken from RFC 8448
 


### PR DESCRIPTION
This PR refactors the `simple_https_client` to make it already usable as a library for testing. This will later be used to do a "self test", i.e., "bertie client" connectiong to "bertie server". Furthermore, it introduces a `RecordStream` type (file `simple_https_client/src/stream.rs`) that encapsulates TLS record splitting and IO handling. This component will later be used for an `simple_https_server`. Furthermore, the PR introduces debugging support by tracing record framing (file `simple_https_client/src/debug.rs`).

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change