### PR TITLE
Extend hax driver for ProVerif

### DIFF
--- a/hax-driver.py
+++ b/hax-driver.py
@@ -35,7 +35,7 @@ sub_parser = parser.add_subparsers(
     help="Extract and typecheck F* etc. from the Bertie Rust code.",
 )
 extract_parser = sub_parser.add_parser("extract")
-
+extract_proverif_parser = sub_parser.add_parser("extract-proverif")
 typecheck_parser = sub_parser.add_parser("typecheck")
 typecheck_parser.add_argument(
     "--lax",
@@ -78,6 +78,24 @@ if options.sub == "extract":
             "-i",
             "-**::non_hax::** -bertie::stream::**",
             "fstar",
+        ],
+        cwd=".",
+        env=hax_env,
+    )
+elif options.sub == "extract-proverif":
+    # The extract sub command.
+    shell(
+        cargo_hax_into
+        + [
+            "-i",
+            " ".join([
+                "-**",
+                "+**::tls13handshake::put_server_hello",
+                "-**::tls13utils::**",
+                "-**::tls13formats::**",
+                "-**::tls13crypto::**",
+                      "-**::tls13cert::**"]),
+            "pro-verif",
         ],
         cwd=".",
         env=hax_env,

--- a/hax-driver.py
+++ b/hax-driver.py
@@ -37,6 +37,7 @@ sub_parser = parser.add_subparsers(
 extract_parser = sub_parser.add_parser("extract")
 extract_proverif_parser = sub_parser.add_parser("extract-proverif")
 typecheck_parser = sub_parser.add_parser("typecheck")
+typecheck_proverif_parser = sub_parser.add_parser("typecheck-proverif")
 typecheck_parser.add_argument(
     "--lax",
     action="store_true",
@@ -110,6 +111,11 @@ elif options.sub == "typecheck":
     if options.clean:
         shell(["make", "-C", "proofs/fstar/extraction/", "clean"])
     shell(["make", "-C", "proofs/fstar/extraction/"], env=custom_env)
+    exit(0)
+elif options.sub == "typecheck-proverif":
+    # Typecheck subcommand.
+    custom_env = {}
+    shell(["proverif", "proofs/proverif/extraction/output.pv"], env=custom_env)
     exit(0)
 else:
     parser.print_help()


### PR DESCRIPTION
This PR  implements extraction and typechecking subcommands for ProVerif in the `hax-driver.py` script.
Extraction is currently scoped to just one function (`bertie::tls13handshake::put_server_hello`) and a selection of its dependencies.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Automation
