### PR TITLE
Fix the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
     {
       # Takes the lockfile as input.
       packages.default = cargoLock: pkgs.callPackage bertie { inherit hax craneLib cargoLock; };
+      devShells.default = craneLib.devShell { };
     }
   );
 }


### PR DESCRIPTION
The recent removal of `Cargo.lock` (https://github.com/cryspen/bertie/pull/135) made the nix flake inoperant. This fixes the flake by making he bertie package take a pointer to a `Cargo.lock` as argument.