### PR TITLE
fix(fstar/makefile): use common HAX variables

### DIFF
--- a/proofs/fstar/extraction/Makefile
+++ b/proofs/fstar/extraction/Makefile
@@ -29,13 +29,18 @@
 # (setq fstar-subp-prover-args #'my-fstar-compute-prover-args-using-make)
 #
 
-HAX_HOME      ?= $(shell git rev-parse --show-toplevel)/../hax/proof-libs/fstar
-FSTAR_HOME    ?= $(HAX_HOME)../FStar
-HACL_HOME     ?= $(HAX_HOME)../hacl-star
+WORKSPACE_ROOT ?= $(shell git rev-parse --show-toplevel)/..
+
+HAX_HOME            ?= $(WORKSPACE_ROOT)/hax
+HAX_PROOF_LIBS_HOME ?= $(HAX_HOME)/proof-libs/fstar
+HAX_LIBS_HOME       ?= $(HAX_HOME)/hax-lib/proofs/fstar/extraction
+
+FSTAR_HOME    ?= $(WORKSPACE_ROOT)/FStar
+HACL_HOME     ?= $(WORKSPACE_ROOT)/hacl-star
 FSTAR_BIN     ?= $(shell command -v fstar.exe 1>&2 2> /dev/null && echo "fstar.exe" || echo "$(FSTAR_HOME)/bin/fstar.exe")
 
-CACHE_DIR     ?= $(HAX_HOME)proof-libs/fstar/.cache
-HINT_DIR      ?= $(HAX_HOME)proof-libs/fstar/.hints
+CACHE_DIR     ?= .cache
+HINT_DIR      ?= .hints
 
 .PHONY: all verify clean
 
@@ -47,8 +52,9 @@ all:
 # *extend* the set of relevant files with the tests.
 ROOTS = $(wildcard *.fst)
 
-FSTAR_INCLUDE_DIRS = $(HACL_HOME)/lib $(HAX_HOME)/proof-libs/fstar/rust_primitives \
-	$(HAX_HOME)/proof-libs/fstar/core $(HAX_HOME)/proof-libs/fstar/hax_lib
+
+
+FSTAR_INCLUDE_DIRS = $(HACL_HOME)/lib $(HAX_PROOF_LIBS_HOME)/rust_primitives $(HAX_PROOF_LIBS_HOME)/core $(HAX_LIBS_HOME)
 
 FSTAR_FLAGS = --cmi \
   --warn_error -331 \


### PR DESCRIPTION
This PR addresses fixes the F* Makefile so that it's using the same env variables as other hax+F* projects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Automation

## Motivation and Context

<!-- Why is this change required? This may reference to the issue. -->

## Changes

<!--
 A clear description of what the PR does.
- It must be possible to understand the design of your change from the description.
- Explain what other alternates were considered and why the proposed version was selected.
- What are the possible side-effects or negative impacts of the code change?
- What process did you follow to verify that your change has the desired effects?
  - How did you verify that all new functionality works as expected?
  - How did you verify that all changed functionality works as expected?
  - How did you verify that the change has not introduced any regressions?
  - Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
- If this is a user-facing change please describe the changes in a single line that explains this improvement in terms that a library user can understand.
-->

## Checklist
- [ ] I have linked an issue to this PR
- [ ] I have described the changes
- [ ] I have read and understood the code of conduct, contribution guidelines, and contributor license agreement
- [ ] I have added tests for all changes
- [ ] I have tested that all tests pass locally and all checks pass
- [ ] I have updated documentation if necessary


<!-- Add the issue number for the issue that will be fixed by this PR. Remove if the issue will not be fixed. -->
Fixes #
 
