### PR TITLE
Pin `libcrux`, `libcrux-kem` to `rand` pre-0.9 versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ backtrace = "0.3.0"
 rand = "0.8.0"
 hex = "0.4.3"
 tracing = "0.1"
-libcrux-kem = { git = "https://github.com/cryspen/libcrux", features = ["kyber"]}
+libcrux-kem = { git = "https://github.com/cryspen/libcrux", features = ["kyber"], rev = "2a3e2f22ec9e1f1f4ecf317338408b873e7f538a"}
 libcrux = { git = "https://github.com/cryspen/libcrux", features = [
     "rand",
-]}
+], rev = "2a3e2f22ec9e1f1f4ecf317338408b873e7f538a"}
 hax-lib-macros = { git = "https://github.com/hacspec/hax", optional = true }
 hax-lib = { git = "https://github.com/hacspec/hax" }
 


### PR DESCRIPTION
This PR is a hotfix for the `rand` version mismatch between latest libcrux and Bertie until we have resolved #141.