### PR TITLE
A number of small code quality improvements

### DIFF
--- a/src/test_tls13traces_internal.rs
+++ b/src/test_tls13traces_internal.rs
@@ -260,7 +260,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_client_hello() {
-        let ch = handshake_data(Bytes::from_hex(client_hello));
+        let ch = HandshakeData::from(Bytes::from_hex(client_hello));
         //   let default_algs = Algorithms(SHA256,CHACHA20_POLY1305,ECDSA_SECP256R1_SHA256,X25519,false,false);
         let res = parse_client_hello(&TLS_AES_128_GCM_SHA256_X25519_RSA, &ch);
         let b = res.is_ok();
@@ -351,7 +351,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_server_hello() {
-        let sh = handshake_data(Bytes::from_hex(server_hello));
+        let sh = HandshakeData::from(Bytes::from_hex(server_hello));
         //   let default_algs = Algorithms(SHA256,AES_128_GCM,ECDSA_SECP256R1_SHA256,X25519,false,false);
         let res = parse_server_hello(&TLS_AES_128_GCM_SHA256_X25519_RSA, &sh);
         let b = res.is_ok();
@@ -371,7 +371,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
     #[test]
     #[ignore = "Enable this later."]
     fn test_parse_server_hello_length_zero() {
-        let sh = handshake_data(Bytes::from_hex("02000000"));
+        let sh = HandshakeData::from(Bytes::from_hex("02000000"));
         let res = parse_server_hello(&TLS_AES_128_GCM_SHA256_X25519_RSA, &sh);
     }
 
@@ -410,7 +410,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_encrypted_extensions() {
-        let ee = handshake_data(Bytes::from_hex(encrypted_extensions));
+        let ee = HandshakeData::from(Bytes::from_hex(encrypted_extensions));
         let res = parse_encrypted_extensions(&TLS_AES_128_GCM_SHA256_X25519_RSA, &ee);
         let b = res.is_ok();
         match res {
@@ -426,7 +426,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_server_certificate() {
-        let sc = handshake_data(Bytes::from_hex(server_certificate));
+        let sc = HandshakeData::from(Bytes::from_hex(server_certificate));
         let res = parse_server_certificate(&TLS_AES_128_GCM_SHA256_X25519_RSA, &sc);
         let b = res.is_ok();
         match res {
@@ -442,7 +442,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_server_certificate_verify() {
-        let cv = handshake_data(Bytes::from_hex(server_certificate_verify));
+        let cv = HandshakeData::from(Bytes::from_hex(server_certificate_verify));
         let res = parse_certificate_verify(&TLS_AES_128_GCM_SHA256_X25519_RSA, &cv);
         let b = res.is_ok();
         match res {
@@ -458,7 +458,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_server_finished() {
-        let sf = handshake_data(Bytes::from_hex(server_finished));
+        let sf = HandshakeData::from(Bytes::from_hex(server_finished));
         let res = parse_finished(&TLS_AES_128_GCM_SHA256_X25519_RSA, &sf);
         let b = res.is_ok();
         match res {
@@ -474,7 +474,7 @@ d8 7f 38 f8 03 38 ac 98 fc 46 de b3 84 bd 1c ae ac ab 68 67 d7
 
     #[test]
     fn test_parse_client_finished() {
-        let cf = handshake_data(Bytes::from_hex(client_finished));
+        let cf = HandshakeData::from(Bytes::from_hex(client_finished));
         let res = parse_finished(&TLS_AES_128_GCM_SHA256_X25519_RSA, &cf);
         let b = res.is_ok();
         match res {

--- a/src/tls13crypto.rs
+++ b/src/tls13crypto.rs
@@ -8,8 +8,8 @@ use rand::{CryptoRng, RngCore};
 // use tracing::{event, Level};
 
 use crate::tls13utils::{
-    check_lbytes2, check_mem, eq, tlserr, Bytes, Error, TLSError, CRYPTO_ERROR, INVALID_SIGNATURE,
-    UNSUPPORTED_ALGORITHM,
+    check_mem, eq, length_u16_encoded, tlserr, Bytes, Error, TLSError, CRYPTO_ERROR,
+    INVALID_SIGNATURE, UNSUPPORTED_ALGORITHM,
 };
 
 pub(crate) type Random = Bytes; //was [U8;32]
@@ -692,7 +692,7 @@ impl Algorithms {
 
     /// Check the ciphersuite in `bytes` against this ciphersuite.
     pub(crate) fn check(&self, bytes: &Bytes) -> Result<usize, TLSError> {
-        let len = check_lbytes2(bytes)?;
+        let len = length_u16_encoded(bytes)?;
         let cs = self.ciphersuite()?;
         let csl = bytes.slice_range(2..2 + len);
         check_mem(&cs, &csl)?;

--- a/src/tls13formats.rs
+++ b/src/tls13formats.rs
@@ -8,10 +8,10 @@ use crate::{
     tls13utils::{
         bytes1, bytes2, check_eq, check_lbyte, check_lbyte_full, check_lbytes2, check_lbytes2_full,
         check_lbytes3, check_lbytes3_full, check_mem, encode_lbyte, encode_lbytes2, encode_lbytes3,
-        eq, eq1, parse_failed, tlserr, Bytes,
-        HandshakeData, TLSError, APPLICATION_DATA_INSTEAD_OF_HANDSHAKE, DECODE_ERROR,
-        INVALID_COMPRESSION_LIST, INVALID_SIGNATURE, MISSING_KEY_SHARE, PROTOCOL_VERSION_ALERT,
-        PSK_MODE_MISMATCH, U32, U8, UNSUPPORTED_ALGORITHM,
+        eq, eq1, parse_failed, tlserr, Bytes, HandshakeData, TLSError,
+        APPLICATION_DATA_INSTEAD_OF_HANDSHAKE, DECODE_ERROR, INVALID_COMPRESSION_LIST,
+        INVALID_SIGNATURE, MISSING_KEY_SHARE, PROTOCOL_VERSION_ALERT, PSK_MODE_MISMATCH, U32, U8,
+        UNSUPPORTED_ALGORITHM,
     },
 };
 
@@ -548,7 +548,8 @@ pub fn get_next_handshake_message(
     if ({
         let p: &HandshakeData = &payload;
         p.len()
-    }) < 4 {
+    }) < 4
+    {
         tlserr(parse_failed())
     } else {
         let len = check_lbytes3(&payload.0.slice_range(1..payload.0.len()))?;
@@ -568,7 +569,8 @@ pub fn get_handshake_message(payload: &HandshakeData) -> Result<HandshakeData, T
     if ({
         let p = &payload_rest;
         p.len()
-    }) != 0 {
+    }) != 0
+    {
         tlserr(parse_failed())
     } else {
         Ok(message)
@@ -606,7 +608,8 @@ pub fn get_handshake_messages2(
     if ({
         let p = &payload_rest;
         p.len()
-    }) != 0 {
+    }) != 0
+    {
         tlserr(parse_failed())
     } else {
         Ok((message1, message2))
@@ -628,7 +631,8 @@ pub fn get_handshake_messages4(
     if ({
         let p = &payload_rest;
         p.len()
-    }) != 0 {
+    }) != 0
+    {
         tlserr(parse_failed())
     } else {
         Ok((message1, message2, message3, message4))
@@ -646,7 +650,8 @@ pub fn find_handshake_message(
     if ({
         let p: &HandshakeData = &payload;
         p.len()
-    }) < start + 4 {
+    }) < start + 4
+    {
         false
     } else {
         match check_lbytes3(&payload.0.slice_range(start + 1..payload.0.len())) {

--- a/src/tls13formats.rs
+++ b/src/tls13formats.rs
@@ -545,11 +545,7 @@ pub fn handshake_message(
 pub fn get_next_handshake_message(
     payload: &HandshakeData,
 ) -> Result<(HandshakeData, HandshakeData), TLSError> {
-    if ({
-        let p: &HandshakeData = &payload;
-        p.len()
-    }) < 4
-    {
+    if (payload.len()) < 4 {
         tlserr(parse_failed())
     } else {
         let len = check_lbytes3(&payload.0.slice_range(1..payload.0.len()))?;
@@ -647,11 +643,7 @@ pub fn find_handshake_message(
     payload: &HandshakeData,
     start: usize,
 ) -> bool {
-    if ({
-        let p: &HandshakeData = &payload;
-        p.len()
-    }) < start + 4
-    {
+    if (payload.len()) < start + 4 {
         false
     } else {
         match check_lbytes3(&payload.0.slice_range(start + 1..payload.0.len())) {

--- a/src/tls13handshake.rs
+++ b/src/tls13handshake.rs
@@ -34,8 +34,8 @@ fn hkdf_expand_label(
         let lenb = U16::from(len as u16).as_be_bytes();
         let tls13_label = Bytes::from_slice(&LABEL_TLS13).concat(label);
         let info = lenb
-            .concat(&encode_lbyte(&tls13_label)?)
-            .concat(&encode_lbyte(context)?);
+            .concat(&encode_length_u8(&tls13_label)?)
+            .concat(&encode_length_u8(context)?);
         hkdf_expand(hash_algorithm, key, &info, len)
     }
 }

--- a/src/tls13handshake.rs
+++ b/src/tls13handshake.rs
@@ -22,8 +22,8 @@ fn hash_empty(algorithm: &HashAlgorithm) -> Result<Digest, TLSError> {
 
 /// HKDF expand with a `label`.
 fn hkdf_expand_label(
-    ha: &HashAlgorithm,
-    k: &Key,
+    hash_algorithm: &HashAlgorithm,
+    key: &Key,
     label: &Bytes,
     context: &Bytes,
     len: usize,
@@ -34,9 +34,9 @@ fn hkdf_expand_label(
         let lenb = U16::from(len as u16).as_be_bytes();
         let tls13_label = Bytes::from_slice(&LABEL_TLS13).concat(label);
         let info = lenb
-            .concat(&encode_u8(&tls13_label)?)
-            .concat(&encode_u8(context)?);
-        hkdf_expand(ha, k, &info, len)
+            .concat(&encode_lbyte(&tls13_label)?)
+            .concat(&encode_lbyte(context)?);
+        hkdf_expand(hash_algorithm, key, &info, len)
     }
 }
 
@@ -44,9 +44,15 @@ pub fn derive_secret(
     hash_algorithm: &HashAlgorithm,
     key: &Key,
     label: &Bytes,
-    tx: &Digest,
+    transcript_hash: &Digest,
 ) -> Result<Key, TLSError> {
-    hkdf_expand_label(hash_algorithm, key, label, tx, hash_algorithm.hash_len())
+    hkdf_expand_label(
+        hash_algorithm,
+        key,
+        label,
+        transcript_hash,
+        hash_algorithm.hash_len(),
+    )
 }
 
 pub fn derive_binder_key(ha: &HashAlgorithm, k: &Key) -> Result<MacKey, TLSError> {
@@ -253,17 +259,18 @@ fn build_client_hello(
     ),
     TLSError,
 > {
-    let gx_len = ciphersuite.kem().kem_priv_len();
     let tx = transcript_empty(ciphersuite.hash());
-    let mut cr = [0u8; 32];
-    rng.fill_bytes(&mut cr);
-    let (x, gx) = kem_keygen(ciphersuite.kem(), rng)?;
-    let (ch, trunc_len) = client_hello(&ciphersuite, &cr.into(), &gx, sn, &tkt)?;
-    let (nch, cipher0, tx_ch) = compute_psk_binder_zero_rtt(ciphersuite, ch, trunc_len, &psk, tx)?;
+    let mut client_random = [0u8; 32];
+    rng.fill_bytes(&mut client_random);
+    let (kem_sk, kem_pk) = kem_keygen(ciphersuite.kem(), rng)?;
+    let (client_hello, trunc_len) =
+        client_hello(&ciphersuite, &client_random.into(), &kem_pk, sn, &tkt)?;
+    let (nch, cipher0, tx_ch) =
+        compute_psk_binder_zero_rtt(ciphersuite, client_hello, trunc_len, &psk, tx)?;
     Ok((
         nch,
         cipher0,
-        ClientPostClientHello(cr.into(), ciphersuite, x, psk, tx_ch),
+        ClientPostClientHello(client_random.into(), ciphersuite, kem_sk, psk, tx_ch),
     ))
 }
 
@@ -310,7 +317,7 @@ fn put_server_hello(
     handshake: &HandshakeData,
     state: ClientPostClientHello,
 ) -> Result<(DuplexCipherStateH, ClientPostServerHello), TLSError> {
-    let ClientPostClientHello(cr, ciphersuite, sk, psk, tx) = state;
+    let ClientPostClientHello(client_random, ciphersuite, sk, psk, tx) = state;
 
     let (sr, ct) = parse_server_hello(&ciphersuite, handshake)?;
     let tx = transcript_add1(tx, handshake);
@@ -326,84 +333,156 @@ fn put_server_hello(
 
     Ok((
         DuplexCipherStateH::new(chk, 0, shk, 0),
-        ClientPostServerHello(cr, sr, ciphersuite, ms, cfk, sfk, tx),
+        ClientPostServerHello(client_random, sr, ciphersuite, ms, cfk, sfk, tx),
     ))
 }
 
 fn put_server_signature(
-    ee: &HandshakeData,
-    sc: &HandshakeData,
-    scv: &HandshakeData,
-    st: ClientPostServerHello,
+    encrypted_extensions: &HandshakeData,
+    server_certificate: &HandshakeData,
+    server_certificate_verify: &HandshakeData,
+    handshake_state: ClientPostServerHello,
 ) -> Result<ClientPostCertificateVerify, TLSError> {
-    let ClientPostServerHello(cr, sr, algs, ms, cfk, sfk, tx) = st;
-    if !algs.psk_mode() {
-        parse_encrypted_extensions(&algs, ee)?;
-        let tx = transcript_add1(tx, ee);
-        let cert = parse_server_certificate(&algs, sc)?;
-        let tx = transcript_add1(tx, sc);
-        let th_sc = get_transcript_hash(&tx)?;
-        let spki = verification_key_from_cert(&cert)?;
-        // println!("Server signature scheme: {:?}", spki.0);
-        let pk = cert_public_key(&cert, &spki)?;
-        let sig = parse_certificate_verify(&algs, scv)?;
-        let sigval = (Bytes::from_slice(&PREFIX_SERVER_SIGNATURE)).concat(&th_sc);
-        verify(&algs.signature(), &pk, &sigval, &sig)?;
-        let tx = transcript_add1(tx, scv);
-        Ok(ClientPostCertificateVerify(cr, sr, algs, ms, cfk, sfk, tx))
+    let ClientPostServerHello(
+        client_random,
+        server_random,
+        algorithms,
+        master_secret,
+        client_finished_key,
+        server_finished_key,
+        transcript,
+    ) = handshake_state;
+    if !algorithms.psk_mode() {
+        parse_encrypted_extensions(&algorithms, encrypted_extensions)?;
+        let transcript = transcript_add1(transcript, encrypted_extensions);
+        let certificate = parse_server_certificate(&algorithms, server_certificate)?;
+        let transcript = transcript_add1(transcript, server_certificate);
+        let transcript_hash_server_certificate = get_transcript_hash(&transcript)?;
+        let spki = verification_key_from_cert(&certificate)?;
+        let cert_pk = cert_public_key(&certificate, &spki)?;
+        let cert_signature = parse_certificate_verify(&algorithms, server_certificate_verify)?;
+        let sigval = (Bytes::from_slice(&PREFIX_SERVER_SIGNATURE))
+            .concat(&transcript_hash_server_certificate);
+        verify(&algorithms.signature(), &cert_pk, &sigval, &cert_signature)?;
+        let transcript = transcript_add1(transcript, server_certificate_verify);
+        Ok(ClientPostCertificateVerify(
+            client_random,
+            server_random,
+            algorithms,
+            master_secret,
+            client_finished_key,
+            server_finished_key,
+            transcript,
+        ))
     } else {
         Err(PSK_MODE_MISMATCH)
     }
 }
 
 fn put_psk_skip_server_signature(
-    ee: &HandshakeData,
-    st: ClientPostServerHello,
+    encrypted_extensions: &HandshakeData,
+    handshake_state: ClientPostServerHello,
 ) -> Result<ClientPostCertificateVerify, TLSError> {
-    let ClientPostServerHello(cr, sr, algs, ms, cfk, sfk, tx) = st;
-    if algs.psk_mode() {
-        parse_encrypted_extensions(&algs, ee)?;
-        let tx = transcript_add1(tx, ee);
-        Ok(ClientPostCertificateVerify(cr, sr, algs, ms, cfk, sfk, tx))
+    let ClientPostServerHello(
+        client_random,
+        server_random,
+        algorithms,
+        master_secret,
+        client_finished_key,
+        server_finished_key,
+        transcript,
+    ) = handshake_state;
+    if algorithms.psk_mode() {
+        parse_encrypted_extensions(&algorithms, encrypted_extensions)?;
+        let transcript = transcript_add1(transcript, encrypted_extensions);
+        Ok(ClientPostCertificateVerify(
+            client_random,
+            server_random,
+            algorithms,
+            master_secret,
+            client_finished_key,
+            server_finished_key,
+            transcript,
+        ))
     } else {
         Err(PSK_MODE_MISMATCH)
     }
 }
 
 fn put_server_finished(
-    sfin: &HandshakeData,
-    st: ClientPostCertificateVerify,
+    server_finished: &HandshakeData,
+    handshake_state: ClientPostCertificateVerify,
 ) -> Result<(DuplexCipherState1, ClientPostServerFinished), TLSError> {
-    let ClientPostCertificateVerify(cr, sr, algs, ms, cfk, sfk, tx) = st;
+    let ClientPostCertificateVerify(
+        client_random,
+        server_random,
+        algorithms,
+        master_secret,
+        client_finished_key,
+        server_finished_key,
+        transcript,
+    ) = handshake_state;
     let Algorithms {
-        hash: ha,
-        aead: ae,
-        signature: _sa,
-        kem: _gn,
-        psk_mode: _psk_mode,
-        zero_rtt: _zero_rtt,
-    } = algs;
-    let th = get_transcript_hash(&tx)?;
-    let vd = parse_finished(&algs, sfin)?;
-    hmac_verify(&ha, &sfk, &th, &vd)?;
-    let tx = transcript_add1(tx, sfin);
-    let th_sfin = get_transcript_hash(&tx)?;
-    let (cak, sak, exp) = derive_app_keys(&ha, &ae, &ms, &th_sfin)?;
-    let cipher1 = duplex_cipher_state1(ae, cak, 0, sak, 0, exp);
-    Ok((cipher1, ClientPostServerFinished(cr, sr, algs, ms, cfk, tx)))
+        hash,
+        aead,
+        signature,
+        kem,
+        psk_mode,
+        zero_rtt,
+    } = algorithms;
+    let transcript_hash = get_transcript_hash(&transcript)?;
+    let verify_data = parse_finished(&algorithms, server_finished)?;
+    hmac_verify(&hash, &server_finished_key, &transcript_hash, &verify_data)?;
+    let transcript = transcript_add1(transcript, server_finished);
+    let transcript_hash_server_finished = get_transcript_hash(&transcript)?;
+    let (cak, sak, exp) = derive_app_keys(
+        &hash,
+        &aead,
+        &master_secret,
+        &transcript_hash_server_finished,
+    )?;
+    let cipher1 = duplex_cipher_state1(aead, cak, 0, sak, 0, exp);
+    Ok((
+        cipher1,
+        ClientPostServerFinished(
+            client_random,
+            server_random,
+            algorithms,
+            master_secret,
+            client_finished_key,
+            transcript,
+        ),
+    ))
 }
 
 fn get_client_finished(
-    st: ClientPostServerFinished,
+    handshake_state: ClientPostServerFinished,
 ) -> Result<(HandshakeData, ClientPostClientFinished), TLSError> {
-    let ClientPostServerFinished(cr, sr, algs, ms, cfk, tx) = st;
-    let th = get_transcript_hash(&tx)?;
-    let vd = hmac_tag(&algs.hash(), &cfk, &th)?;
-    let cfin = finished(&algs, &vd)?;
-    let tx = transcript_add1(tx, &cfin);
-    let th = get_transcript_hash(&tx)?;
-    let rms = derive_rms(&algs.hash(), &ms, &th)?;
-    Ok((cfin, ClientPostClientFinished(cr, sr, algs, rms, tx)))
+    let ClientPostServerFinished(
+        client_random,
+        server_random,
+        algorithms,
+        master_secret,
+        client_finished_key,
+        transcript,
+    ) = handshake_state;
+    let transcript_hash = get_transcript_hash(&transcript)?;
+    let verify_data = hmac_tag(&algorithms.hash(), &client_finished_key, &transcript_hash)?;
+    let client_finished = finished(&algorithms, &verify_data)?;
+    let transcript = transcript_add1(transcript, &client_finished);
+    let transcript_hash = get_transcript_hash(&transcript)?;
+    let resumption_master_secret =
+        derive_rms(&algorithms.hash(), &master_secret, &transcript_hash)?;
+    Ok((
+        client_finished,
+        ClientPostClientFinished(
+            client_random,
+            server_random,
+            algorithms,
+            resumption_master_secret,
+            transcript,
+        ),
+    ))
 }
 
 // Client-Side Handshake API: Usable by Quic and TLS
@@ -438,22 +517,37 @@ pub(crate) fn client_set_params(
 
 pub fn client_finish(
     payload: &HandshakeData,
-    st: ClientPostServerHello,
+    handshake_state: ClientPostServerHello,
 ) -> Result<(HandshakeData, DuplexCipherState1, ClientPostClientFinished), TLSError> {
-    match algs_post_server_hello(&st).psk_mode() {
+    match algs_post_server_hello(&handshake_state).psk_mode() {
         false => {
-            let (ee, sc, scv, sfin) = get_handshake_messages4(payload)?;
-            let cstate_cv = put_server_signature(&ee, &sc, &scv, st)?;
-            let (cipher, cstate_fin) = put_server_finished(&sfin, cstate_cv)?;
-            let (cfin, cstate) = get_client_finished(cstate_fin)?;
-            Ok((cfin, cipher, cstate))
+            let (
+                encrypted_extensions,
+                server_certificate,
+                server_certificate_verify,
+                server_finished,
+            ) = get_handshake_messages4(payload)?;
+            let client_state_certificate_verify = put_server_signature(
+                &encrypted_extensions,
+                &server_certificate,
+                &server_certificate_verify,
+                handshake_state,
+            )?;
+            let (cipher, client_state_server_finished) =
+                put_server_finished(&server_finished, client_state_certificate_verify)?;
+            let (client_finished, client_state) =
+                get_client_finished(client_state_server_finished)?;
+            Ok((client_finished, cipher, client_state))
         }
         true => {
-            let (ee, sfin) = get_handshake_messages2(payload)?;
-            let cstate_cv = put_psk_skip_server_signature(&ee, st)?;
-            let (cipher, cstate_fin) = put_server_finished(&sfin, cstate_cv)?;
-            let (cfin, cstate) = get_client_finished(cstate_fin)?;
-            Ok((cfin, cipher, cstate))
+            let (encrypted_extensions, server_finished) = get_handshake_messages2(payload)?;
+            let client_state_certificate_verify =
+                put_psk_skip_server_signature(&encrypted_extensions, handshake_state)?;
+            let (cipher, client_state_server_finished) =
+                put_server_finished(&server_finished, client_state_certificate_verify)?;
+            let (client_finished, client_state) =
+                get_client_finished(client_state_server_finished)?;
+            Ok((client_finished, cipher, client_state))
         }
     }
 }
@@ -671,13 +765,13 @@ pub fn server_init(
         false => {
             let (ee, sc, scv, st) = get_server_signature(st, rng)?;
             let (sfin, cipher1, st) = get_server_finished(st)?;
-            let flight = handshake_concat(ee, &handshake_concat(sc, &handshake_concat(scv, &sfin)));
+            let flight = ee.concat(&sc).concat(&scv).concat(&sfin);
             Ok((sh, flight, cipher0, cipher_hs, cipher1, st))
         }
         true => {
             let (ee, st) = get_skip_server_signature(st)?;
             let (sfin, cipher1, st) = get_server_finished(st)?;
-            let flight = handshake_concat(ee, &sfin);
+            let flight = ee.concat(&sfin);
             Ok((sh, flight, cipher0, cipher_hs, cipher1, st))
         }
     }

--- a/src/tls13record.rs
+++ b/src/tls13record.rs
@@ -184,7 +184,7 @@ pub(crate) fn encrypt_handshake(
     pad: usize,
     mut state: DuplexCipherStateH,
 ) -> Result<(Bytes, DuplexCipherStateH), TLSError> {
-    let payload = payload.bytes();
+    let payload = payload.to_bytes();
 
     let rec = encrypt_record_payload(
         &state.sender_key_iv,

--- a/src/tls13record.rs
+++ b/src/tls13record.rs
@@ -184,7 +184,7 @@ pub(crate) fn encrypt_handshake(
     pad: usize,
     mut state: DuplexCipherStateH,
 ) -> Result<(Bytes, DuplexCipherStateH), TLSError> {
-    let payload = handshake_data_bytes(&payload);
+    let payload = payload.bytes();
 
     let rec = encrypt_record_payload(
         &state.sender_key_iv,
@@ -210,7 +210,7 @@ pub(crate) fn decrypt_handshake(
     } else {
         check(ct == ContentType::Handshake)?;
         state.receiver_counter += 1;
-        Ok((handshake_data(payload), state))
+        Ok((HandshakeData::from(payload), state))
     }
 }
 

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -412,7 +412,7 @@ pub(crate) fn check_mem(b1: &Bytes, b2: &Bytes) -> Result<(), TLSError> {
 /// On success, return a new [Bytes] slice such that its first byte encodes the
 /// length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
 /// the length of `bytes` exceeds what can be encoded in one byte.
-pub(crate) fn encode_lbyte(bytes: &Bytes) -> Result<Bytes, TLSError> {
+pub(crate) fn encode_length_u8(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 256 {
         Err(PAYLOAD_TOO_LONG)
@@ -429,7 +429,7 @@ pub(crate) fn encode_lbyte(bytes: &Bytes) -> Result<Bytes, TLSError> {
 /// On success, return a new [Bytes] slice such that its first two bytes encode the
 /// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
 /// the length of `bytes` exceeds what can be encoded in two bytes.
-pub(crate) fn encode_lbytes2(bytes: &Bytes) -> Result<Bytes, TLSError> {
+pub(crate) fn encode_length_u16(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 65536 {
         Err(PAYLOAD_TOO_LONG)
@@ -448,7 +448,7 @@ pub(crate) fn encode_lbytes2(bytes: &Bytes) -> Result<Bytes, TLSError> {
 /// On success, return a new [Bytes] slice such that its first three bytes encode the
 /// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
 /// the length of `bytes` exceeds what can be encoded in three bytes.
-pub(crate) fn encode_lbytes3(bytes: &Bytes) -> Result<Bytes, TLSError> {
+pub(crate) fn encode_length_u24(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 16777216 {
         Err(PAYLOAD_TOO_LONG)
@@ -469,7 +469,7 @@ pub(crate) fn encode_lbytes3(bytes: &Bytes) -> Result<Bytes, TLSError> {
 /// On success, return the encoded length. Return a [TLSError] if `bytes` is
 /// empty or if the encoded length exceeds the length of the remainder of
 /// `bytes`.
-pub(crate) fn check_lbyte(bytes: &Bytes) -> Result<usize, TLSError> {
+pub(crate) fn length_u8_encoded(bytes: &Bytes) -> Result<usize, TLSError> {
     if bytes.is_empty() {
         Err(parse_failed())
     } else {
@@ -488,7 +488,7 @@ pub(crate) fn check_lbyte(bytes: &Bytes) -> Result<usize, TLSError> {
 /// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 2
 /// bytes long or if the encoded length exceeds the length of the remainder of
 /// `bytes`.
-pub(crate) fn check_lbytes2(bytes: &Bytes) -> Result<usize, TLSError> {
+pub(crate) fn length_u16_encoded(bytes: &Bytes) -> Result<usize, TLSError> {
     if bytes.len() < 2 {
         Err(parse_failed())
     } else {
@@ -509,7 +509,7 @@ pub(crate) fn check_lbytes2(bytes: &Bytes) -> Result<usize, TLSError> {
 /// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 3
 /// bytes long or if the encoded length exceeds the length of the remainder of
 /// `bytes`.
-pub(crate) fn check_lbytes3(bytes: &Bytes) -> Result<usize, TLSError> {
+pub(crate) fn length_u24_encoded(bytes: &Bytes) -> Result<usize, TLSError> {
     if bytes.len() < 3 {
         Err(parse_failed())
     } else {
@@ -529,8 +529,8 @@ pub(crate) fn check_lbytes3(bytes: &Bytes) -> Result<usize, TLSError> {
 ///
 /// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
 /// more bytes in the `bytes`.
-pub(crate) fn check_lbyte_full(bytes: &Bytes) -> Result<(), TLSError> {
-    if check_lbyte(bytes)? + 1 != bytes.len() {
+pub(crate) fn check_length_encoding_u8(bytes: &Bytes) -> Result<(), TLSError> {
+    if length_u8_encoded(bytes)? + 1 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())
@@ -542,8 +542,8 @@ pub(crate) fn check_lbyte_full(bytes: &Bytes) -> Result<(), TLSError> {
 ///
 /// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
 /// more bytes in the `bytes`.
-pub(crate) fn check_lbytes2_full(bytes: &Bytes) -> Result<(), TLSError> {
-    if check_lbytes2(bytes)? + 2 != bytes.len() {
+pub(crate) fn check_length_encoding_u16(bytes: &Bytes) -> Result<(), TLSError> {
+    if length_u16_encoded(bytes)? + 2 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())
@@ -555,8 +555,8 @@ pub(crate) fn check_lbytes2_full(bytes: &Bytes) -> Result<(), TLSError> {
 ///
 /// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
 /// more bytes in the `bytes`.
-pub(crate) fn check_lbytes3_full(bytes: &Bytes) -> Result<(), TLSError> {
-    if check_lbytes3(bytes)? + 3 != bytes.len() {
+pub(crate) fn check_length_encoding_u24(bytes: &Bytes) -> Result<(), TLSError> {
+    if length_u24_encoded(bytes)? + 3 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -572,12 +572,13 @@ impl HandshakeData {
     }
 
     pub(crate) fn bytes(&self) -> Bytes {
+    pub(crate) fn to_bytes(&self) -> Bytes {
         self.0.clone()
     }
 
     pub(crate) fn concat(self, other: &HandshakeData) -> HandshakeData {
-        let mut message1 = self.bytes();
-        let message2 = other.bytes();
+        let mut message1 = self.to_bytes();
+        let message2 = other.to_bytes();
 
         message1.0.extend_from_slice(&message2.0);
         HandshakeData::from(message1)

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -567,15 +567,18 @@ pub(crate) fn check_lbytes3_full(bytes: &Bytes) -> Result<(), TLSError> {
 pub struct HandshakeData(pub Bytes);
 
 impl HandshakeData {
+    /// Returns the length, in bytes.
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
-    pub(crate) fn bytes(&self) -> Bytes {
+    /// Returns the handshake data bytes.
     pub(crate) fn to_bytes(&self) -> Bytes {
         self.0.clone()
     }
 
+    /// Returns a new [`HandshakeData`] that contains the bytes of
+    /// `other` appended to the bytes of `self`.
     pub(crate) fn concat(self, other: &HandshakeData) -> HandshakeData {
         let mut message1 = self.to_bytes();
         let message2 = other.to_bytes();

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -342,10 +342,13 @@ pub(crate) fn check(b: bool) -> Result<(), TLSError> {
     }
 }
 
+/// Test if [Bytes] `b1` and `b2` have the same value.
 pub(crate) fn eq1(b1: U8, b2: U8) -> bool {
     b1.declassify() == b2.declassify()
 }
 
+/// Parser function to check if [Bytes] `b1` and `b2` have the same value,
+/// returning a [TLSError] otherwise.
 pub(crate) fn check_eq1(b1: U8, b2: U8) -> Result<(), TLSError> {
     if eq1(b1, b2) {
         Ok(())
@@ -355,7 +358,8 @@ pub(crate) fn check_eq1(b1: U8, b2: U8) -> Result<(), TLSError> {
 }
 
 // TODO: This function should short-circuit once hax supports returns within loops
-/// Compare two
+/// Check if [Bytes] slices `b1` and `b2` are of the same
+/// length and agree on all positions.
 pub fn eq(b1: &Bytes, b2: &Bytes) -> bool {
     if b1.len() != b2.len() {
         false
@@ -370,6 +374,8 @@ pub fn eq(b1: &Bytes, b2: &Bytes) -> bool {
     }
 }
 
+/// Parse function to check if [Bytes] slices `b1` and `b2` are of the same
+/// length and agree on all positions, returning a [TLSError] otherwise.
 pub(crate) fn check_eq(b1: &Bytes, b2: &Bytes) -> Result<(), TLSError> {
     let b = eq(b1, b2);
     if b {
@@ -401,8 +407,12 @@ pub(crate) fn check_mem(b1: &Bytes, b2: &Bytes) -> Result<(), TLSError> {
     }
 }
 
-/// TLS encode the `bytes` with [`u8`] length.
-pub(crate) fn encode_u8(bytes: &Bytes) -> Result<Bytes, TLSError> {
+/// Attempt to TLS encode the `bytes` with [`u8`] length.
+///
+/// On success, return a new [Bytes] slice such that its first byte encodes the
+/// length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in one byte.
+pub(crate) fn encode_lbyte(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 256 {
         Err(PAYLOAD_TOO_LONG)
@@ -414,8 +424,12 @@ pub(crate) fn encode_u8(bytes: &Bytes) -> Result<Bytes, TLSError> {
     }
 }
 
-/// TLS encode the `bytes` with [`u16`] length.
-pub(crate) fn encode_u16(bytes: &Bytes) -> Result<Bytes, TLSError> {
+/// Attempt to TLS encode the `bytes` with [`u16`] length.
+///
+/// On success, return a new [Bytes] slice such that its first two bytes encode the
+/// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in two bytes.
+pub(crate) fn encode_lbytes2(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 65536 {
         Err(PAYLOAD_TOO_LONG)
@@ -429,8 +443,12 @@ pub(crate) fn encode_u16(bytes: &Bytes) -> Result<Bytes, TLSError> {
     }
 }
 
-/// TLS encode the `bytes` with [`u24`] length.
-pub(crate) fn lbytes3(bytes: &Bytes) -> Result<Bytes, TLSError> {
+/// Attempt to TLS encode the `bytes` with [`u24`] length.
+///
+/// On success, return a new [Bytes] slice such that its first three bytes encode the
+/// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in three bytes.
+pub(crate) fn encode_lbytes3(bytes: &Bytes) -> Result<Bytes, TLSError> {
     let len = bytes.len();
     if len >= 16777216 {
         Err(PAYLOAD_TOO_LONG)
@@ -445,12 +463,18 @@ pub(crate) fn lbytes3(bytes: &Bytes) -> Result<Bytes, TLSError> {
     }
 }
 
-pub(crate) fn decode_u8_length(b: &Bytes) -> Result<usize, TLSError> {
-    if b.is_empty() {
+/// Check if `bytes[1..]` is at least as long as the length encoded by
+/// `bytes[0]` in big-endian order.
+///
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is
+/// empty or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+pub(crate) fn check_lbyte(bytes: &Bytes) -> Result<usize, TLSError> {
+    if bytes.is_empty() {
         Err(parse_failed())
     } else {
-        let l = b[0].declassify() as usize;
-        if b.len() - 1 < l {
+        let l = bytes[0].declassify() as usize;
+        if bytes.len() - 1 < l {
             Err(parse_failed())
         } else {
             Ok(l)
@@ -458,14 +482,20 @@ pub(crate) fn decode_u8_length(b: &Bytes) -> Result<usize, TLSError> {
     }
 }
 
-pub(crate) fn check_lbytes2(b: &Bytes) -> Result<usize, TLSError> {
-    if b.len() < 2 {
+/// Check if `bytes[2..]` is at least as long as the length encoded by `bytes[0..2]`
+/// in big-endian order.
+///
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 2
+/// bytes long or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+pub(crate) fn check_lbytes2(bytes: &Bytes) -> Result<usize, TLSError> {
+    if bytes.len() < 2 {
         Err(parse_failed())
     } else {
-        let l0 = b[0].declassify() as usize;
-        let l1 = b[1].declassify() as usize;
+        let l0 = bytes[0].declassify() as usize;
+        let l1 = bytes[1].declassify() as usize;
         let l = l0 * 256 + l1;
-        if b.len() - 2 < l {
+        if bytes.len() - 2 < l {
             Err(parse_failed())
         } else {
             Ok(l)
@@ -473,15 +503,21 @@ pub(crate) fn check_lbytes2(b: &Bytes) -> Result<usize, TLSError> {
     }
 }
 
-pub(crate) fn check_lbytes3(b: &Bytes) -> Result<usize, TLSError> {
-    if b.len() < 3 {
+/// Check if `bytes[3..]` is at least as long as the length encoded by `bytes[0..3]`
+/// in big-endian order.
+///
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 3
+/// bytes long or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+pub(crate) fn check_lbytes3(bytes: &Bytes) -> Result<usize, TLSError> {
+    if bytes.len() < 3 {
         Err(parse_failed())
     } else {
-        let l0 = b[0].declassify() as usize;
-        let l1 = b[1].declassify() as usize;
-        let l2 = b[2].declassify() as usize;
+        let l0 = bytes[0].declassify() as usize;
+        let l1 = bytes[1].declassify() as usize;
+        let l2 = bytes[2].declassify() as usize;
         let l = l0 * 65536 + l1 * 256 + l2;
-        if b.len() - 3 < l {
+        if bytes.len() - 3 < l {
             Err(parse_failed())
         } else {
             Ok(l)
@@ -489,28 +525,38 @@ pub(crate) fn check_lbytes3(b: &Bytes) -> Result<usize, TLSError> {
     }
 }
 
-/// Check if `bytes` contains more than the TLS `u8` length encoded content.
+/// Check if `bytes` contains exactly the TLS `u8` length encoded content.
 ///
 /// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
 /// more bytes in the `bytes`.
-pub(crate) fn check_u8_encoded_full(bytes: &Bytes) -> Result<(), TLSError> {
-    if decode_u8_length(bytes)? + 1 != bytes.len() {
+pub(crate) fn check_lbyte_full(bytes: &Bytes) -> Result<(), TLSError> {
+    if check_lbyte(bytes)? + 1 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())
     }
 }
 
-pub(crate) fn check_lbytes2_full(b: &Bytes) -> Result<(), TLSError> {
-    if check_lbytes2(b)? + 2 != b.len() {
+/// Check if `bytes` contains exactly as many bytes of content as encoded by its
+/// first two bytes.
+///
+/// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
+/// more bytes in the `bytes`.
+pub(crate) fn check_lbytes2_full(bytes: &Bytes) -> Result<(), TLSError> {
+    if check_lbytes2(bytes)? + 2 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())
     }
 }
 
-pub(crate) fn check_lbytes3_full(b: &Bytes) -> Result<(), TLSError> {
-    if check_lbytes3(b)? + 3 != b.len() {
+/// Check if `bytes` contains exactly as many bytes of content as encoded by its
+/// first three bytes.
+///
+/// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
+/// more bytes in the `bytes`.
+pub(crate) fn check_lbytes3_full(bytes: &Bytes) -> Result<(), TLSError> {
+    if check_lbytes3(bytes)? + 3 != bytes.len() {
         Err(parse_failed())
     } else {
         Ok(())
@@ -520,22 +566,28 @@ pub(crate) fn check_lbytes3_full(b: &Bytes) -> Result<(), TLSError> {
 // Handshake Data
 pub struct HandshakeData(pub Bytes);
 
-pub(crate) fn handshake_data(b: Bytes) -> HandshakeData {
-    HandshakeData(b)
-}
-pub(crate) fn handshake_data_bytes(hd: &HandshakeData) -> Bytes {
-    hd.0.clone()
+impl HandshakeData {
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn bytes(&self) -> Bytes {
+        self.0.clone()
+    }
+
+    pub(crate) fn concat(self, other: &HandshakeData) -> HandshakeData {
+        let mut message1 = self.bytes();
+        let message2 = other.bytes();
+
+        message1.0.extend_from_slice(&message2.0);
+        HandshakeData::from(message1)
+    }
 }
 
-pub(crate) fn handshake_data_len(p: &HandshakeData) -> usize {
-    p.0.len()
-}
-
-pub(crate) fn handshake_concat(msg1: HandshakeData, msg2: &HandshakeData) -> HandshakeData {
-    let HandshakeData(mut m1) = msg1;
-    let HandshakeData(m2) = msg2;
-    m1.0.extend_from_slice(&m2.0);
-    HandshakeData(m1)
+impl From<Bytes> for HandshakeData {
+    fn from(value: Bytes) -> Self {
+        HandshakeData(value)
+    }
 }
 
 // Application Data


### PR DESCRIPTION
This PR adds more documentation to a bunch of smaller functions and renames some variables and functions to make naming more consistent and hopefully improve code legibility.

In addition it includes two changes that are meant to make the code more idiomatic:
- Directly include the `u8` encoding in the `HandshakeType` enum. Similar treatment could be applied to other `u8`-encoding enums in the future, e.g. `AlertDescription`.
- Implement functions related to `HandshakeData` directly on the struct.
