### PR TITLE
ci: use `hacpsec/hax-actions`

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -25,27 +25,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: hacspec/hax-actions@main
+        with: 
+          fstar: v2025.02.17
 
       - name: Update dependencies
         run: cargo update
-
-      - name: 🔨 OCaml Setup
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 5.2.0
-
-      - name: ⤵ Clone hax repository
-        uses: actions/checkout@v4
-        with:
-          repository: hacspec/hax
-          path: hax
-
-      - name: 🔨 Setup hax
-        working-directory: hax
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes nodejs
-          ./setup.sh
 
       - name: 🏃🏻‍♀️ Run hax extraction
         run: |


### PR DESCRIPTION
This PR addresses slow CI times described in issue [#123](https://github.com/cryspen/bertie/issues/123).

Using Nix, the CI now takes 2:30 minutes instead of ~14 minutes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Automation

## Motivation and Context

Hax CI was slow because it was installing it manually.

## Changes

Now the CI uses `hacspec/hax-actions`, which uses nix, leveraging a binary cache (using [cachix](https://hax.cachix.org/)).

## Checklist
- [x] I have linked an issue to this PR
- [x] I have described the changes
- [x] I have read and understood the code of conduct, contribution guidelines, and contributor license agreement
- [ ] I have added tests for all changes
- [ ] I have tested that all tests pass locally and all checks pass
- [ ] I have updated documentation if necessary

Fixes #123
 
