### PR TITLE
don't include fuzzing crates in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ criterion = "0.3"
 [workspace]
 members = [
     "simple_https_client",
-    "simple_https_client/fuzz",
     "simple_https_server",
     "bogo_shim",
 ]

--- a/simple_https_client/fuzz/Cargo.toml
+++ b/simple_https_client/fuzz/Cargo.toml
@@ -14,6 +14,9 @@ libfuzzer-sys = "0.4"
 [dependencies.simple_https_client]
 path = ".."
 
+[workspace]
+members = ["."]
+
 [[bin]]
 name = "client"
 path = "fuzz_targets/client.rs"


### PR DESCRIPTION
Fuzzing crates should not be part of any workspace. This only messes with CI, dependents, and most workflows.