### PR TITLE
update libcrux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,31 @@ path = "src/lib.rs"
 
 [dependencies]
 backtrace = "0.3.0"
-rand = "0.8.0"
+rand = "0.9"
 hex = "0.4.3"
 tracing = "0.1"
-libcrux-kem = { git = "https://github.com/cryspen/libcrux", features = ["kyber"], rev = "2a3e2f22ec9e1f1f4ecf317338408b873e7f538a"}
-libcrux = { git = "https://github.com/cryspen/libcrux", features = [
+libcrux-kem = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux", features = [
+    "kyber",
+] }
+libcrux-sha2 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-hmac = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-hkdf = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-chacha20poly1305 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-rsa = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-ed25519 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
+libcrux-ecdsa = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux", features = [
     "rand",
-], rev = "2a3e2f22ec9e1f1f4ecf317338408b873e7f538a"}
-hax-lib-macros = { git = "https://github.com/hacspec/hax", optional = true }
-hax-lib = { git = "https://github.com/hacspec/hax" }
+] }
+hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax" }
 
 [features]
 default = ["api", "std"]
 std = []
 test_utils = []
 secret_integers = []
-api = []                           # The streaming Rust API that everyone should use but is not hacspec.
-hax-fstar = ["dep:hax-lib-macros"]
-hax-pv = ["dep:hax-lib-macros"]
+api = []
+hax-fstar = []
+hax-pv = []
 
 [dev-dependencies]
 bertie = { path = ".", features = ["test_utils"] }

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -25,7 +25,7 @@ use bertie::{
     tls13utils::Bytes,
     Client, Server,
 };
-use libcrux::{digest, drbg::Drbg};
+use rand::RngCore;
 
 fn hs_per_second(d: Duration) -> f64 {
     // ITERATIONS per d
@@ -159,7 +159,7 @@ fn protocol() {
     println!("Client");
 
     for ciphersuite in CIPHERSUITES {
-        let mut rng = Drbg::new(digest::Algorithm::Sha256).unwrap();
+        let mut rng = rand::rng();
 
         // Server
         let server_name_str = "localhost";
@@ -178,7 +178,8 @@ fn protocol() {
 
         let mut handshake_time = Duration::ZERO;
         let mut application_time = Duration::ZERO;
-        let payload = rng.generate_vec(NUM_PAYLOAD_BYTES).unwrap();
+        let mut payload = vec![0u8; NUM_PAYLOAD_BYTES];
+        rng.fill_bytes(&mut payload);
         let mut size1: usize = 0;
         let mut size2: usize = 0;
         let mut size3: usize = 0;

--- a/benches/client_stack.rs
+++ b/benches/client_stack.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use bytesize::ByteSize;
-use rand::thread_rng;
 use std::alloc;
 use std::net::TcpListener;
 
@@ -117,7 +116,7 @@ fn protocol() {
                 BertieStream::server("127.0.0.1", port, stream, ciphersuite, cert_file, key_file)
                     .unwrap();
 
-            server.connect(&mut thread_rng()).unwrap();
+            server.connect(&mut rand::rng()).unwrap();
             server
         });
 
@@ -137,7 +136,7 @@ fn protocol() {
             }
 
             client = psm::on_stack(paintstack, STACK_SIZE, || {
-                BertieStream::client("127.0.0.1", port, ciphersuite, &mut thread_rng()).unwrap()
+                BertieStream::client("127.0.0.1", port, ciphersuite, &mut rand::rng()).unwrap()
             });
 
             for i in (0..STACK_SIZE).step_by(4) {

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -21,7 +21,7 @@ use bertie::{
     tls13utils::Bytes,
     Client, Server,
 };
-use libcrux::{digest, drbg::Drbg};
+use rand::RngCore;
 
 fn hs_per_second(d: Duration) -> f64 {
     // ITERATIONS per d
@@ -99,7 +99,7 @@ fn protocol() {
     println!("Server");
 
     for ciphersuite in CIPHERSUITES {
-        let mut rng = Drbg::new(digest::Algorithm::Sha256).unwrap();
+        let mut rng = rand::rng();
 
         // Server
         let server_name_str = "localhost";
@@ -118,7 +118,8 @@ fn protocol() {
 
         let mut handshake_time = Duration::ZERO;
         let mut application_time = Duration::ZERO;
-        let payload = rng.generate_vec(NUM_PAYLOAD_BYTES).unwrap();
+        let mut payload = vec![0u8; NUM_PAYLOAD_BYTES];
+        rng.fill_bytes(&mut payload);
 
         for _ in 0..ITERATIONS {
             let (client_hello, client) =

--- a/bogo_shim/Cargo.toml
+++ b/bogo_shim/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 base64 = "0.20.0"
 bertie = { path = "../" }
-rand = "0.8.5"
+rand = "0.9"
 tracing = "*"
 tracing-subscriber = "*"

--- a/bogo_shim/src/main.rs
+++ b/bogo_shim/src/main.rs
@@ -218,7 +218,7 @@ fn main() {
                 stream,
             )
             .unwrap();
-            let _r = client.start(&mut rand::thread_rng());
+            let _r = client.start(&mut rand::rng());
         }
         Role::Server => {
             let bertie_home = std::env::var("BERTIE_HOME")
@@ -244,7 +244,7 @@ fn main() {
             )
             .unwrap();
 
-            if let Err(e) = server.connect(&mut rand::thread_rng()) {
+            if let Err(e) = server.connect(&mut rand::rng()) {
                 match e {
                     BertieError::TLS(137) => eprintln!("Wrong TLS protocol version {:?}", e),
                     // AppError::TLS(137) => eprintln!("Wrong TLS protocol version {:?}", e),

--- a/hax-driver.py
+++ b/hax-driver.py
@@ -70,6 +70,7 @@ cargo_hax_into = [
     "-p",
     "rand_core",
     "--no-default-features",
+    "-F std",
     ";",
     "into",
 ]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,4 +11,4 @@ libcrux-platform = { git = "https://github.com/cryspen/libcrux" }
 tracing-subscriber = "0.3"
 
 [dev-dependencies]
-rand = "0.8.0"
+rand = "0.9"

--- a/integration_tests/tests/self_test.rs
+++ b/integration_tests/tests/self_test.rs
@@ -1,19 +1,14 @@
-use rand::thread_rng;
 use std::net::TcpListener;
 
 use bertie::{
     stream::BertieStream,
     tls13crypto::{
-        SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256, SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519,
-        SHA256_Aes128Gcm_RsaPssRsaSha256_P256, SHA256_Aes128Gcm_RsaPssRsaSha256_X25519,
         SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_P256,
         SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519,
         SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00,
         SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519MlKem768,
         SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256,
-        SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519, SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256,
-        SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519, SHA384_Aes256Gcm_RsaPssRsaSha256_P256,
-        SHA384_Aes256Gcm_RsaPssRsaSha256_X25519, SignatureScheme,
+        SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519, SignatureScheme,
     },
 };
 
@@ -41,54 +36,54 @@ fn test_sha256_chacha20_poly1305_ecdsa_secp256r1_sha256_p256() {
 fn test_sha256_chacha20_poly1305_rsa_pss_rsa_sha256_p256() {
     self_test_algorithm(SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256);
 }
-#[test]
-fn test_sha256_aes128_gcm_ecdsa_secp256r1_sha256_p256() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256);
-    }
-}
-#[test]
-fn test_sha256_aes128_gcm_ecdsa_secp256r1_sha256_x25519() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519);
-    }
-}
-#[test]
-fn test_sha256_aes128_gcm_rsa_pss_rsa_sha256_p256() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA256_Aes128Gcm_RsaPssRsaSha256_P256);
-    }
-}
-#[test]
-fn test_sha256_aes128_gcm_rsa_pss_rsa_sha256_x25519() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA256_Aes128Gcm_RsaPssRsaSha256_X25519);
-    }
-}
-#[test]
-fn test_sha384_aes256_gcm_ecdsa_secp256r1_sha256_p256() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256);
-    }
-}
-#[test]
-fn test_sha384_aes256_gcm_ecdsa_secp256r1_sha256_x25519() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519);
-    }
-}
-#[test]
-fn test_sha384_aes256_gcm_rsa_pss_rsa_sha256_p256() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA384_Aes256Gcm_RsaPssRsaSha256_P256);
-    }
-}
-#[test]
-fn test_sha384_aes256_gcm_rsa_pss_rsa_sha256_x25519() {
-    if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
-        self_test_algorithm(SHA384_Aes256Gcm_RsaPssRsaSha256_X25519);
-    }
-}
+// #[test]
+// fn test_sha256_aes128_gcm_ecdsa_secp256r1_sha256_p256() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256);
+//     }
+// }
+// #[test]
+// fn test_sha256_aes128_gcm_ecdsa_secp256r1_sha256_x25519() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519);
+//     }
+// }
+// #[test]
+// fn test_sha256_aes128_gcm_rsa_pss_rsa_sha256_p256() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA256_Aes128Gcm_RsaPssRsaSha256_P256);
+//     }
+// }
+// #[test]
+// fn test_sha256_aes128_gcm_rsa_pss_rsa_sha256_x25519() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA256_Aes128Gcm_RsaPssRsaSha256_X25519);
+//     }
+// }
+// #[test]
+// fn test_sha384_aes256_gcm_ecdsa_secp256r1_sha256_p256() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256);
+//     }
+// }
+// #[test]
+// fn test_sha384_aes256_gcm_ecdsa_secp256r1_sha256_x25519() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519);
+//     }
+// }
+// #[test]
+// fn test_sha384_aes256_gcm_rsa_pss_rsa_sha256_p256() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA384_Aes256Gcm_RsaPssRsaSha256_P256);
+//     }
+// }
+// #[test]
+// fn test_sha384_aes256_gcm_rsa_pss_rsa_sha256_x25519() {
+//     if libcrux_platform::aes_ni_support() && cfg!(target_arch = "x64") {
+//         self_test_algorithm(SHA384_Aes256Gcm_RsaPssRsaSha256_X25519);
+//     }
+// }
 
 fn self_test_algorithm(ciphersuite: bertie::tls13crypto::Algorithms) {
     let _ = tracing_subscriber::fmt::try_init();
@@ -125,14 +120,14 @@ fn self_test_algorithm(ciphersuite: bertie::tls13crypto::Algorithms) {
                 .unwrap();
 
         eprintln!("Server setup finished.");
-        server.connect(&mut thread_rng()).unwrap();
+        server.connect(&mut rand::rng()).unwrap();
         server
     });
 
     // Client thread.
     let port = rx.recv().unwrap();
 
-    let mut client = BertieStream::client("127.0.0.1", port, ciphersuite, &mut thread_rng())
+    let mut client = BertieStream::client("127.0.0.1", port, ciphersuite, &mut rand::rng())
         .expect("Error connecting to server");
     eprintln!("Client connected to 127.0.0.1:{}.", port);
 

--- a/proofs/fstar/extraction/Bertie.Server.fst
+++ b/proofs/fstar/extraction/Bertie.Server.fst
@@ -3,7 +3,31 @@ module Bertie.Server
 open Core
 open FStar.Mul
 
-let impl__ServerDB__new
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core.Fmt.t_Debug t_ServerDB
+
+let impl_1 = impl_1'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core.Clone.t_Clone t_ServerDB
+
+let impl_2 = impl_2'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_3': Core.Default.t_Default t_ServerDB
+
+let impl_3 = impl_3'
+
+let impl_ServerDB__new
       (server_name cert sk: Bertie.Tls13utils.t_Bytes)
       (psk_opt: Core.Option.t_Option (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes))
      = { f_server_name = server_name; f_cert = cert; f_sk = sk; f_psk_opt = psk_opt } <: t_ServerDB
@@ -15,25 +39,32 @@ let lookup_db
       (tkt: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
      =
   if
-    Bertie.Tls13utils.eq sni (Bertie.Tls13utils.impl__Bytes__new () <: Bertie.Tls13utils.t_Bytes) ||
+    Bertie.Tls13utils.eq sni (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes) ||
     Bertie.Tls13utils.eq sni db.f_server_name
   then
     match
-      Bertie.Tls13crypto.impl__Algorithms__psk_mode ciphersuite, tkt, db.f_psk_opt
+      Bertie.Tls13crypto.impl_Algorithms__psk_mode ciphersuite, tkt, db.f_psk_opt
       <:
       (bool & Core.Option.t_Option Bertie.Tls13utils.t_Bytes &
         Core.Option.t_Option (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes))
     with
     | true, Core.Option.Option_Some ctkt, Core.Option.Option_Some (stkt, psk) ->
-      (match Bertie.Tls13utils.check_eq ctkt stkt with
+      (match Bertie.Tls13utils.check_eq ctkt stkt <: Core.Result.t_Result Prims.unit u8 with
         | Core.Result.Result_Ok _ ->
           let server:t_ServerInfo =
             {
-              f_cert = Core.Clone.f_clone db.f_cert;
-              f_sk = Core.Clone.f_clone db.f_sk;
+              f_cert
+              =
+              Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+                #FStar.Tactics.Typeclasses.solve
+                db.f_cert;
+              f_sk
+              =
+              Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve db.f_sk;
               f_psk_opt
               =
-              Core.Option.Option_Some (Core.Clone.f_clone psk)
+              Core.Option.Option_Some
+              (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve psk)
               <:
               Core.Option.t_Option Bertie.Tls13utils.t_Bytes
             }
@@ -46,8 +77,12 @@ let lookup_db
     | false, _, _ ->
       let server:t_ServerInfo =
         {
-          f_cert = Core.Clone.f_clone db.f_cert;
-          f_sk = Core.Clone.f_clone db.f_sk;
+          f_cert
+          =
+          Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve db.f_cert;
+          f_sk
+          =
+          Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve db.f_sk;
           f_psk_opt = Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes
         }
         <:

--- a/proofs/fstar/extraction/Bertie.Server.fsti
+++ b/proofs/fstar/extraction/Bertie.Server.fsti
@@ -3,6 +3,13 @@ module Bertie.Server
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
+
+/// The Server Database
 type t_ServerDB = {
   f_server_name:Bertie.Tls13utils.t_Bytes;
   f_cert:Bertie.Tls13utils.t_Bytes;
@@ -10,17 +17,31 @@ type t_ServerDB = {
   f_psk_opt:Core.Option.t_Option (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes)
 }
 
-val impl__ServerDB__new
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core.Fmt.t_Debug t_ServerDB
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_2:Core.Clone.t_Clone t_ServerDB
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_3:Core.Default.t_Default t_ServerDB
+
+/// Create a new server database.
+/// Note that this only holds one value at a time right now. #51
+val impl_ServerDB__new
       (server_name cert sk: Bertie.Tls13utils.t_Bytes)
       (psk_opt: Core.Option.t_Option (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes))
     : Prims.Pure t_ServerDB Prims.l_True (fun _ -> Prims.l_True)
 
+/// Global server information.
 type t_ServerInfo = {
   f_cert:Bertie.Tls13utils.t_Bytes;
   f_sk:Bertie.Tls13utils.t_Bytes;
   f_psk_opt:Core.Option.t_Option Bertie.Tls13utils.t_Bytes
 }
 
+/// Look up a server for the given `ciphersuite`.
+/// The function returns a server with the first algorithm it finds.
 val lookup_db
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
       (db: t_ServerDB)

--- a/proofs/fstar/extraction/Bertie.Tls13api.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13api.fst
@@ -3,49 +3,73 @@ module Bertie.Tls13api
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13formats.Handshake_data in
+  let open Bertie.Tls13utils in
+  let open Rand_core in
+  ()
+
 let in_psk_mode (c: t_Client) =
-  match c with
+  match c <: t_Client with
   | Client_Client0 cstate _ ->
-    Bertie.Tls13crypto.impl__Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_client_hello cstate
+    Bertie.Tls13crypto.impl_Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_client_hello cstate
 
         <:
         Bertie.Tls13crypto.t_Algorithms)
   | Client_ClientH cstate _ _ _ ->
-    Bertie.Tls13crypto.impl__Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_server_hello cstate
+    Bertie.Tls13crypto.impl_Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_server_hello cstate
 
         <:
         Bertie.Tls13crypto.t_Algorithms)
   | Client_Client1 cstate _ ->
-    Bertie.Tls13crypto.impl__Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_client_finished cstate
+    Bertie.Tls13crypto.impl_Algorithms__psk_mode (Bertie.Tls13handshake.algs_post_client_finished cstate
 
         <:
         Bertie.Tls13crypto.t_Algorithms)
 
-let impl__Client__connect
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+let impl_Client__connect
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
       (server_name: Bertie.Tls13utils.t_Bytes)
       (session_ticket psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
-  let tmp0, out:(impl_916461611_ &
+  let tmp0, out:(iimpl_916461611_ &
     Core.Result.t_Result
       (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
         Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
         Bertie.Tls13handshake.t_ClientPostClientHello) u8) =
-    Bertie.Tls13handshake.client_init ciphersuite server_name session_ticket psk rng
+    Bertie.Tls13handshake.client_init #iimpl_916461611_
+      ciphersuite
+      server_name
+      session_ticket
+      psk
+      rng
   in
-  let rng:impl_916461611_ = tmp0 in
-  match out with
+  let rng:iimpl_916461611_ = tmp0 in
+  match
+    out
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+        Bertie.Tls13handshake.t_ClientPostClientHello) u8
+  with
   | Core.Result.Result_Ok (client_hello, cipherstate0, client_state) ->
-    (match Bertie.Tls13formats.handshake_record client_hello with
+    (match
+        Bertie.Tls13formats.handshake_record client_hello
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
       | Core.Result.Result_Ok client_hello_record ->
         let client_hello_record:Bertie.Tls13utils.t_Bytes =
           Rust_primitives.Hax.update_at client_hello_record
-            (sz 2)
-            (Bertie.Tls13utils.v_U8 1uy <: u8)
+            (mk_usize 2)
+            (Bertie.Tls13utils.v_U8 (mk_u8 1) <: u8)
         in
         let hax_temp_output:Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8 =
           Core.Result.Result_Ok
@@ -57,154 +81,42 @@ let impl__Client__connect
         in
         rng, hax_temp_output
         <:
-        (impl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
+        (iimpl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
       | Core.Result.Result_Err err ->
         rng,
         (Core.Result.Result_Err err
           <:
           Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
         <:
-        (impl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8))
+        (iimpl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8))
   | Core.Result.Result_Err err ->
     rng,
     (Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
     <:
-    (impl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
+    (iimpl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
 
-let impl__Server__read (self: t_Server) (application_data: Bertie.Tls13utils.t_Bytes) =
-  match self with
-  | Server_Server1 sstate cipher1 ->
-    (match Bertie.Tls13record.decrypt_data application_data cipher1 with
-      | Core.Result.Result_Ok (ad, cipher1) ->
-        Core.Result.Result_Ok
-        ((Core.Option.Option_Some ad <: Core.Option.t_Option Bertie.Tls13utils.t_AppData),
-          (Server_Server1 sstate cipher1 <: t_Server)
-          <:
-          (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server))
-        <:
-        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8)
-  | _ ->
-    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
-    <:
-    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8
-
-let impl__Client__read (self: t_Client) (message_bytes: Bertie.Tls13utils.t_Bytes) =
-  match self with
-  | Client_Client1 state cipher1 ->
-    (match Bertie.Tls13record.decrypt_data_or_hs message_bytes cipher1 with
-      | Core.Result.Result_Ok (ty, hd, cipher1) ->
-        (match ty with
-          | Bertie.Tls13formats.ContentType_ApplicationData  ->
-            Core.Result.Result_Ok
-            ((Core.Option.Option_Some (Bertie.Tls13utils.impl__AppData__new hd)
-                <:
-                Core.Option.t_Option Bertie.Tls13utils.t_AppData),
-              (Client_Client1 state cipher1 <: t_Client)
-              <:
-              (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client))
-            <:
-            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
-          | Bertie.Tls13formats.ContentType_Handshake  ->
-            let _:Prims.unit =
-              Std.Io.Stdio.v__eprint (Core.Fmt.impl_2__new_const (Rust_primitives.unsize (let list =
-                            ["Received Session Ticket\n"]
-                          in
-                          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                          Rust_primitives.Hax.array_of_list 1 list)
-                      <:
-                      t_Slice string)
-                  <:
-                  Core.Fmt.t_Arguments)
-            in
-            let _:Prims.unit = () in
-            Core.Result.Result_Ok
-            ((Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_AppData),
-              (Client_Client1 state cipher1 <: t_Client)
-              <:
-              (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client))
-            <:
-            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
-          | _ ->
-            Core.Result.Result_Err Bertie.Tls13utils.v_PARSE_FAILED
-            <:
-            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
-  | _ ->
-    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
-    <:
-    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
-
-let impl__Server__read_handshake (self: t_Server) (handshake_bytes: Bertie.Tls13utils.t_Bytes) =
-  match self with
-  | Server_ServerH sstate v__cipher0 cipher_hs cipher1 ->
-    (match Bertie.Tls13record.decrypt_handshake handshake_bytes cipher_hs with
-      | Core.Result.Result_Ok (cf, v__cipher_hs) ->
-        (match Bertie.Tls13handshake.server_finish cf sstate with
-          | Core.Result.Result_Ok sstate ->
-            Core.Result.Result_Ok (Server_Server1 sstate cipher1 <: t_Server)
-            <:
-            Core.Result.t_Result t_Server u8
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result t_Server u8)
-      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result t_Server u8
-    )
-  | _ ->
-    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE <: Core.Result.t_Result t_Server u8
-
-let impl__Client__write (self: t_Client) (application_data: Bertie.Tls13utils.t_AppData) =
-  match self with
-  | Client_Client1 cstate cipher1 ->
-    (match Bertie.Tls13record.encrypt_data application_data (sz 0) cipher1 with
-      | Core.Result.Result_Ok (v_by, cipher1) ->
-        Core.Result.Result_Ok
-        (v_by, (Client_Client1 cstate cipher1 <: t_Client) <: (Bertie.Tls13utils.t_Bytes & t_Client)
-        )
-        <:
-        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
-    )
-  | _ ->
-    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
-    <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
-
-let impl__Server__write (self: t_Server) (application_data: Bertie.Tls13utils.t_AppData) =
-  match self with
-  | Server_Server1 sstate cipher1 ->
-    (match Bertie.Tls13record.encrypt_data application_data (sz 0) cipher1 with
-      | Core.Result.Result_Ok (v_by, cipher1) ->
-        Core.Result.Result_Ok
-        (v_by, (Server_Server1 sstate cipher1 <: t_Server) <: (Bertie.Tls13utils.t_Bytes & t_Server)
-        )
-        <:
-        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
-    )
-  | _ ->
-    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
-    <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
-
-let impl__Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13utils.t_Bytes) =
-  match self with
+let impl_Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13utils.t_Bytes) =
+  match self <: t_Client with
   | Client_Client0 state cipher_state ->
-    (match Bertie.Tls13formats.get_handshake_record handshake_bytes with
+    (match
+        Bertie.Tls13formats.get_handshake_record handshake_bytes
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+      with
       | Core.Result.Result_Ok sf ->
-        (match Bertie.Tls13handshake.client_set_params sf state with
+        (match
+            Bertie.Tls13handshake.client_set_params sf state
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13record.t_DuplexCipherStateH &
+                Bertie.Tls13handshake.t_ClientPostServerHello) u8
+          with
           | Core.Result.Result_Ok (cipher1, cstate) ->
             let buf:Bertie.Tls13formats.Handshake_data.t_HandshakeData =
-              Core.Convert.f_from (Bertie.Tls13utils.impl__Bytes__new ()
-                  <:
-                  Bertie.Tls13utils.t_Bytes)
+              Core.Convert.f_from #Bertie.Tls13formats.Handshake_data.t_HandshakeData
+                #Bertie.Tls13utils.t_Bytes
+                #FStar.Tactics.Typeclasses.solve
+                (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes)
             in
             Core.Result.Result_Ok
             ((Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes),
@@ -222,22 +134,40 @@ let impl__Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13
         <:
         Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & t_Client) u8)
   | Client_ClientH cstate cipher0 cipher_hs buf ->
-    (match Bertie.Tls13record.decrypt_handshake handshake_bytes cipher_hs with
+    (match
+        Bertie.Tls13record.decrypt_handshake handshake_bytes cipher_hs
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherStateH) u8
+      with
       | Core.Result.Result_Ok (hd, cipher_hs) ->
         let buf:Bertie.Tls13formats.Handshake_data.t_HandshakeData =
-          Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat buf hd
+          Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat buf hd
         in
         if
-          Bertie.Tls13formats.Handshake_data.impl__HandshakeData__find_handshake_message buf
+          Bertie.Tls13formats.Handshake_data.impl_HandshakeData__find_handshake_message buf
             (Bertie.Tls13formats.Handshake_data.HandshakeType_Finished
               <:
               Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-            (sz 0)
+            (mk_usize 0)
         then
-          match Bertie.Tls13handshake.client_finish buf cstate with
+          match
+            Bertie.Tls13handshake.client_finish buf cstate
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                Bertie.Tls13record.t_DuplexCipherState1 &
+                Bertie.Tls13handshake.t_ClientPostClientFinished) u8
+          with
           | Core.Result.Result_Ok (cfin, cipher1, cstate) ->
-            (match Bertie.Tls13record.encrypt_handshake cfin (sz 0) cipher_hs with
-              | Core.Result.Result_Ok (cf_rec, v__cipher_hs) ->
+            (match
+                Bertie.Tls13record.encrypt_handshake cfin (mk_usize 0) cipher_hs
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13utils.t_Bytes & Bertie.Tls13record.t_DuplexCipherStateH) u8
+              with
+              | Core.Result.Result_Ok (cf_rec, e_cipher_hs) ->
                 Core.Result.Result_Ok
                 ((Core.Option.Option_Some cf_rec <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes),
                   (Client_Client1 cstate cipher1 <: t_Client)
@@ -270,22 +200,94 @@ let impl__Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13
     <:
     Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & t_Client) u8
 
-let impl__Server__accept
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+let impl_Client__read (self: t_Client) (message_bytes: Bertie.Tls13utils.t_Bytes) =
+  match self <: t_Client with
+  | Client_Client1 state cipher1 ->
+    (match
+        Bertie.Tls13record.decrypt_data_or_hs message_bytes cipher1
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes &
+            Bertie.Tls13record.t_DuplexCipherState1) u8
+      with
+      | Core.Result.Result_Ok (ty, hd, cipher1) ->
+        (match ty <: Bertie.Tls13formats.t_ContentType with
+          | Bertie.Tls13formats.ContentType_ApplicationData  ->
+            Core.Result.Result_Ok
+            ((Core.Option.Option_Some (Bertie.Tls13utils.impl_AppData__new hd)
+                <:
+                Core.Option.t_Option Bertie.Tls13utils.t_AppData),
+              (Client_Client1 state cipher1 <: t_Client)
+              <:
+              (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client))
+            <:
+            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
+          | Bertie.Tls13formats.ContentType_Handshake  ->
+            Core.Result.Result_Ok
+            ((Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_AppData),
+              (Client_Client1 state cipher1 <: t_Client)
+              <:
+              (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client))
+            <:
+            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
+          | _ ->
+            Core.Result.Result_Err Bertie.Tls13utils.v_PARSE_FAILED
+            <:
+            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
+  | _ ->
+    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
+    <:
+    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8
+
+let impl_Client__write (self: t_Client) (application_data: Bertie.Tls13utils.t_AppData) =
+  match self <: t_Client with
+  | Client_Client1 cstate cipher1 ->
+    (match
+        Bertie.Tls13record.encrypt_data application_data (mk_usize 0) cipher1
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13record.t_DuplexCipherState1)
+          u8
+      with
+      | Core.Result.Result_Ok (v_by, cipher1) ->
+        Core.Result.Result_Ok
+        (v_by, (Client_Client1 cstate cipher1 <: t_Client) <: (Bertie.Tls13utils.t_Bytes & t_Client)
+        )
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
+    )
+  | _ ->
+    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8
+
+let impl_Server__accept
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
       (db: Bertie.Server.t_ServerDB)
       (client_hello: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
-  let ch_rec:Bertie.Tls13utils.t_Bytes = Core.Clone.f_clone client_hello in
   let ch_rec:Bertie.Tls13utils.t_Bytes =
-    Rust_primitives.Hax.update_at ch_rec (sz 2) (Bertie.Tls13utils.v_U8 3uy <: u8)
+    Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve client_hello
   in
-  match Bertie.Tls13formats.get_handshake_record ch_rec with
+  let ch_rec:Bertie.Tls13utils.t_Bytes =
+    Rust_primitives.Hax.update_at ch_rec (mk_usize 2) (Bertie.Tls13utils.v_U8 (mk_u8 3) <: u8)
+  in
+  match
+    Bertie.Tls13formats.get_handshake_record ch_rec
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
   | Core.Result.Result_Ok ch ->
-    let tmp0, out:(impl_916461611_ &
+    let tmp0, out:(iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -293,14 +295,33 @@ let impl__Server__accept
           Bertie.Tls13record.t_DuplexCipherStateH &
           Bertie.Tls13record.t_DuplexCipherState1 &
           Bertie.Tls13handshake.t_ServerPostServerFinished) u8) =
-      Bertie.Tls13handshake.server_init ciphersuite ch db rng
+      Bertie.Tls13handshake.server_init #iimpl_916461611_ ciphersuite ch db rng
     in
-    let rng:impl_916461611_ = tmp0 in
-    (match out with
+    let rng:iimpl_916461611_ = tmp0 in
+    (match
+        out
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 &
+            Bertie.Tls13record.t_DuplexCipherStateH &
+            Bertie.Tls13record.t_DuplexCipherState1 &
+            Bertie.Tls13handshake.t_ServerPostServerFinished) u8
+      with
       | Core.Result.Result_Ok (server_hello, server_finished, cipher0, cipher_hs, cipher1, sstate) ->
-        (match Bertie.Tls13formats.handshake_record server_hello with
+        (match
+            Bertie.Tls13formats.handshake_record server_hello
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
           | Core.Result.Result_Ok sh_rec ->
-            (match Bertie.Tls13record.encrypt_handshake server_finished (sz 0) cipher_hs with
+            (match
+                Bertie.Tls13record.encrypt_handshake server_finished (mk_usize 0) cipher_hs
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13utils.t_Bytes & Bertie.Tls13record.t_DuplexCipherStateH) u8
+              with
               | Core.Result.Result_Ok (sf_rec, cipher_hs) ->
                 let hax_temp_output:Core.Result.t_Result
                   (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8 =
@@ -314,7 +335,7 @@ let impl__Server__accept
                 in
                 rng, hax_temp_output
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
               | Core.Result.Result_Err err ->
@@ -324,7 +345,7 @@ let impl__Server__accept
                   Core.Result.t_Result
                     (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8))
           | Core.Result.Result_Err err ->
@@ -334,7 +355,7 @@ let impl__Server__accept
               Core.Result.t_Result
                 (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
             <:
-            (impl_916461611_ &
+            (iimpl_916461611_ &
               Core.Result.t_Result
                 (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8))
       | Core.Result.Result_Err err ->
@@ -344,7 +365,7 @@ let impl__Server__accept
           Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8
         )
         <:
-        (impl_916461611_ &
+        (iimpl_916461611_ &
           Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8
         ))
   | Core.Result.Result_Err err ->
@@ -353,5 +374,81 @@ let impl__Server__accept
       <:
       Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
     <:
-    (impl_916461611_ &
+    (iimpl_916461611_ &
       Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
+
+let impl_Server__read_handshake (self: t_Server) (handshake_bytes: Bertie.Tls13utils.t_Bytes) =
+  match self <: t_Server with
+  | Server_ServerH sstate e_cipher0 cipher_hs cipher1 ->
+    (match
+        Bertie.Tls13record.decrypt_handshake handshake_bytes cipher_hs
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherStateH) u8
+      with
+      | Core.Result.Result_Ok (cf, e_cipher_hs) ->
+        (match
+            Bertie.Tls13handshake.server_finish cf sstate
+            <:
+            Core.Result.t_Result Bertie.Tls13handshake.t_ServerPostClientFinished u8
+          with
+          | Core.Result.Result_Ok sstate ->
+            Core.Result.Result_Ok (Server_Server1 sstate cipher1 <: t_Server)
+            <:
+            Core.Result.t_Result t_Server u8
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result t_Server u8)
+      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result t_Server u8
+    )
+  | _ ->
+    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE <: Core.Result.t_Result t_Server u8
+
+let impl_Server__write (self: t_Server) (application_data: Bertie.Tls13utils.t_AppData) =
+  match self <: t_Server with
+  | Server_Server1 sstate cipher1 ->
+    (match
+        Bertie.Tls13record.encrypt_data application_data (mk_usize 0) cipher1
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13record.t_DuplexCipherState1)
+          u8
+      with
+      | Core.Result.Result_Ok (v_by, cipher1) ->
+        Core.Result.Result_Ok
+        (v_by, (Server_Server1 sstate cipher1 <: t_Server) <: (Bertie.Tls13utils.t_Bytes & t_Server)
+        )
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
+    )
+  | _ ->
+    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8
+
+let impl_Server__read (self: t_Server) (application_data: Bertie.Tls13utils.t_Bytes) =
+  match self <: t_Server with
+  | Server_Server1 sstate cipher1 ->
+    (match
+        Bertie.Tls13record.decrypt_data application_data cipher1
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_AppData & Bertie.Tls13record.t_DuplexCipherState1)
+          u8
+      with
+      | Core.Result.Result_Ok (ad, cipher1) ->
+        Core.Result.Result_Ok
+        ((Core.Option.Option_Some ad <: Core.Option.t_Option Bertie.Tls13utils.t_AppData),
+          (Server_Server1 sstate cipher1 <: t_Server)
+          <:
+          (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server))
+        <:
+        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8)
+  | _ ->
+    Core.Result.Result_Err Bertie.Tls13utils.v_INCORRECT_STATE
+    <:
+    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8

--- a/proofs/fstar/extraction/Bertie.Tls13api.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13api.fsti
@@ -3,6 +3,15 @@ module Bertie.Tls13api
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13formats.Handshake_data in
+  let open Bertie.Tls13utils in
+  let open Rand_core in
+  ()
+
+/// The TLS Client state.
 type t_Client =
   | Client_Client0 :
       Bertie.Tls13handshake.t_ClientPostClientHello ->
@@ -19,8 +28,77 @@ type t_Client =
       Bertie.Tls13record.t_DuplexCipherState1
     -> t_Client
 
+/// Check if the client is using a PSK mode or not.
+/// Returns `true` if the client is in PSK mode and `false` otherwise.
 val in_psk_mode (c: t_Client) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
+/// Start a TLS handshake as client.
+/// Note that Bertie clients only support a single ciphersuite at a time and
+/// do not perform ciphersuite negotiation.
+/// This function takes the
+/// * `ciphersuite` to use for this client
+/// * `server_name` for the server to connect to
+/// * `session_ticket` for an optional session ticket
+/// * `psk` for an optional pre-shared-key
+/// * `entropy` for the randomness required in the handshake
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// client hello record as bytes, and the [`Client`] state as the second element.
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Client__connect
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
+      (server_name: Bertie.Tls13utils.t_Bytes)
+      (session_ticket psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+    : Prims.Pure (iimpl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Read the next handshake Message.
+/// This function takes the current state and `handshake_bytes` and returns
+/// the next state or a [`TLSError`].
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// next client handshake message as bytes option, and the next [`Client`] state as
+/// the second element.
+/// If there's no handshake message, the first element is [`None`].
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & t_Client) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Read application data and session tickets.
+/// This function can be used when the TLS handshake is complete, to read
+/// application data and session tickets from the server.
+/// It takes the current state and `message_bytes` and returns
+/// the next state or a [`TLSError`].
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// application data as bytes option, and the new [`Client`] state as the second element.
+/// If there's no application data, the first element is [`None`].
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Client__read (self: t_Client) (message_bytes: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Send application data to the server.
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// encrypted `application_data` as bytes, and the new [`Client`] state as the second element.
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Client__write (self: t_Client) (application_data: Bertie.Tls13utils.t_AppData)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// The TLS server state.
 type t_Server =
   | Server_ServerH :
       Bertie.Tls13handshake.t_ServerPostServerFinished ->
@@ -33,59 +111,64 @@ type t_Server =
       Bertie.Tls13record.t_DuplexCipherState1
     -> t_Server
 
-val impl__Client__connect
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
+/// Start a new TLS handshake as server.
+/// Note that Bertie servers only support a single ciphersuite at a time and
+/// do not perform ciphersuite negotiation.
+/// This function takes the
+/// * `ciphersuite` to use for this server
+/// * `db` for the server database containing certificates and keys
+/// * `client_hello` for the initial client hello message
+/// * `entropy` for the randomness required in the handshake
+/// The function returns a [`Result`].
+/// When successful, the function returns a three-tuple with the first element the
+/// server hello record as bytes, the second the server finished record as bytes,
+/// and the new [`Server`] state as the third element.
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Server__accept
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (server_name: Bertie.Tls13utils.t_Bytes)
-      (session_ticket psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure (impl_916461611_ & Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Server__read (self: t_Server) (application_data: Bertie.Tls13utils.t_Bytes)
+      (db: Bertie.Server.t_ServerDB)
+      (client_hello: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8)
+      (iimpl_916461611_ &
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__Client__read (self: t_Client) (message_bytes: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure
-      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Client) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Server__read_handshake (self: t_Server) (handshake_bytes: Bertie.Tls13utils.t_Bytes)
+/// Read the next handshake Message.
+/// This function takes the current state and `handshake_bytes` and returns
+/// the next state or a [`TLSError`].
+/// The function returns a [`Result`].
+/// When successful, the function returns the next [`Server`] state.
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Server__read_handshake (self: t_Server) (handshake_bytes: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result t_Server u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Client__write (self: t_Client) (application_data: Bertie.Tls13utils.t_AppData)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Client) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Server__write (self: t_Server) (application_data: Bertie.Tls13utils.t_AppData)
+/// Send application data to the client.
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// encrypted `application_data` as bytes, and the new [`Server`] state as the second element.
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Server__write (self: t_Server) (application_data: Bertie.Tls13utils.t_AppData)
     : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_Server) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__Client__read_handshake (self: t_Client) (handshake_bytes: Bertie.Tls13utils.t_Bytes)
+/// Read application data.
+/// This function can be used when the TLS handshake is complete, to read
+/// application data from the client.
+/// It takes the current state and `application_data` and returns
+/// the next state or a [`TLSError`].
+/// The function returns a [`Result`].
+/// When successful, the function returns a tuple with the first element the
+/// application data as bytes option, and the new [`Server`] state as the second element.
+/// If there's no application data, the first element is [`None`].
+/// If an error occurs, it returns a [`TLSError`].
+val impl_Server__read (self: t_Server) (application_data: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure
-      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & t_Client) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Server__accept
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (db: Bertie.Server.t_ServerDB)
-      (client_hello: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & t_Server) u8)
+      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_AppData & t_Server) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Bertie.Tls13cert.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13cert.fst
@@ -3,91 +3,40 @@ module Bertie.Tls13cert
 open Core
 open FStar.Mul
 
-let asn1_error (#v_T: Type) (err: u8) = Core.Result.Result_Err err <: Core.Result.t_Result v_T u8
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
 
-let check_success (v_val: bool) =
-  if v_val
-  then Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
-  else asn1_error v_ASN1_ERROR
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl': Core.Clone.t_Clone t_CertificateKey
 
-let ecdsa_secp256r1_sha256_oid (_: Prims.unit) =
-  Core.Convert.f_into (let list = [42uy; 134uy; 72uy; 206uy; 61uy; 3uy; 1uy; 7uy] in
-      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
-      Rust_primitives.Hax.array_of_list 8 list)
+let impl = impl'
 
-let rsa_pkcs1_encryption_oid (_: Prims.unit) =
-  Core.Convert.f_into (let list = [42uy; 134uy; 72uy; 134uy; 247uy; 13uy; 1uy; 1uy; 1uy] in
-      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 9);
-      Rust_primitives.Hax.array_of_list 9 list)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core.Marker.t_Copy t_CertificateKey
 
-let x962_ec_public_key_oid (_: Prims.unit) =
-  Core.Convert.f_into (let list = [42uy; 134uy; 72uy; 206uy; 61uy; 2uy; 1uy] in
-      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 7);
-      Rust_primitives.Hax.array_of_list 7 list)
+let impl_1 = impl_1'
 
-let check_tag (b: Bertie.Tls13utils.t_Bytes) (offset: usize) (value: u8) =
-  if (Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) =. value
-  then Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
-  else asn1_error v_ASN1_INVALID_TAG
-
-let length_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  if ((Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) >>! 7l <: u8) =. 1uy
-  then cast ((Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) &. 127uy <: u8) <: usize
-  else sz 0
-
-let read_octet_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 4uy with
-  | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    let length_length:usize = length_length b offset in
-    let offset:usize = (offset +! length_length <: usize) +! sz 1 in
-    Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
-
-let read_sequence_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 48uy with
-  | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    let length_length:usize = length_length b offset in
-    let offset:usize = (offset +! length_length <: usize) +! sz 1 in
-    Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
-
-let short_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  if ((Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) &. 128uy <: u8) =. 0uy
-  then
-    Core.Result.Result_Ok
-    (cast ((Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) &. 127uy <: u8) <: usize)
-    <:
-    Core.Result.t_Result usize u8
-  else asn1_error v_ASN1_ERROR
-
-let read_version_number (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 160uy with
-  | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    (match short_length b offset with
-      | Core.Result.Result_Ok length ->
-        Core.Result.Result_Ok ((offset +! sz 1 <: usize) +! length) <: Core.Result.t_Result usize u8
-      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8)
-  | Core.Result.Result_Err _ -> Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
+let asn1_error (#v_T: Type0) (err: u8) = Core.Result.Result_Err err <: Core.Result.t_Result v_T u8
 
 let long_length (b: Bertie.Tls13utils.t_Bytes) (offset len: usize) =
-  if len >. sz 4
-  then asn1_error v_ASN1_SEQUENCE_TOO_LONG
+  if len >. mk_usize 4
+  then asn1_error #usize v_ASN1_SEQUENCE_TOO_LONG
   else
-    let u32word:t_Array u8 (sz 4) =
-      Rust_primitives.Hax.repeat (Bertie.Tls13utils.v_U8 0uy <: u8) (sz 4)
+    let u32word:t_Array u8 (mk_usize 4) =
+      Rust_primitives.Hax.repeat (Bertie.Tls13utils.v_U8 (mk_u8 0) <: u8) (mk_usize 4)
     in
-    let u32word:t_Array u8 (sz 4) =
+    let u32word:t_Array u8 (mk_usize 4) =
       Rust_primitives.Hax.Monomorphized_update_at.update_at_range u32word
-        ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = len }
+        ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = len }
           <:
           Core.Ops.Range.t_Range usize)
-        (Core.Slice.impl__copy_from_slice (u32word.[ {
-                  Core.Ops.Range.f_start = sz 0;
-                  Core.Ops.Range.f_end = len
-                }
+        (Core.Slice.impl__copy_from_slice #u8
+            (u32word.[ { Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = len }
                 <:
                 Core.Ops.Range.t_Range usize ]
               <:
@@ -101,29 +50,88 @@ let long_length (b: Bertie.Tls13utils.t_Bytes) (offset len: usize) =
           t_Slice u8)
     in
     Core.Result.Result_Ok
-    ((cast (Bertie.Tls13utils.f_declassify (Bertie.Tls13utils.u32_from_be_bytes u32word <: u32)
+    ((cast (Bertie.Tls13utils.f_declassify #u32
+              #u32
+              #FStar.Tactics.Typeclasses.solve
+              (Bertie.Tls13utils.u32_from_be_bytes u32word <: u32)
             <:
             u32)
         <:
         usize) >>!
-      ((sz 4 -! len <: usize) *! sz 8 <: usize))
+      ((mk_usize 4 -! len <: usize) *! mk_usize 8 <: usize))
     <:
     Core.Result.t_Result usize u8
 
-let length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  if ((Bertie.Tls13utils.f_declassify (b.[ offset ] <: u8) <: u8) &. 128uy <: u8) =. 0uy
+let length_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  if
+    ((Bertie.Tls13utils.f_declassify #u8 #u8 #FStar.Tactics.Typeclasses.solve (b.[ offset ] <: u8)
+        <:
+        u8) >>!
+      mk_i32 7
+      <:
+      u8) =.
+    mk_u8 1
   then
-    match short_length b offset with
+    cast ((Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (b.[ offset ] <: u8)
+          <:
+          u8) &.
+        mk_u8 127
+        <:
+        u8)
+    <:
+    usize
+  else mk_usize 0
+
+let short_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  if
+    ((Bertie.Tls13utils.f_declassify #u8 #u8 #FStar.Tactics.Typeclasses.solve (b.[ offset ] <: u8)
+        <:
+        u8) &.
+      mk_u8 128
+      <:
+      u8) =.
+    mk_u8 0
+  then
+    Core.Result.Result_Ok
+    (cast ((Bertie.Tls13utils.f_declassify #u8
+              #u8
+              #FStar.Tactics.Typeclasses.solve
+              (b.[ offset ] <: u8)
+            <:
+            u8) &.
+          mk_u8 127
+          <:
+          u8)
+      <:
+      usize)
+    <:
+    Core.Result.t_Result usize u8
+  else asn1_error #usize v_ASN1_ERROR
+
+let length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  if
+    ((Bertie.Tls13utils.f_declassify #u8 #u8 #FStar.Tactics.Typeclasses.solve (b.[ offset ] <: u8)
+        <:
+        u8) &.
+      mk_u8 128
+      <:
+      u8) =.
+    mk_u8 0
+  then
+    match short_length b offset <: Core.Result.t_Result usize u8 with
     | Core.Result.Result_Ok len ->
-      Core.Result.Result_Ok (offset +! sz 1, len <: (usize & usize))
+      Core.Result.Result_Ok (offset +! mk_usize 1, len <: (usize & usize))
       <:
       Core.Result.t_Result (usize & usize) u8
     | Core.Result.Result_Err err ->
       Core.Result.Result_Err err <: Core.Result.t_Result (usize & usize) u8
   else
     let len:usize = length_length b offset in
-    let offset:usize = offset +! sz 1 in
-    match long_length b offset len with
+    let offset:usize = offset +! mk_usize 1 in
+    match long_length b offset len <: Core.Result.t_Result usize u8 with
     | Core.Result.Result_Ok v_end ->
       Core.Result.Result_Ok (offset +! len, v_end <: (usize & usize))
       <:
@@ -131,287 +139,452 @@ let length (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
     | Core.Result.Result_Err err ->
       Core.Result.Result_Err err <: Core.Result.t_Result (usize & usize) u8
 
-let skip_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 2uy with
+let check_tag (b: Bertie.Tls13utils.t_Bytes) (offset: usize) (value: u8) =
+  if
+    (Bertie.Tls13utils.f_declassify #u8 #u8 #FStar.Tactics.Typeclasses.solve (b.[ offset ] <: u8)
+      <:
+      u8) =.
+    value
+  then Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
+  else asn1_error #Prims.unit v_ASN1_INVALID_TAG
+
+let read_sequence_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  match check_tag b offset (mk_u8 48) <: Core.Result.t_Result Prims.unit u8 with
   | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    (match length b offset with
-      | Core.Result.Result_Ok (offset, length) ->
-        Core.Result.Result_Ok (offset +! length) <: Core.Result.t_Result usize u8
-      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8)
+    let offset:usize = offset +! mk_usize 1 in
+    let length_length:usize = length_length b offset in
+    let offset:usize = (offset +! length_length <: usize) +! mk_usize 1 in
+    Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
+
+let read_octet_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  match check_tag b offset (mk_u8 4) <: Core.Result.t_Result Prims.unit u8 with
+  | Core.Result.Result_Ok _ ->
+    let offset:usize = offset +! mk_usize 1 in
+    let length_length:usize = length_length b offset in
+    let offset:usize = (offset +! length_length <: usize) +! mk_usize 1 in
+    Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
 
 let skip_sequence (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 48uy with
+  match check_tag b offset (mk_u8 48) <: Core.Result.t_Result Prims.unit u8 with
   | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    (match length b offset with
+    let offset:usize = offset +! mk_usize 1 in
+    (match length b offset <: Core.Result.t_Result (usize & usize) u8 with
       | Core.Result.Result_Ok (offset, length) ->
         Core.Result.Result_Ok (offset +! length) <: Core.Result.t_Result usize u8
       | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8)
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
 
+let read_version_number (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  match check_tag b offset (mk_u8 160) <: Core.Result.t_Result Prims.unit u8 with
+  | Core.Result.Result_Ok _ ->
+    let offset:usize = offset +! mk_usize 1 in
+    (match short_length b offset <: Core.Result.t_Result usize u8 with
+      | Core.Result.Result_Ok length ->
+        Core.Result.Result_Ok ((offset +! mk_usize 1 <: usize) +! length)
+        <:
+        Core.Result.t_Result usize u8
+      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8)
+  | Core.Result.Result_Err _ -> Core.Result.Result_Ok offset <: Core.Result.t_Result usize u8
+
+let skip_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  match check_tag b offset (mk_u8 2) <: Core.Result.t_Result Prims.unit u8 with
+  | Core.Result.Result_Ok _ ->
+    let offset:usize = offset +! mk_usize 1 in
+    (match length b offset <: Core.Result.t_Result (usize & usize) u8 with
+      | Core.Result.Result_Ok (offset, length) ->
+        Core.Result.Result_Ok (offset +! length) <: Core.Result.t_Result usize u8
+      | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result usize u8
+
+let read_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
+  match check_tag b offset (mk_u8 2) <: Core.Result.t_Result Prims.unit u8 with
+  | Core.Result.Result_Ok _ ->
+    let offset:usize = offset +! mk_usize 1 in
+    (match length b offset <: Core.Result.t_Result (usize & usize) u8 with
+      | Core.Result.Result_Ok (offset, length) ->
+        Core.Result.Result_Ok (Bertie.Tls13utils.impl_Bytes__slice b offset length)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let x962_ec_public_key_oid (_: Prims.unit) =
+  Core.Convert.f_into #(t_Array u8 (mk_usize 7))
+    #Bertie.Tls13utils.t_Bytes
+    #FStar.Tactics.Typeclasses.solve
+    (let list = [mk_u8 42; mk_u8 134; mk_u8 72; mk_u8 206; mk_u8 61; mk_u8 2; mk_u8 1] in
+      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 7);
+      Rust_primitives.Hax.array_of_list 7 list)
+
+let ecdsa_secp256r1_sha256_oid (_: Prims.unit) =
+  Core.Convert.f_into #(t_Array u8 (mk_usize 8))
+    #Bertie.Tls13utils.t_Bytes
+    #FStar.Tactics.Typeclasses.solve
+    (let list = [mk_u8 42; mk_u8 134; mk_u8 72; mk_u8 206; mk_u8 61; mk_u8 3; mk_u8 1; mk_u8 7] in
+      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
+      Rust_primitives.Hax.array_of_list 8 list)
+
+let rsa_pkcs1_encryption_oid (_: Prims.unit) =
+  Core.Convert.f_into #(t_Array u8 (mk_usize 9))
+    #Bertie.Tls13utils.t_Bytes
+    #FStar.Tactics.Typeclasses.solve
+    (let list =
+        [mk_u8 42; mk_u8 134; mk_u8 72; mk_u8 134; mk_u8 247; mk_u8 13; mk_u8 1; mk_u8 1; mk_u8 1]
+      in
+      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 9);
+      Rust_primitives.Hax.array_of_list 9 list)
+
+let check_success (v_val: bool) =
+  if v_val
+  then Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
+  else asn1_error #Prims.unit v_ASN1_ERROR
+
 let read_spki (cert: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  Rust_primitives.Hax.Control_flow_monad.Mexception.run (match
-        check_tag cert offset 48uy <: Core.Result.t_Result Prims.unit u8
-      with
-      | Core.Result.Result_Ok _ ->
-        let offset:usize = offset +! sz 1 in
-        (match length cert offset with
-          | Core.Result.Result_Ok (offset, v__seq_len) ->
-            (match check_tag cert offset 48uy with
-              | Core.Result.Result_Ok _ ->
-                let offset:usize = offset +! sz 1 in
-                (match length cert offset with
-                  | Core.Result.Result_Ok (offset, seq_len) ->
-                    (match check_tag cert offset 6uy with
-                      | Core.Result.Result_Ok _ ->
-                        (match length cert (offset +! sz 1 <: usize) with
-                          | Core.Result.Result_Ok (oid_offset, oid_len) ->
-                            let ec_pk_oid, ecdsa_p256, rsa_pk_oid:(bool & bool & bool) =
-                              false, false, false <: (bool & bool & bool)
-                            in
-                            let ec_oid:Bertie.Tls13utils.t_Bytes = x962_ec_public_key_oid () in
-                            let rsa_oid:Bertie.Tls13utils.t_Bytes = rsa_pkcs1_encryption_oid () in
-                            let! ec_pk_oid, ecdsa_p256, oid_offset:(bool & bool & usize) =
-                              if (Bertie.Tls13utils.impl__Bytes__len ec_oid <: usize) =. oid_len
-                              then
-                                let ec_pk_oid:bool = true in
-                                let ec_pk_oid:bool =
-                                  Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter
-                                        ({
-                                            Core.Ops.Range.f_start = sz 0;
-                                            Core.Ops.Range.f_end
-                                            =
-                                            Bertie.Tls13utils.impl__Bytes__len ec_oid <: usize
-                                          }
-                                          <:
-                                          Core.Ops.Range.t_Range usize)
+  match check_tag cert offset (mk_u8 48) <: Core.Result.t_Result Prims.unit u8 with
+  | Core.Result.Result_Ok _ ->
+    let offset:usize = offset +! mk_usize 1 in
+    (match length cert offset <: Core.Result.t_Result (usize & usize) u8 with
+      | Core.Result.Result_Ok (offset, e_seq_len) ->
+        (match check_tag cert offset (mk_u8 48) <: Core.Result.t_Result Prims.unit u8 with
+          | Core.Result.Result_Ok _ ->
+            let offset:usize = offset +! mk_usize 1 in
+            (match length cert offset <: Core.Result.t_Result (usize & usize) u8 with
+              | Core.Result.Result_Ok (offset, seq_len) ->
+                (match check_tag cert offset (mk_u8 6) <: Core.Result.t_Result Prims.unit u8 with
+                  | Core.Result.Result_Ok _ ->
+                    (match
+                        length cert (offset +! mk_usize 1 <: usize)
+                        <:
+                        Core.Result.t_Result (usize & usize) u8
+                      with
+                      | Core.Result.Result_Ok (oid_offset, oid_len) ->
+                        let ec_pk_oid, ecdsa_p256, rsa_pk_oid:(bool & bool & bool) =
+                          false, false, false <: (bool & bool & bool)
+                        in
+                        let ec_oid:Bertie.Tls13utils.t_Bytes = x962_ec_public_key_oid () in
+                        let rsa_oid:Bertie.Tls13utils.t_Bytes = rsa_pkcs1_encryption_oid () in
+                        if (Bertie.Tls13utils.impl_Bytes__len ec_oid <: usize) =. oid_len
+                        then
+                          let ec_pk_oid:bool = true in
+                          let ec_pk_oid:bool =
+                            Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+                              (Bertie.Tls13utils.impl_Bytes__len ec_oid <: usize)
+                              (fun ec_pk_oid temp_1_ ->
+                                  let ec_pk_oid:bool = ec_pk_oid in
+                                  let _:usize = temp_1_ in
+                                  true)
+                              ec_pk_oid
+                              (fun ec_pk_oid i ->
+                                  let ec_pk_oid:bool = ec_pk_oid in
+                                  let i:usize = i in
+                                  let oid_byte_equal:bool =
+                                    (Bertie.Tls13utils.f_declassify #u8
+                                        #u8
+                                        #FStar.Tactics.Typeclasses.solve
+                                        (cert.[ oid_offset +! i <: usize ] <: u8)
                                       <:
-                                      Core.Ops.Range.t_Range usize)
-                                    ec_pk_oid
-                                    (fun ec_pk_oid i ->
-                                        let ec_pk_oid:bool = ec_pk_oid in
-                                        let i:usize = i in
-                                        let oid_byte_equal:bool =
-                                          (Bertie.Tls13utils.f_declassify (cert.[ oid_offset +! i
-                                                  <:
-                                                  usize ]
-                                                <:
-                                                u8)
-                                            <:
-                                            u8) =.
-                                          (Bertie.Tls13utils.f_declassify (ec_oid.[ i ] <: u8) <: u8
-                                          )
-                                        in
-                                        let ec_pk_oid:bool = ec_pk_oid && oid_byte_equal in
-                                        ec_pk_oid)
-                                in
-                                if ec_pk_oid
-                                then
-                                  let oid_offset:usize = oid_offset +! oid_len in
-                                  match check_tag cert oid_offset 6uy with
-                                  | Core.Result.Result_Ok _ ->
-                                    let oid_offset:usize = oid_offset +! sz 1 in
-                                    (match length cert oid_offset with
-                                      | Core.Result.Result_Ok (oid_offset, v__oid_len) ->
-                                        let ecdsa_p256:bool = true in
-                                        let ec_oid:Bertie.Tls13utils.t_Bytes =
-                                          ecdsa_secp256r1_sha256_oid ()
-                                        in
-                                        let ecdsa_p256:bool =
-                                          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter
-                                                ({
-                                                    Core.Ops.Range.f_start = sz 0;
-                                                    Core.Ops.Range.f_end
-                                                    =
-                                                    Bertie.Tls13utils.impl__Bytes__len ec_oid
-                                                    <:
-                                                    usize
-                                                  }
-                                                  <:
-                                                  Core.Ops.Range.t_Range usize)
+                                      u8) =.
+                                    (Bertie.Tls13utils.f_declassify #u8
+                                        #u8
+                                        #FStar.Tactics.Typeclasses.solve
+                                        (ec_oid.[ i ] <: u8)
+                                      <:
+                                      u8)
+                                  in
+                                  let ec_pk_oid:bool = ec_pk_oid && oid_byte_equal in
+                                  ec_pk_oid)
+                          in
+                          if ec_pk_oid
+                          then
+                            let oid_offset:usize = oid_offset +! oid_len in
+                            match
+                              check_tag cert oid_offset (mk_u8 6)
+                              <:
+                              Core.Result.t_Result Prims.unit u8
+                            with
+                            | Core.Result.Result_Ok _ ->
+                              let oid_offset:usize = oid_offset +! mk_usize 1 in
+                              (match
+                                  length cert oid_offset <: Core.Result.t_Result (usize & usize) u8
+                                with
+                                | Core.Result.Result_Ok (oid_offset, e_oid_len) ->
+                                  let ecdsa_p256:bool = true in
+                                  let ec_oid:Bertie.Tls13utils.t_Bytes =
+                                    ecdsa_secp256r1_sha256_oid ()
+                                  in
+                                  let ecdsa_p256:bool =
+                                    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+                                      (Bertie.Tls13utils.impl_Bytes__len ec_oid <: usize)
+                                      (fun ecdsa_p256 temp_1_ ->
+                                          let ecdsa_p256:bool = ecdsa_p256 in
+                                          let _:usize = temp_1_ in
+                                          true)
+                                      ecdsa_p256
+                                      (fun ecdsa_p256 i ->
+                                          let ecdsa_p256:bool = ecdsa_p256 in
+                                          let i:usize = i in
+                                          let oid_byte_equal:bool =
+                                            (Bertie.Tls13utils.f_declassify #u8
+                                                #u8
+                                                #FStar.Tactics.Typeclasses.solve
+                                                (cert.[ oid_offset +! i <: usize ] <: u8)
                                               <:
-                                              Core.Ops.Range.t_Range usize)
-                                            ecdsa_p256
-                                            (fun ecdsa_p256 i ->
-                                                let ecdsa_p256:bool = ecdsa_p256 in
+                                              u8) =.
+                                            (Bertie.Tls13utils.f_declassify #u8
+                                                #u8
+                                                #FStar.Tactics.Typeclasses.solve
+                                                (ec_oid.[ i ] <: u8)
+                                              <:
+                                              u8)
+                                          in
+                                          let ecdsa_p256:bool = ecdsa_p256 && oid_byte_equal in
+                                          ecdsa_p256)
+                                  in
+                                  (match
+                                      check_success ecdsa_p256 <: Core.Result.t_Result Prims.unit u8
+                                    with
+                                    | Core.Result.Result_Ok _ ->
+                                      let ec_pk_oid, ecdsa_p256, oid_offset:(bool & bool & usize) =
+                                        ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize)
+                                      in
+                                      let rsa_pk_oid:bool =
+                                        if
+                                          (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize) =.
+                                          oid_len
+                                        then
+                                          let rsa_pk_oid:bool = true in
+                                          Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+                                            (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize)
+                                            (fun rsa_pk_oid temp_1_ ->
+                                                let rsa_pk_oid:bool = rsa_pk_oid in
+                                                let _:usize = temp_1_ in
+                                                true)
+                                            rsa_pk_oid
+                                            (fun rsa_pk_oid i ->
+                                                let rsa_pk_oid:bool = rsa_pk_oid in
                                                 let i:usize = i in
                                                 let oid_byte_equal:bool =
-                                                  (Bertie.Tls13utils.f_declassify (cert.[ oid_offset +!
-                                                          i
-                                                          <:
-                                                          usize ]
-                                                        <:
-                                                        u8)
+                                                  (Bertie.Tls13utils.f_declassify #u8
+                                                      #u8
+                                                      #FStar.Tactics.Typeclasses.solve
+                                                      (cert.[ oid_offset +! i <: usize ] <: u8)
                                                     <:
                                                     u8) =.
-                                                  (Bertie.Tls13utils.f_declassify (ec_oid.[ i ]
-                                                        <:
-                                                        u8)
+                                                  (Bertie.Tls13utils.f_declassify #u8
+                                                      #u8
+                                                      #FStar.Tactics.Typeclasses.solve
+                                                      (rsa_oid.[ i ] <: u8)
                                                     <:
                                                     u8)
                                                 in
-                                                let ecdsa_p256:bool =
-                                                  ecdsa_p256 && oid_byte_equal
+                                                let rsa_pk_oid:bool =
+                                                  rsa_pk_oid && oid_byte_equal
                                                 in
-                                                ecdsa_p256)
-                                        in
-                                        (match check_success ecdsa_p256 with
-                                          | Core.Result.Result_Ok _ ->
-                                            Core.Ops.Control_flow.ControlFlow_Continue
-                                            (ec_pk_oid, ecdsa_p256, oid_offset
-                                              <:
-                                              (bool & bool & usize))
-                                            <:
-                                            Core.Ops.Control_flow.t_ControlFlow
-                                              (Core.Result.t_Result
-                                                  (Bertie.Tls13crypto.t_SignatureScheme &
-                                                    t_CertificateKey) u8) (bool & bool & usize)
-                                          | Core.Result.Result_Err err ->
-                                            let! _:Prims.unit =
-                                              Core.Ops.Control_flow.ControlFlow_Break
-                                              (Core.Result.Result_Err err
-                                                <:
-                                                Core.Result.t_Result
-                                                  (Bertie.Tls13crypto.t_SignatureScheme &
-                                                    t_CertificateKey) u8)
-                                              <:
-                                              Core.Ops.Control_flow.t_ControlFlow
-                                                (Core.Result.t_Result
-                                                    (Bertie.Tls13crypto.t_SignatureScheme &
-                                                      t_CertificateKey) u8) Prims.unit
-                                            in
-                                            Core.Ops.Control_flow.ControlFlow_Continue
-                                            (ec_pk_oid, ecdsa_p256, oid_offset
-                                              <:
-                                              (bool & bool & usize))
-                                            <:
-                                            Core.Ops.Control_flow.t_ControlFlow
-                                              (Core.Result.t_Result
-                                                  (Bertie.Tls13crypto.t_SignatureScheme &
-                                                    t_CertificateKey) u8) (bool & bool & usize))
-                                      | Core.Result.Result_Err err ->
-                                        let! _:Prims.unit =
-                                          Core.Ops.Control_flow.ControlFlow_Break
-                                          (Core.Result.Result_Err err
-                                            <:
-                                            Core.Result.t_Result
-                                              (Bertie.Tls13crypto.t_SignatureScheme &
-                                                t_CertificateKey) u8)
+                                                rsa_pk_oid)
+                                        else rsa_pk_oid
+                                      in
+                                      (match
+                                          check_success (ec_pk_oid && ecdsa_p256 || rsa_pk_oid)
                                           <:
-                                          Core.Ops.Control_flow.t_ControlFlow
-                                            (Core.Result.t_Result
+                                          Core.Result.t_Result Prims.unit u8
+                                        with
+                                        | Core.Result.Result_Ok _ ->
+                                          let offset:usize = offset +! seq_len in
+                                          (match
+                                              check_tag cert offset (mk_u8 3)
+                                              <:
+                                              Core.Result.t_Result Prims.unit u8
+                                            with
+                                            | Core.Result.Result_Ok _ ->
+                                              let offset:usize = offset +! mk_usize 1 in
+                                              (match
+                                                  length cert offset
+                                                  <:
+                                                  Core.Result.t_Result (usize & usize) u8
+                                                with
+                                                | Core.Result.Result_Ok (offset, bit_string_len) ->
+                                                  let offset:usize =
+                                                    if
+                                                      (Bertie.Tls13utils.f_declassify #u8
+                                                          #u8
+                                                          #FStar.Tactics.Typeclasses.solve
+                                                          (cert.[ offset ] <: u8)
+                                                        <:
+                                                        u8) =.
+                                                      mk_u8 0
+                                                    then
+                                                      let offset:usize = offset +! mk_usize 1 in
+                                                      offset
+                                                    else offset
+                                                  in
+                                                  if ec_pk_oid && ecdsa_p256
+                                                  then
+                                                    Core.Result.Result_Ok
+                                                    ((Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256
+                                                        <:
+                                                        Bertie.Tls13crypto.t_SignatureScheme),
+                                                      (CertificateKey offset
+                                                          (bit_string_len -! mk_usize 1)
+                                                        <:
+                                                        t_CertificateKey)
+                                                      <:
+                                                      (Bertie.Tls13crypto.t_SignatureScheme &
+                                                        t_CertificateKey))
+                                                    <:
+                                                    Core.Result.t_Result
+                                                      (Bertie.Tls13crypto.t_SignatureScheme &
+                                                        t_CertificateKey) u8
+                                                  else
+                                                    if rsa_pk_oid
+                                                    then
+                                                      Core.Result.Result_Ok
+                                                      ((Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256
+                                                          <:
+                                                          Bertie.Tls13crypto.t_SignatureScheme),
+                                                        (CertificateKey offset
+                                                            (bit_string_len -! mk_usize 1)
+                                                          <:
+                                                          t_CertificateKey)
+                                                        <:
+                                                        (Bertie.Tls13crypto.t_SignatureScheme &
+                                                          t_CertificateKey))
+                                                      <:
+                                                      Core.Result.t_Result
+                                                        (Bertie.Tls13crypto.t_SignatureScheme &
+                                                          t_CertificateKey) u8
+                                                    else
+                                                      asn1_error #(Bertie.Tls13crypto.t_SignatureScheme &
+                                                          t_CertificateKey)
+                                                        v_ASN1_INVALID_CERTIFICATE
+                                                | Core.Result.Result_Err err ->
+                                                  Core.Result.Result_Err err
+                                                  <:
+                                                  Core.Result.t_Result
+                                                    (Bertie.Tls13crypto.t_SignatureScheme &
+                                                      t_CertificateKey) u8)
+                                            | Core.Result.Result_Err err ->
+                                              Core.Result.Result_Err err
+                                              <:
+                                              Core.Result.t_Result
                                                 (Bertie.Tls13crypto.t_SignatureScheme &
-                                                  t_CertificateKey) u8) Prims.unit
-                                        in
-                                        Core.Ops.Control_flow.ControlFlow_Continue
-                                        (ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize))
-                                        <:
-                                        Core.Ops.Control_flow.t_ControlFlow
-                                          (Core.Result.t_Result
-                                              (Bertie.Tls13crypto.t_SignatureScheme &
-                                                t_CertificateKey) u8) (bool & bool & usize))
-                                  | Core.Result.Result_Err err ->
-                                    let! _:Prims.unit =
-                                      Core.Ops.Control_flow.ControlFlow_Break
-                                      (Core.Result.Result_Err err
+                                                  t_CertificateKey) u8)
+                                        | Core.Result.Result_Err err ->
+                                          Core.Result.Result_Err err
+                                          <:
+                                          Core.Result.t_Result
+                                            (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey
+                                            ) u8)
+                                    | Core.Result.Result_Err err ->
+                                      Core.Result.Result_Err err
+                                      <:
+                                      Core.Result.t_Result
+                                        (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
+                                  )
+                                | Core.Result.Result_Err err ->
+                                  Core.Result.Result_Err err
+                                  <:
+                                  Core.Result.t_Result
+                                    (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+                            | Core.Result.Result_Err err ->
+                              Core.Result.Result_Err err
+                              <:
+                              Core.Result.t_Result
+                                (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
+                          else
+                            let ec_pk_oid, ecdsa_p256, oid_offset:(bool & bool & usize) =
+                              ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize)
+                            in
+                            let rsa_pk_oid:bool =
+                              if (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize) =. oid_len
+                              then
+                                let rsa_pk_oid:bool = true in
+                                Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+                                  (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize)
+                                  (fun rsa_pk_oid temp_1_ ->
+                                      let rsa_pk_oid:bool = rsa_pk_oid in
+                                      let _:usize = temp_1_ in
+                                      true)
+                                  rsa_pk_oid
+                                  (fun rsa_pk_oid i ->
+                                      let rsa_pk_oid:bool = rsa_pk_oid in
+                                      let i:usize = i in
+                                      let oid_byte_equal:bool =
+                                        (Bertie.Tls13utils.f_declassify #u8
+                                            #u8
+                                            #FStar.Tactics.Typeclasses.solve
+                                            (cert.[ oid_offset +! i <: usize ] <: u8)
+                                          <:
+                                          u8) =.
+                                        (Bertie.Tls13utils.f_declassify #u8
+                                            #u8
+                                            #FStar.Tactics.Typeclasses.solve
+                                            (rsa_oid.[ i ] <: u8)
+                                          <:
+                                          u8)
+                                      in
+                                      let rsa_pk_oid:bool = rsa_pk_oid && oid_byte_equal in
+                                      rsa_pk_oid)
+                              else rsa_pk_oid
+                            in
+                            match
+                              check_success (ec_pk_oid && ecdsa_p256 || rsa_pk_oid)
+                              <:
+                              Core.Result.t_Result Prims.unit u8
+                            with
+                            | Core.Result.Result_Ok _ ->
+                              let offset:usize = offset +! seq_len in
+                              (match
+                                  check_tag cert offset (mk_u8 3)
+                                  <:
+                                  Core.Result.t_Result Prims.unit u8
+                                with
+                                | Core.Result.Result_Ok _ ->
+                                  let offset:usize = offset +! mk_usize 1 in
+                                  (match
+                                      length cert offset <: Core.Result.t_Result (usize & usize) u8
+                                    with
+                                    | Core.Result.Result_Ok (offset, bit_string_len) ->
+                                      let offset:usize =
+                                        if
+                                          (Bertie.Tls13utils.f_declassify #u8
+                                              #u8
+                                              #FStar.Tactics.Typeclasses.solve
+                                              (cert.[ offset ] <: u8)
+                                            <:
+                                            u8) =.
+                                          mk_u8 0
+                                        then
+                                          let offset:usize = offset +! mk_usize 1 in
+                                          offset
+                                        else offset
+                                      in
+                                      if ec_pk_oid && ecdsa_p256
+                                      then
+                                        Core.Result.Result_Ok
+                                        ((Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256
+                                            <:
+                                            Bertie.Tls13crypto.t_SignatureScheme),
+                                          (CertificateKey offset (bit_string_len -! mk_usize 1)
+                                            <:
+                                            t_CertificateKey)
+                                          <:
+                                          (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey))
                                         <:
                                         Core.Result.t_Result
                                           (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
-                                          u8)
-                                      <:
-                                      Core.Ops.Control_flow.t_ControlFlow
-                                        (Core.Result.t_Result
-                                            (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey
-                                            ) u8) Prims.unit
-                                    in
-                                    Core.Ops.Control_flow.ControlFlow_Continue
-                                    (ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize))
-                                    <:
-                                    Core.Ops.Control_flow.t_ControlFlow
-                                      (Core.Result.t_Result
-                                          (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
-                                          u8) (bool & bool & usize)
-                                else
-                                  Core.Ops.Control_flow.ControlFlow_Continue
-                                  (ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize))
-                                  <:
-                                  Core.Ops.Control_flow.t_ControlFlow
-                                    (Core.Result.t_Result
-                                        (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
-                                    ) (bool & bool & usize)
-                              else
-                                Core.Ops.Control_flow.ControlFlow_Continue
-                                (ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize))
-                                <:
-                                Core.Ops.Control_flow.t_ControlFlow
-                                  (Core.Result.t_Result
-                                      (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                                  (bool & bool & usize)
-                            in
-                            Core.Ops.Control_flow.ControlFlow_Continue
-                            (let rsa_pk_oid:bool =
-                                if (Bertie.Tls13utils.impl__Bytes__len rsa_oid <: usize) =. oid_len
-                                then
-                                  let rsa_pk_oid:bool = true in
-                                  Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter
-                                        ({
-                                            Core.Ops.Range.f_start = sz 0;
-                                            Core.Ops.Range.f_end
-                                            =
-                                            Bertie.Tls13utils.impl__Bytes__len rsa_oid <: usize
-                                          }
-                                          <:
-                                          Core.Ops.Range.t_Range usize)
-                                      <:
-                                      Core.Ops.Range.t_Range usize)
-                                    rsa_pk_oid
-                                    (fun rsa_pk_oid i ->
-                                        let rsa_pk_oid:bool = rsa_pk_oid in
-                                        let i:usize = i in
-                                        let oid_byte_equal:bool =
-                                          (Bertie.Tls13utils.f_declassify (cert.[ oid_offset +! i
-                                                  <:
-                                                  usize ]
-                                                <:
-                                                u8)
-                                            <:
-                                            u8) =.
-                                          (Bertie.Tls13utils.f_declassify (rsa_oid.[ i ] <: u8)
-                                            <:
-                                            u8)
-                                        in
-                                        let rsa_pk_oid:bool = rsa_pk_oid && oid_byte_equal in
-                                        rsa_pk_oid)
-                                else rsa_pk_oid
-                              in
-                              match check_success (ec_pk_oid && ecdsa_p256 || rsa_pk_oid) with
-                              | Core.Result.Result_Ok _ ->
-                                let offset:usize = offset +! seq_len in
-                                (match check_tag cert offset 3uy with
-                                  | Core.Result.Result_Ok _ ->
-                                    let offset:usize = offset +! sz 1 in
-                                    (match length cert offset with
-                                      | Core.Result.Result_Ok (offset, bit_string_len) ->
-                                        let offset:usize =
-                                          if
-                                            (Bertie.Tls13utils.f_declassify (cert.[ offset ] <: u8)
-                                              <:
-                                              u8) =.
-                                            0uy
-                                          then
-                                            let offset:usize = offset +! sz 1 in
-                                            offset
-                                          else offset
-                                        in
-                                        if ec_pk_oid && ecdsa_p256
+                                          u8
+                                      else
+                                        if rsa_pk_oid
                                         then
                                           Core.Result.Result_Ok
-                                          ((Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256
+                                          ((Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256
                                               <:
                                               Bertie.Tls13crypto.t_SignatureScheme),
-                                            (CertificateKey offset (bit_string_len -! sz 1)
+                                            (CertificateKey offset (bit_string_len -! mk_usize 1)
                                               <:
                                               t_CertificateKey)
                                             <:
@@ -422,135 +595,196 @@ let read_spki (cert: Bertie.Tls13utils.t_Bytes) (offset: usize) =
                                             (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey
                                             ) u8
                                         else
-                                          if rsa_pk_oid
-                                          then
-                                            Core.Result.Result_Ok
-                                            ((Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256
-                                                <:
-                                                Bertie.Tls13crypto.t_SignatureScheme),
-                                              (CertificateKey offset (bit_string_len -! sz 1)
-                                                <:
-                                                t_CertificateKey)
-                                              <:
-                                              (Bertie.Tls13crypto.t_SignatureScheme &
-                                                t_CertificateKey))
+                                          asn1_error #(Bertie.Tls13crypto.t_SignatureScheme &
+                                              t_CertificateKey)
+                                            v_ASN1_INVALID_CERTIFICATE
+                                    | Core.Result.Result_Err err ->
+                                      Core.Result.Result_Err err
+                                      <:
+                                      Core.Result.t_Result
+                                        (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
+                                  )
+                                | Core.Result.Result_Err err ->
+                                  Core.Result.Result_Err err
+                                  <:
+                                  Core.Result.t_Result
+                                    (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+                            | Core.Result.Result_Err err ->
+                              Core.Result.Result_Err err
+                              <:
+                              Core.Result.t_Result
+                                (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
+                        else
+                          let ec_pk_oid, ecdsa_p256, oid_offset:(bool & bool & usize) =
+                            ec_pk_oid, ecdsa_p256, oid_offset <: (bool & bool & usize)
+                          in
+                          let rsa_pk_oid:bool =
+                            if (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize) =. oid_len
+                            then
+                              let rsa_pk_oid:bool = true in
+                              Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+                                (Bertie.Tls13utils.impl_Bytes__len rsa_oid <: usize)
+                                (fun rsa_pk_oid temp_1_ ->
+                                    let rsa_pk_oid:bool = rsa_pk_oid in
+                                    let _:usize = temp_1_ in
+                                    true)
+                                rsa_pk_oid
+                                (fun rsa_pk_oid i ->
+                                    let rsa_pk_oid:bool = rsa_pk_oid in
+                                    let i:usize = i in
+                                    let oid_byte_equal:bool =
+                                      (Bertie.Tls13utils.f_declassify #u8
+                                          #u8
+                                          #FStar.Tactics.Typeclasses.solve
+                                          (cert.[ oid_offset +! i <: usize ] <: u8)
+                                        <:
+                                        u8) =.
+                                      (Bertie.Tls13utils.f_declassify #u8
+                                          #u8
+                                          #FStar.Tactics.Typeclasses.solve
+                                          (rsa_oid.[ i ] <: u8)
+                                        <:
+                                        u8)
+                                    in
+                                    let rsa_pk_oid:bool = rsa_pk_oid && oid_byte_equal in
+                                    rsa_pk_oid)
+                            else rsa_pk_oid
+                          in
+                          (match
+                              check_success (ec_pk_oid && ecdsa_p256 || rsa_pk_oid)
+                              <:
+                              Core.Result.t_Result Prims.unit u8
+                            with
+                            | Core.Result.Result_Ok _ ->
+                              let offset:usize = offset +! seq_len in
+                              (match
+                                  check_tag cert offset (mk_u8 3)
+                                  <:
+                                  Core.Result.t_Result Prims.unit u8
+                                with
+                                | Core.Result.Result_Ok _ ->
+                                  let offset:usize = offset +! mk_usize 1 in
+                                  (match
+                                      length cert offset <: Core.Result.t_Result (usize & usize) u8
+                                    with
+                                    | Core.Result.Result_Ok (offset, bit_string_len) ->
+                                      let offset:usize =
+                                        if
+                                          (Bertie.Tls13utils.f_declassify #u8
+                                              #u8
+                                              #FStar.Tactics.Typeclasses.solve
+                                              (cert.[ offset ] <: u8)
                                             <:
-                                            Core.Result.t_Result
-                                              (Bertie.Tls13crypto.t_SignatureScheme &
-                                                t_CertificateKey) u8
-                                          else asn1_error v_ASN1_INVALID_CERTIFICATE
-                                      | Core.Result.Result_Err err ->
-                                        Core.Result.Result_Err err
+                                            u8) =.
+                                          mk_u8 0
+                                        then
+                                          let offset:usize = offset +! mk_usize 1 in
+                                          offset
+                                        else offset
+                                      in
+                                      if ec_pk_oid && ecdsa_p256
+                                      then
+                                        Core.Result.Result_Ok
+                                        ((Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256
+                                            <:
+                                            Bertie.Tls13crypto.t_SignatureScheme),
+                                          (CertificateKey offset (bit_string_len -! mk_usize 1)
+                                            <:
+                                            t_CertificateKey)
+                                          <:
+                                          (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey))
                                         <:
                                         Core.Result.t_Result
                                           (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
-                                          u8)
-                                  | Core.Result.Result_Err err ->
-                                    Core.Result.Result_Err err
-                                    <:
-                                    Core.Result.t_Result
-                                      (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                              | Core.Result.Result_Err err ->
-                                Core.Result.Result_Err err
-                                <:
-                                Core.Result.t_Result
-                                  (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                            <:
-                            Core.Ops.Control_flow.t_ControlFlow
-                              (Core.Result.t_Result
-                                  (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                              (Core.Result.t_Result
-                                  (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                          | Core.Result.Result_Err err ->
-                            Core.Ops.Control_flow.ControlFlow_Continue
-                            (Core.Result.Result_Err err
+                                          u8
+                                      else
+                                        if rsa_pk_oid
+                                        then
+                                          Core.Result.Result_Ok
+                                          ((Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256
+                                              <:
+                                              Bertie.Tls13crypto.t_SignatureScheme),
+                                            (CertificateKey offset (bit_string_len -! mk_usize 1)
+                                              <:
+                                              t_CertificateKey)
+                                            <:
+                                            (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey
+                                            ))
+                                          <:
+                                          Core.Result.t_Result
+                                            (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey
+                                            ) u8
+                                        else
+                                          asn1_error #(Bertie.Tls13crypto.t_SignatureScheme &
+                                              t_CertificateKey)
+                                            v_ASN1_INVALID_CERTIFICATE
+                                    | Core.Result.Result_Err err ->
+                                      Core.Result.Result_Err err
+                                      <:
+                                      Core.Result.t_Result
+                                        (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
+                                  )
+                                | Core.Result.Result_Err err ->
+                                  Core.Result.Result_Err err
+                                  <:
+                                  Core.Result.t_Result
+                                    (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+                            | Core.Result.Result_Err err ->
+                              Core.Result.Result_Err err
                               <:
                               Core.Result.t_Result
                                 (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                            <:
-                            Core.Ops.Control_flow.t_ControlFlow
-                              (Core.Result.t_Result
-                                  (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                              (Core.Result.t_Result
-                                  (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8))
                       | Core.Result.Result_Err err ->
-                        Core.Ops.Control_flow.ControlFlow_Continue
-                        (Core.Result.Result_Err err
-                          <:
-                          Core.Result.t_Result
-                            (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+                        Core.Result.Result_Err err
                         <:
-                        Core.Ops.Control_flow.t_ControlFlow
-                          (Core.Result.t_Result
-                              (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                          (Core.Result.t_Result
-                              (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8))
-                  | Core.Result.Result_Err err ->
-                    Core.Ops.Control_flow.ControlFlow_Continue
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
-                        u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result
+                        Core.Result.t_Result
                           (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-                      (Core.Result.t_Result
-                          (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8))
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err
+                    <:
+                    Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
+                      u8)
               | Core.Result.Result_Err err ->
-                Core.Ops.Control_flow.ControlFlow_Continue
-                (Core.Result.Result_Err err
-                  <:
-                  Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+                Core.Result.Result_Err err
                 <:
-                Core.Ops.Control_flow.t_ControlFlow
-                  (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
-                  )
-                  (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
-                  ))
+                Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
           | Core.Result.Result_Err err ->
-            Core.Ops.Control_flow.ControlFlow_Continue
-            (Core.Result.Result_Err err
-              <:
-              Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+            Core.Result.Result_Err err
             <:
-            Core.Ops.Control_flow.t_ControlFlow
-              (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-              (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8))
+            Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
       | Core.Result.Result_Err err ->
-        Core.Ops.Control_flow.ControlFlow_Continue
-        (Core.Result.Result_Err err
-          <:
-          Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+        Core.Result.Result_Err err
         <:
-        Core.Ops.Control_flow.t_ControlFlow
-          (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
-          (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8))
+        Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8
 
 let verification_key_from_cert (cert: Bertie.Tls13utils.t_Bytes) =
-  match read_sequence_header cert (sz 0) with
+  match read_sequence_header cert (mk_usize 0) <: Core.Result.t_Result usize u8 with
   | Core.Result.Result_Ok offset ->
-    (match read_sequence_header cert offset with
-      | Core.Result.Result_Ok hoist30 ->
-        let offset:usize = hoist30 in
-        (match read_version_number cert offset with
-          | Core.Result.Result_Ok hoist31 ->
-            let offset:usize = hoist31 in
-            (match skip_integer cert offset with
-              | Core.Result.Result_Ok hoist32 ->
-                let offset:usize = hoist32 in
-                (match skip_sequence cert offset with
-                  | Core.Result.Result_Ok hoist33 ->
-                    let offset:usize = hoist33 in
-                    (match skip_sequence cert offset with
-                      | Core.Result.Result_Ok hoist34 ->
-                        let offset:usize = hoist34 in
-                        (match skip_sequence cert offset with
-                          | Core.Result.Result_Ok hoist35 ->
-                            let offset:usize = hoist35 in
-                            (match skip_sequence cert offset with
-                              | Core.Result.Result_Ok hoist36 ->
-                                let offset:usize = hoist36 in
+    (match read_sequence_header cert offset <: Core.Result.t_Result usize u8 with
+      | Core.Result.Result_Ok hoist107 ->
+        let offset:usize = hoist107 in
+        (match read_version_number cert offset <: Core.Result.t_Result usize u8 with
+          | Core.Result.Result_Ok hoist108 ->
+            let offset:usize = hoist108 in
+            (match skip_integer cert offset <: Core.Result.t_Result usize u8 with
+              | Core.Result.Result_Ok hoist109 ->
+                let offset:usize = hoist109 in
+                (match skip_sequence cert offset <: Core.Result.t_Result usize u8 with
+                  | Core.Result.Result_Ok hoist110 ->
+                    let offset:usize = hoist110 in
+                    (match skip_sequence cert offset <: Core.Result.t_Result usize u8 with
+                      | Core.Result.Result_Ok hoist111 ->
+                        let offset:usize = hoist111 in
+                        (match skip_sequence cert offset <: Core.Result.t_Result usize u8 with
+                          | Core.Result.Result_Ok hoist112 ->
+                            let offset:usize = hoist112 in
+                            (match skip_sequence cert offset <: Core.Result.t_Result usize u8 with
+                              | Core.Result.Result_Ok hoist113 ->
+                                let offset:usize = hoist113 in
                                 read_spki cert offset
                               | Core.Result.Result_Err err ->
                                 Core.Result.Result_Err err
@@ -591,100 +825,40 @@ let verification_key_from_cert (cert: Bertie.Tls13utils.t_Bytes) =
 
 let ecdsa_public_key (cert: Bertie.Tls13utils.t_Bytes) (indices: t_CertificateKey) =
   let CertificateKey offset len:t_CertificateKey = indices in
-  match check_tag cert offset 4uy with
+  match check_tag cert offset (mk_u8 4) <: Core.Result.t_Result Prims.unit u8 with
   | Core.Result.Result_Ok _ ->
     Core.Result.Result_Ok
-    (Bertie.Tls13utils.impl__Bytes__slice cert (offset +! sz 1 <: usize) (len -! sz 1 <: usize))
+    (Bertie.Tls13utils.impl_Bytes__slice cert
+        (offset +! mk_usize 1 <: usize)
+        (len -! mk_usize 1 <: usize))
     <:
     Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
-let read_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize) =
-  match check_tag b offset 2uy with
-  | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    (match length b offset with
-      | Core.Result.Result_Ok (offset, length) ->
-        Core.Result.Result_Ok (Bertie.Tls13utils.impl__Bytes__slice b offset length)
-        <:
-        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let rsa_private_key (key: Bertie.Tls13utils.t_Bytes) =
-  match read_sequence_header key (sz 0) with
-  | Core.Result.Result_Ok offset ->
-    (match skip_integer key offset with
-      | Core.Result.Result_Ok hoist41 ->
-        let offset:usize = hoist41 in
-        (match skip_sequence key offset with
-          | Core.Result.Result_Ok hoist42 ->
-            let offset:usize = hoist42 in
-            (match read_octet_header key offset with
-              | Core.Result.Result_Ok hoist43 ->
-                let offset:usize = hoist43 in
-                (match read_sequence_header key offset with
-                  | Core.Result.Result_Ok hoist44 ->
-                    let offset:usize = hoist44 in
-                    (match skip_integer key offset with
-                      | Core.Result.Result_Ok hoist45 ->
-                        let offset:usize = hoist45 in
-                        (match skip_integer key offset with
-                          | Core.Result.Result_Ok hoist46 ->
-                            let offset:usize = hoist46 in
-                            (match skip_integer key offset with
-                              | Core.Result.Result_Ok hoist47 ->
-                                let offset:usize = hoist47 in
-                                read_integer key offset
-                              | Core.Result.Result_Err err ->
-                                Core.Result.Result_Err err
-                                <:
-                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                          | Core.Result.Result_Err err ->
-                            Core.Result.Result_Err err
-                            <:
-                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                      | Core.Result.Result_Err err ->
-                        Core.Result.Result_Err err
-                        <:
-                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
 let rsa_public_key (cert: Bertie.Tls13utils.t_Bytes) (indices: t_CertificateKey) =
-  let CertificateKey offset v__len:t_CertificateKey = indices in
-  match check_tag cert offset 48uy with
+  let CertificateKey offset e_len:t_CertificateKey = indices in
+  match check_tag cert offset (mk_u8 48) <: Core.Result.t_Result Prims.unit u8 with
   | Core.Result.Result_Ok _ ->
-    let offset:usize = offset +! sz 1 in
-    (match length cert offset with
-      | Core.Result.Result_Ok (offset, v__seq_len) ->
-        (match check_tag cert offset 2uy with
+    let offset:usize = offset +! mk_usize 1 in
+    (match length cert offset <: Core.Result.t_Result (usize & usize) u8 with
+      | Core.Result.Result_Ok (offset, e_seq_len) ->
+        (match check_tag cert offset (mk_u8 2) <: Core.Result.t_Result Prims.unit u8 with
           | Core.Result.Result_Ok _ ->
-            let offset:usize = offset +! sz 1 in
-            (match length cert offset with
+            let offset:usize = offset +! mk_usize 1 in
+            (match length cert offset <: Core.Result.t_Result (usize & usize) u8 with
               | Core.Result.Result_Ok (offset, int_len) ->
                 let n:Bertie.Tls13utils.t_Bytes =
-                  Bertie.Tls13utils.impl__Bytes__slice cert offset int_len
+                  Bertie.Tls13utils.impl_Bytes__slice cert offset int_len
                 in
                 let offset:usize = offset +! int_len in
-                (match check_tag cert offset 2uy with
+                (match check_tag cert offset (mk_u8 2) <: Core.Result.t_Result Prims.unit u8 with
                   | Core.Result.Result_Ok _ ->
-                    let offset:usize = offset +! sz 1 in
-                    (match length cert offset with
+                    let offset:usize = offset +! mk_usize 1 in
+                    (match length cert offset <: Core.Result.t_Result (usize & usize) u8 with
                       | Core.Result.Result_Ok (offset, int_len) ->
                         let e:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__slice cert offset int_len
+                          Bertie.Tls13utils.impl_Bytes__slice cert offset int_len
                         in
                         Core.Result.Result_Ok
                         ({ Bertie.Tls13crypto.f_modulus = n; Bertie.Tls13crypto.f_exponent = e }
@@ -715,14 +889,65 @@ let rsa_public_key (cert: Bertie.Tls13utils.t_Bytes) (indices: t_CertificateKey)
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13crypto.t_RsaVerificationKey u8
 
+let rsa_private_key (key: Bertie.Tls13utils.t_Bytes) =
+  match read_sequence_header key (mk_usize 0) <: Core.Result.t_Result usize u8 with
+  | Core.Result.Result_Ok offset ->
+    (match skip_integer key offset <: Core.Result.t_Result usize u8 with
+      | Core.Result.Result_Ok hoist114 ->
+        let offset:usize = hoist114 in
+        (match skip_sequence key offset <: Core.Result.t_Result usize u8 with
+          | Core.Result.Result_Ok hoist115 ->
+            let offset:usize = hoist115 in
+            (match read_octet_header key offset <: Core.Result.t_Result usize u8 with
+              | Core.Result.Result_Ok hoist116 ->
+                let offset:usize = hoist116 in
+                (match read_sequence_header key offset <: Core.Result.t_Result usize u8 with
+                  | Core.Result.Result_Ok hoist117 ->
+                    let offset:usize = hoist117 in
+                    (match skip_integer key offset <: Core.Result.t_Result usize u8 with
+                      | Core.Result.Result_Ok hoist118 ->
+                        let offset:usize = hoist118 in
+                        (match skip_integer key offset <: Core.Result.t_Result usize u8 with
+                          | Core.Result.Result_Ok hoist119 ->
+                            let offset:usize = hoist119 in
+                            (match skip_integer key offset <: Core.Result.t_Result usize u8 with
+                              | Core.Result.Result_Ok hoist120 ->
+                                let offset:usize = hoist120 in
+                                read_integer key offset
+                              | Core.Result.Result_Err err ->
+                                Core.Result.Result_Err err
+                                <:
+                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                          | Core.Result.Result_Err err ->
+                            Core.Result.Result_Err err
+                            <:
+                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                      | Core.Result.Result_Err err ->
+                        Core.Result.Result_Err err
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
 let cert_public_key
       (certificate: Bertie.Tls13utils.t_Bytes)
       (spki: (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey))
      =
-  match spki._1 with
-  | Bertie.Tls13crypto.SignatureScheme_ED25519  -> asn1_error v_ASN1_UNSUPPORTED_ALGORITHM
+  match spki._1 <: Bertie.Tls13crypto.t_SignatureScheme with
+  | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
+    asn1_error #Bertie.Tls13crypto.t_PublicVerificationKey v_ASN1_UNSUPPORTED_ALGORITHM
   | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
-    (match ecdsa_public_key certificate spki._2 with
+    (match
+        ecdsa_public_key certificate spki._2 <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
       | Core.Result.Result_Ok pk ->
         Core.Result.Result_Ok
         (Bertie.Tls13crypto.PublicVerificationKey_EcDsa pk
@@ -735,7 +960,11 @@ let cert_public_key
         <:
         Core.Result.t_Result Bertie.Tls13crypto.t_PublicVerificationKey u8)
   | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
-    match rsa_public_key certificate spki._2 with
+    match
+      rsa_public_key certificate spki._2
+      <:
+      Core.Result.t_Result Bertie.Tls13crypto.t_RsaVerificationKey u8
+    with
     | Core.Result.Result_Ok pk ->
       Core.Result.Result_Ok
       (Bertie.Tls13crypto.PublicVerificationKey_Rsa pk <: Bertie.Tls13crypto.t_PublicVerificationKey

--- a/proofs/fstar/extraction/Bertie.Tls13cert.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13cert.fsti
@@ -3,29 +3,91 @@ module Bertie.Tls13cert
 open Core
 open FStar.Mul
 
-unfold
-let t_Asn1Error = u8
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
 
-let v_ASN1_ERROR: u8 = 25uy
-
-let v_ASN1_INVALID_CERTIFICATE: u8 = 23uy
-
-let v_ASN1_INVALID_TAG: u8 = 22uy
-
-let v_ASN1_SEQUENCE_TOO_LONG: u8 = 21uy
-
-let v_ASN1_UNSUPPORTED_ALGORITHM: u8 = 24uy
-
-val asn1_error (#v_T: Type) (err: u8)
-    : Prims.Pure (Core.Result.t_Result v_T u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_success (v_val: bool)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
+/// Certificate key start and length within the certificate DER.
 type t_CertificateKey = | CertificateKey : usize -> usize -> t_CertificateKey
 
-unfold
-let t_Spki = (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl:Core.Clone.t_Clone t_CertificateKey
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core.Marker.t_Copy t_CertificateKey
+
+let v_ASN1_SEQUENCE_TOO_LONG: u8 = mk_u8 21
+
+let v_ASN1_INVALID_TAG: u8 = mk_u8 22
+
+let v_ASN1_INVALID_CERTIFICATE: u8 = mk_u8 23
+
+let v_ASN1_UNSUPPORTED_ALGORITHM: u8 = mk_u8 24
+
+let v_ASN1_ERROR: u8 = mk_u8 25
+
+val asn1_error (#v_T: Type0) (err: u8)
+    : Prims.Pure (Core.Result.t_Result v_T u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val long_length (b: Bertie.Tls13utils.t_Bytes) (offset len: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val length_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val short_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the length of an ASN.1 type.
+/// This assumes that the length starts at the beginning of the provided byte
+/// sequence.
+/// Returns: (offset, length)
+val length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result (usize & usize) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check that the tag has a certain value.
+val check_tag (b: Bertie.Tls13utils.t_Bytes) (offset: usize) (value: u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Read a byte sequence header from the provided bytes.
+/// Returns the new offset into the bytes.
+val read_sequence_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Read an octet string from the provided bytes.
+/// Returns the new offset into the bytes.
+val read_octet_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Skip a sequence.
+/// XXX: Share code with [read_sequence_header].
+/// Returns the new offset into the bytes.
+val skip_sequence (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Read the version number.
+/// We don't really care, just check that it's some valid structure and keep the
+/// offset moving.
+/// Note that this might be missing. So we don't fail in here.
+val read_version_number (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Skip an integer.
+/// We don't really care, just check that it's some valid structure and keep the
+/// offset moving.
+val skip_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Read an integer and return a copy of the actual bytes.
+val read_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val x962_ec_public_key_oid: Prims.unit
+  -> Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
 val ecdsa_secp256r1_sha256_oid: Prims.unit
   -> Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
@@ -33,60 +95,26 @@ val ecdsa_secp256r1_sha256_oid: Prims.unit
 val rsa_pkcs1_encryption_oid: Prims.unit
   -> Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val x962_ec_public_key_oid: Prims.unit
-  -> Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val check_tag (b: Bertie.Tls13utils.t_Bytes) (offset: usize) (value: u8)
+val check_success (v_val: bool)
     : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val length_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
-
-val read_octet_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val read_sequence_header (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val short_length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val read_version_number (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val long_length (b: Bertie.Tls13utils.t_Bytes) (offset len: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val length (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result (usize & usize) u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val skip_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val skip_sequence (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
+/// Read the spki from the `cert`.
+/// Returns an error or the [`Spki`].
 val read_spki (cert: Bertie.Tls13utils.t_Bytes) (offset: usize)
     : Prims.Pure (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// Basic, but complete ASN.1 parser to read the public key from an X.509
+/// certificate.
+/// Returns the start offset within the `cert` bytes and length of the key.
 val verification_key_from_cert (cert: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// Read the EC PK from the cert as uncompressed point.
 val ecdsa_public_key (cert: Bertie.Tls13utils.t_Bytes) (indices: t_CertificateKey)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val read_integer (b: Bertie.Tls13utils.t_Bytes) (offset: usize)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val rsa_private_key (key: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
@@ -96,6 +124,28 @@ val rsa_public_key (cert: Bertie.Tls13utils.t_Bytes) (indices: t_CertificateKey)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// Read the private key (d) from an RSA private key.
+/// We expect to have the [version, privateKeyAlgorithm, privateKey] with
+/// RSAPrivateKey ::= SEQUENCE {
+///     version   Version,
+///     modulus   INTEGER,  -- n
+///     publicExponentINTEGER,  -- e
+///     privateExponent   INTEGER,  -- d
+///     prime1INTEGER,  -- p
+///     prime2INTEGER,  -- q
+///     exponent1 INTEGER,  -- d mod (p-1)
+///     exponent2 INTEGER,  -- d mod (q-1)
+///     coefficient   INTEGER,  -- (inverse of q) mod p
+///     otherPrimeInfos   OtherPrimeInfos OPTIONAL
+/// }
+val rsa_private_key (key: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Get the public key from from a certificate.
+/// On input of a `certificate` and `spki`, return a [`PublicVerificationKey`]
+/// if successful, or an [`Asn1Error`] otherwise.
 val cert_public_key
       (certificate: Bertie.Tls13utils.t_Bytes)
       (spki: (Bertie.Tls13crypto.t_SignatureScheme & t_CertificateKey))

--- a/proofs/fstar/extraction/Bertie.Tls13crypto.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13crypto.fsti
@@ -3,20 +3,35 @@ module Bertie.Tls13crypto
 open Core
 open FStar.Mul
 
-type t_AeadAlgorithm =
-  | AeadAlgorithm_Chacha20Poly1305 : t_AeadAlgorithm
-  | AeadAlgorithm_Aes128Gcm : t_AeadAlgorithm
-  | AeadAlgorithm_Aes256Gcm : t_AeadAlgorithm
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  let open Libcrux_ecdsa.P256.Conversions in
+  let open Libcrux_kem in
+  let open Libcrux_rsa.Impl_hacl in
+  let open Rand.Rng in
+  let open Rand_core in
+  ()
 
-val impl__AeadAlgorithm__iv_len (self: t_AeadAlgorithm)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+/// An RSA public key.
+type t_RsaVerificationKey = {
+  f_modulus:Bertie.Tls13utils.t_Bytes;
+  f_exponent:Bertie.Tls13utils.t_Bytes
+}
 
-val impl__AeadAlgorithm__key_len (self: t_AeadAlgorithm)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8:Core.Fmt.t_Debug t_RsaVerificationKey
 
-val t_AeadAlgorithm_cast_to_repr (x: t_AeadAlgorithm)
-    : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
+/// Bertie public verification keys.
+type t_PublicVerificationKey =
+  | PublicVerificationKey_EcDsa : Bertie.Tls13utils.t_Bytes -> t_PublicVerificationKey
+  | PublicVerificationKey_Rsa : t_RsaVerificationKey -> t_PublicVerificationKey
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9:Core.Fmt.t_Debug t_PublicVerificationKey
+
+/// Bertie hash algorithms.
 type t_HashAlgorithm =
   | HashAlgorithm_SHA256 : t_HashAlgorithm
   | HashAlgorithm_SHA384 : t_HashAlgorithm
@@ -25,16 +40,149 @@ type t_HashAlgorithm =
 val t_HashAlgorithm_cast_to_repr (x: t_HashAlgorithm)
     : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
 
-type t_KemScheme =
-  | KemScheme_X25519 : t_KemScheme
-  | KemScheme_Secp256r1 : t_KemScheme
-  | KemScheme_X448 : t_KemScheme
-  | KemScheme_Secp384r1 : t_KemScheme
-  | KemScheme_Secp521r1 : t_KemScheme
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10:Core.Clone.t_Clone t_HashAlgorithm
 
-val t_KemScheme_cast_to_repr (x: t_KemScheme)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_11:Core.Marker.t_Copy t_HashAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_12:Core.Marker.t_StructuralPartialEq t_HashAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_13:Core.Cmp.t_PartialEq t_HashAlgorithm t_HashAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core.Fmt.t_Debug t_HashAlgorithm
+
+/// Get the libcrux hash algorithm
+val impl_HashAlgorithm__libcrux_algorithm (self: t_HashAlgorithm)
+    : Prims.Pure (Core.Result.t_Result Libcrux_sha2.Impl_hacl.t_Algorithm u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Hash `data` with the given `algorithm`.
+/// Returns the digest or an [`TLSError`].
+val impl_HashAlgorithm__hash (self: t_HashAlgorithm) (data: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Get the size of the hash digest.
+val impl_HashAlgorithm__hash_len (self: t_HashAlgorithm)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the libcrux hmac algorithm.
+val impl_HashAlgorithm__hmac_algorithm (self: t_HashAlgorithm)
+    : Prims.Pure (Core.Result.t_Result Libcrux_hmac.t_Algorithm u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Get the size of the hmac tag.
+val impl_HashAlgorithm__hmac_tag_len (self: t_HashAlgorithm)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// Compute the HMAC tag.
+/// Returns the tag [`Hmac`] or a [`TLSError`].
+val hmac_tag (alg: t_HashAlgorithm) (mk input: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Verify a given HMAC `tag`.
+/// Returns `()` if successful or a [`TLSError`].
+val hmac_verify (alg: t_HashAlgorithm) (mk input tag: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get an empty key of the correct size.
+val zero_key (alg: t_HashAlgorithm)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the libcrux HKDF algorithm.
+val hkdf_algorithm (alg: t_HashAlgorithm)
+    : Prims.Pure (Core.Result.t_Result Libcrux_hkdf.t_Algorithm u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// HKDF Extract.
+/// Returns the result as [`Bytes`] or a [`TLSError`].
+val hkdf_extract (alg: t_HashAlgorithm) (ikm salt: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// HKDF Expand.
+/// Returns the result as [`Bytes`] or a [`TLSError`].
+val hkdf_expand (alg: t_HashAlgorithm) (prk info: Bertie.Tls13utils.t_Bytes) (len: usize)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// AEAD Algorithms for Bertie
+type t_AeadAlgorithm =
+  | AeadAlgorithm_Chacha20Poly1305 : t_AeadAlgorithm
+  | AeadAlgorithm_Aes128Gcm : t_AeadAlgorithm
+  | AeadAlgorithm_Aes256Gcm : t_AeadAlgorithm
+
+/// An AEAD key.
+type t_AeadKey = {
+  f_bytes:Bertie.Tls13utils.t_Bytes;
+  f_e_alg:t_AeadAlgorithm
+}
+
+/// An AEAD key and iv package.
+type t_AeadKeyIV = {
+  f_key:t_AeadKey;
+  f_iv:Bertie.Tls13utils.t_Bytes
+}
+
+/// Create a new [`AeadKeyIV`].
+val impl_AeadKeyIV__new (key: t_AeadKey) (iv: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure t_AeadKeyIV Prims.l_True (fun _ -> Prims.l_True)
+
+/// Create a new AEAD key from the raw bytes and the algorithm.
+val impl_AeadKey__new (bytes: Bertie.Tls13utils.t_Bytes) (e_alg: t_AeadAlgorithm)
+    : Prims.Pure t_AeadKey Prims.l_True (fun _ -> Prims.l_True)
+
+val t_AeadAlgorithm_cast_to_repr (x: t_AeadAlgorithm)
     : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_15:Core.Clone.t_Clone t_AeadAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_16:Core.Marker.t_Copy t_AeadAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core.Marker.t_StructuralPartialEq t_AeadAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core.Cmp.t_PartialEq t_AeadAlgorithm t_AeadAlgorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core.Fmt.t_Debug t_AeadAlgorithm
+
+/// Get the key length of the AEAD algorithm in bytes.
+val impl_AeadAlgorithm__key_len (self: t_AeadAlgorithm)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the length of the IV for this algorithm.
+val impl_AeadAlgorithm__iv_len (self: t_AeadAlgorithm)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// AEAD encrypt
+val aead_encrypt (k: t_AeadKey) (iv plain aad: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// AEAD decrypt.
+val aead_decrypt (k: t_AeadKey) (iv cip aad: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Signature schemes for Bertie.
 type t_SignatureScheme =
   | SignatureScheme_RsaPssRsaSha256 : t_SignatureScheme
   | SignatureScheme_EcdsaSecp256r1Sha256 : t_SignatureScheme
@@ -43,40 +191,152 @@ type t_SignatureScheme =
 val t_SignatureScheme_cast_to_repr (x: t_SignatureScheme)
     : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core.Clone.t_Clone t_SignatureScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core.Marker.t_Copy t_SignatureScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_22:Core.Marker.t_StructuralPartialEq t_SignatureScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_23:Core.Cmp.t_PartialEq t_SignatureScheme t_SignatureScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_24:Core.Fmt.t_Debug t_SignatureScheme
+
+/// Sign the bytes in `input` with the signature key `sk` and `algorithm`.
+val sign
+      (#iimpl_447424039_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (algorithm: t_SignatureScheme)
+      (sk input: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_447424039_)
+    : Prims.Pure (iimpl_447424039_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Determine if given modulus conforms to one of the key sizes supported by
+/// `libcrux`.
+val supported_rsa_key_size (n: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Determine if given public exponent is supported by `libcrux`, i.e. whether
+///  `e == 0x010001`.
 val valid_rsa_exponent (e: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
     : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__HashAlgorithm__libcrux_algorithm (self: t_HashAlgorithm)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Digest.t_Algorithm u8)
+/// Sign the `input` with the provided RSA key.
+val sign_rsa
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (sk pk_modulus pk_exponent: Bertie.Tls13utils.t_Bytes)
+      (cert_scheme: t_SignatureScheme)
+      (input: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+    : Prims.Pure (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__HashAlgorithm__hash_len (self: t_HashAlgorithm)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+/// Verify the `input` bytes against the provided `signature`.
+/// Return `Ok(())` if the verification succeeds, and a [`TLSError`] otherwise.
+val verify
+      (alg: t_SignatureScheme)
+      (pk: t_PublicVerificationKey)
+      (input sig: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__HashAlgorithm__hmac_tag_len (self: t_HashAlgorithm)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+/// Bertie KEM schemes.
+/// This includes ECDH curves.
+type t_KemScheme =
+  | KemScheme_X25519 : t_KemScheme
+  | KemScheme_Secp256r1 : t_KemScheme
+  | KemScheme_X448 : t_KemScheme
+  | KemScheme_Secp384r1 : t_KemScheme
+  | KemScheme_Secp521r1 : t_KemScheme
+  | KemScheme_X25519Kyber768Draft00 : t_KemScheme
+  | KemScheme_X25519MlKem768 : t_KemScheme
 
-val hkdf_algorithm (alg: t_HashAlgorithm)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Hkdf.t_Algorithm u8)
+val t_KemScheme_cast_to_repr (x: t_KemScheme)
+    : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_25:Core.Clone.t_Clone t_KemScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_26:Core.Marker.t_Copy t_KemScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_27:Core.Marker.t_StructuralPartialEq t_KemScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_28:Core.Cmp.t_PartialEq t_KemScheme t_KemScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_29:Core.Cmp.t_Eq t_KemScheme
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_30:Core.Fmt.t_Debug t_KemScheme
+
+/// Get the libcrux algorithm for this [`KemScheme`].
+val impl_KemScheme__libcrux_kem_algorithm (self: t_KemScheme)
+    : Prims.Pure (Core.Result.t_Result Libcrux_kem.t_Algorithm u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__HashAlgorithm__hmac_algorithm (self: t_HashAlgorithm)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Hmac.t_Algorithm u8)
+/// Note that the `encode` in libcrux currently returns the raw
+/// concatenation of bytes. We have to prepend the 0x04 for
+/// uncompressed points on NIST curves.
+val encoding_prefix (alg: t_KemScheme)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Generate a new KEM key pair.
+val kem_keygen
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (alg: t_KemScheme)
+      (rng: iimpl_916461611_)
+    : Prims.Pure
+      (iimpl_916461611_ &
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__SignatureScheme__libcrux_scheme (self: t_SignatureScheme)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Signature.t_Algorithm u8)
+/// Note that the `encode` in libcrux operates on the raw
+/// concatenation of bytes. We have to work with uncompressed NIST points here.
+val into_raw (alg: t_KemScheme) (point: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// We only want the X coordinate for points on NIST curves.
+val to_shared_secret (alg: t_KemScheme) (shared_secret: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// KEM encapsulation
+val kem_encap
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (alg: t_KemScheme)
+      (pk: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+    : Prims.Pure
+      (iimpl_916461611_ &
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__KemScheme__libcrux_algorithm (self: t_KemScheme)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Kem.t_Algorithm u8)
+/// KEM decapsulation
+val kem_decap (alg: t_KemScheme) (ct sk: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// The algorithms for Bertie.
+/// Note that this is more than the TLS 1.3 ciphersuite. It contains all
+/// necessary cryptographic algorithms and options.
 type t_Algorithms = {
   f_hash:t_HashAlgorithm;
   f_aead:t_AeadAlgorithm;
@@ -86,16 +346,23 @@ type t_Algorithms = {
   f_zero_rtt:bool
 }
 
-val impl__Algorithms__aead (self: t_Algorithms)
-    : Prims.Pure t_AeadAlgorithm Prims.l_True (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_31:Core.Clone.t_Clone t_Algorithms
 
-val impl__Algorithms__hash (self: t_Algorithms)
-    : Prims.Pure t_HashAlgorithm Prims.l_True (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_32:Core.Marker.t_Copy t_Algorithms
 
-val impl__Algorithms__kem (self: t_Algorithms)
-    : Prims.Pure t_KemScheme Prims.l_True (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_33:Core.Marker.t_StructuralPartialEq t_Algorithms
 
-val impl__Algorithms__new
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_34:Core.Cmp.t_PartialEq t_Algorithms t_Algorithms
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_35:Core.Fmt.t_Debug t_Algorithms
+
+/// Create a new [`Algorithms`] object for the TLS 1.3 ciphersuite.
+val impl_Algorithms__new
       (hash: t_HashAlgorithm)
       (aead: t_AeadAlgorithm)
       (sig: t_SignatureScheme)
@@ -103,303 +370,132 @@ val impl__Algorithms__new
       (psk zero_rtt: bool)
     : Prims.Pure t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Algorithms__psk_mode (self: t_Algorithms)
-    : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+/// Get the [`HashAlgorithm`].
+val impl_Algorithms__hash (self: t_Algorithms)
+    : Prims.Pure t_HashAlgorithm Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Algorithms__signature (self: t_Algorithms)
+/// Get the [`AeadAlgorithm`].
+val impl_Algorithms__aead (self: t_Algorithms)
+    : Prims.Pure t_AeadAlgorithm Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the [`SignatureAlgorithm`].
+val impl_Algorithms__signature (self: t_Algorithms)
     : Prims.Pure t_SignatureScheme Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Algorithms__zero_rtt (self: t_Algorithms)
+/// Get the [`KemScheme`].
+val impl_Algorithms__kem (self: t_Algorithms)
+    : Prims.Pure t_KemScheme Prims.l_True (fun _ -> Prims.l_True)
+
+/// Returns `true` when using the PSK mode and `false` otherwise.
+val impl_Algorithms__psk_mode (self: t_Algorithms)
     : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_8: Core.Fmt.t_Display t_Algorithms =
-  {
-    f_fmt_pre = (fun (self: t_Algorithms) (f: Core.Fmt.t_Formatter) -> true);
-    f_fmt_post
-    =
-    (fun
-        (self: t_Algorithms)
-        (f: Core.Fmt.t_Formatter)
-        (out1: (Core.Fmt.t_Formatter & Core.Result.t_Result Prims.unit Core.Fmt.t_Error))
-        ->
-        true);
-    f_fmt
-    =
-    fun (self: t_Algorithms) (f: Core.Fmt.t_Formatter) ->
-      let tmp0, out:(Core.Fmt.t_Formatter & Core.Result.t_Result Prims.unit Core.Fmt.t_Error) =
-        Core.Fmt.impl_7__write_fmt f
-          (Core.Fmt.impl_2__new_v1 (Rust_primitives.unsize (let list =
-                      ["TLS_"; "_"; " w/ "; " | "]
-                    in
-                    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 4);
-                    Rust_primitives.Hax.array_of_list 4 list)
-                <:
-                t_Slice string)
-              (Rust_primitives.unsize (let list =
-                      [
-                        Core.Fmt.Rt.impl_1__new_debug self.f_aead <: Core.Fmt.Rt.t_Argument;
-                        Core.Fmt.Rt.impl_1__new_debug self.f_hash <: Core.Fmt.Rt.t_Argument;
-                        Core.Fmt.Rt.impl_1__new_debug self.f_signature <: Core.Fmt.Rt.t_Argument;
-                        Core.Fmt.Rt.impl_1__new_debug self.f_kem <: Core.Fmt.Rt.t_Argument
-                      ]
-                    in
-                    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 4);
-                    Rust_primitives.Hax.array_of_list 4 list)
-                <:
-                t_Slice Core.Fmt.Rt.t_Argument)
-            <:
-            Core.Fmt.t_Arguments)
-      in
-      let f:Core.Fmt.t_Formatter = tmp0 in
-      let hax_temp_output:Core.Result.t_Result Prims.unit Core.Fmt.t_Error = out in
-      f, hax_temp_output
-      <:
-      (Core.Fmt.t_Formatter & Core.Result.t_Result Prims.unit Core.Fmt.t_Error)
-  }
+/// Returns `true` when using zero rtt and `false` otherwise.
+val impl_Algorithms__zero_rtt (self: t_Algorithms)
+    : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
-let v_SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes128Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes128Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Aes128Gcm_RsaPssRsaSha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes128Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Aes128Gcm_RsaPssRsaSha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes128Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
-    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-let v_SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA384 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes256Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA384 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes256Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-let v_SHA384_Aes256Gcm_RsaPssRsaSha256_P256: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA384 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes256Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_Secp256r1 <: t_KemScheme)
-    false
-    false
-
-let v_SHA384_Aes256Gcm_RsaPssRsaSha256_X25519: t_Algorithms =
-  impl__Algorithms__new (HashAlgorithm_SHA384 <: t_HashAlgorithm)
-    (AeadAlgorithm_Aes256Gcm <: t_AeadAlgorithm)
-    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
-    (KemScheme_X25519 <: t_KemScheme)
-    false
-    false
-
-unfold
-let t_AeadIV = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_Digest = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_Hmac = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_KemPk = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_KemSk = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_Key = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_MacKey = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_Psk = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_Random = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_SignatureKey = Bertie.Tls13utils.t_Bytes
-
-unfold
-let t_VerificationKey = Bertie.Tls13utils.t_Bytes
-
-val impl__HashAlgorithm__hash (self: t_HashAlgorithm) (data: Bertie.Tls13utils.t_Bytes)
+/// Returns the TLS ciphersuite for the given algorithm when it is supported, or
+/// a [`TLSError`] otherwise.
+val impl_Algorithms__ciphersuite (self: t_Algorithms)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val hkdf_expand (alg: t_HashAlgorithm) (prk info: Bertie.Tls13utils.t_Bytes) (len: usize)
+/// Returns the curve id for the given algorithm when it is supported, or a [`TLSError`]
+/// otherwise.
+val impl_Algorithms__supported_group (self: t_Algorithms)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val hkdf_extract (alg: t_HashAlgorithm) (ikm salt: Bertie.Tls13utils.t_Bytes)
+/// Returns the signature id for the given algorithm when it is supported, or a
+///  [`TLSError`] otherwise.
+val impl_Algorithms__signature_algorithm (self: t_Algorithms)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val hmac_tag (alg: t_HashAlgorithm) (mk input: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Algorithms__ciphersuite (self: t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val impl__Algorithms__check (self: t_Algorithms) (bytes: t_Slice u8)
+/// Check the ciphersuite in `bytes` against this ciphersuite.
+val impl_Algorithms__check (self: t_Algorithms) (bytes: t_Slice u8)
     : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Algorithms__signature_algorithm (self: t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7:Core.Fmt.t_Display t_Algorithms
 
-val impl__Algorithms__supported_group (self: t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * x25519 for key exchange
+/// * EcDSA P256 SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
+    (KemScheme_X25519 <: t_KemScheme)
+    false
+    false
 
-val sign
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (algorithm: t_SignatureScheme)
-      (sk input: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * X25519Kyber768Draft00 for key exchange (cf. https://www.ietf.org/archive/id/draft-tls-westerbaan-xyber768d00-02.html)
+/// * EcDSA P256 SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
+    (KemScheme_X25519Kyber768Draft00 <: t_KemScheme)
+    false
+    false
 
-val supported_rsa_key_size (n: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Signature.Rsa_pss.t_RsaPssKeySize u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * X25519MlKem768 for key exchange (cf. https://datatracker.ietf.org/doc/draft-kwiatkowski-tls-ecdhe-mlkem/)
+/// * EcDSA P256 SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519MlKem768: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
+    (KemScheme_X25519MlKem768 <: t_KemScheme)
+    false
+    false
 
-val sign_rsa
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (sk pk_modulus pk_exponent: Bertie.Tls13utils.t_Bytes)
-      (cert_scheme: t_SignatureScheme)
-      (input: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * x25519 for key exchange
+/// * RSA PSS SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
+    (KemScheme_X25519 <: t_KemScheme)
+    false
+    false
 
-val encoding_prefix (alg: t_KemScheme)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * P256 for key exchange
+/// * EcDSA P256 SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_P256: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_EcdsaSecp256r1Sha256 <: t_SignatureScheme)
+    (KemScheme_Secp256r1 <: t_KemScheme)
+    false
+    false
 
-val kem_keygen
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (alg: t_KemScheme)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val into_raw (alg: t_KemScheme) (point: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val to_shared_secret (alg: t_KemScheme) (shared_secret: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val kem_decap (alg: t_KemScheme) (ct sk: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val kem_encap
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (alg: t_KemScheme)
-      (pk: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val zero_key (alg: t_HashAlgorithm)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val hmac_verify (alg: t_HashAlgorithm) (mk input tag: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+/// `TLS_CHACHA20_POLY1305_SHA256`
+/// with
+/// * P256 for key exchange
+/// * RSA PSSS SHA256 for signatures
+let v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256: t_Algorithms =
+  impl_Algorithms__new (HashAlgorithm_SHA256 <: t_HashAlgorithm)
+    (AeadAlgorithm_Chacha20Poly1305 <: t_AeadAlgorithm)
+    (SignatureScheme_RsaPssRsaSha256 <: t_SignatureScheme)
+    (KemScheme_Secp256r1 <: t_KemScheme)
+    false
+    false
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_7: Core.Convert.t_TryFrom t_Algorithms string =
+let impl_6: Core.Convert.t_TryFrom t_Algorithms string =
   {
     f_Error = Bertie.Tls13utils.t_Error;
     f_try_from_pre = (fun (s: string) -> true);
@@ -409,7 +505,7 @@ let impl_7: Core.Convert.t_TryFrom t_Algorithms string =
     f_try_from
     =
     fun (s: string) ->
-      match s with
+      match s <: string with
       | "SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519" ->
         Core.Result.Result_Ok v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_X25519
         <:
@@ -426,103 +522,31 @@ let impl_7: Core.Convert.t_TryFrom t_Algorithms string =
         Core.Result.Result_Ok v_SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256
         <:
         Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256" ->
-        Core.Result.Result_Ok v_SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256
+      | "SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00" ->
+        Core.Result.Result_Ok v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00
         <:
         Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519" ->
-        Core.Result.Result_Ok v_SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA256_Aes128Gcm_RsaPssRsaSha256_P256" ->
-        Core.Result.Result_Ok v_SHA256_Aes128Gcm_RsaPssRsaSha256_P256
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA256_Aes128Gcm_RsaPssRsaSha256_X25519" ->
-        Core.Result.Result_Ok v_SHA256_Aes128Gcm_RsaPssRsaSha256_X25519
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256" ->
-        Core.Result.Result_Ok v_SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519" ->
-        Core.Result.Result_Ok v_SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA384_Aes256Gcm_RsaPssRsaSha256_P256" ->
-        Core.Result.Result_Ok v_SHA384_Aes256Gcm_RsaPssRsaSha256_P256
-        <:
-        Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
-      | "SHA384_Aes256Gcm_RsaPssRsaSha256_X25519" ->
-        Core.Result.Result_Ok v_SHA384_Aes256Gcm_RsaPssRsaSha256_X25519
+      | "SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519MLKEM768" ->
+        Core.Result.Result_Ok v_SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519MlKem768
         <:
         Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
       | _ ->
         let res:Alloc.String.t_String =
-          Alloc.Fmt.format (Core.Fmt.impl_2__new_v1 (Rust_primitives.unsize (let list =
-                        ["Invalid ciphersuite description: "]
-                      in
-                      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                      Rust_primitives.Hax.array_of_list 1 list)
-                  <:
-                  t_Slice string)
-                (Rust_primitives.unsize (let list =
-                        [Core.Fmt.Rt.impl_1__new_display s <: Core.Fmt.Rt.t_Argument]
-                      in
-                      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                      Rust_primitives.Hax.array_of_list 1 list)
-                  <:
-                  t_Slice Core.Fmt.Rt.t_Argument)
+          Alloc.Fmt.format (Core.Fmt.impl_2__new_v1 (mk_usize 1)
+                (mk_usize 1)
+                (let list = ["Invalid ciphersuite description: "] in
+                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                  Rust_primitives.Hax.array_of_list 1 list)
+                (let list = [Core.Fmt.Rt.impl_1__new_display #string s <: Core.Fmt.Rt.t_Argument] in
+                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                  Rust_primitives.Hax.array_of_list 1 list)
               <:
               Core.Fmt.t_Arguments)
         in
         Core.Result.Result_Err
-        (Bertie.Tls13utils.Error_UnknownCiphersuite res <: Bertie.Tls13utils.t_Error)
+        (Bertie.Tls13utils.Error_UnknownCiphersuite (Core.Hint.must_use #Alloc.String.t_String res)
+          <:
+          Bertie.Tls13utils.t_Error)
         <:
         Core.Result.t_Result t_Algorithms Bertie.Tls13utils.t_Error
   }
-
-type t_AeadKey = {
-  f_bytes:Bertie.Tls13utils.t_Bytes;
-  f_alg:t_AeadAlgorithm
-}
-
-val impl__AeadKey__as_libcrux_key (self: t_AeadKey)
-    : Prims.Pure (Core.Result.t_Result Libcrux.Aead.t_Key u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__AeadKey__new (bytes: Bertie.Tls13utils.t_Bytes) (alg: t_AeadAlgorithm)
-    : Prims.Pure t_AeadKey Prims.l_True (fun _ -> Prims.l_True)
-
-type t_RsaVerificationKey = {
-  f_modulus:Bertie.Tls13utils.t_Bytes;
-  f_exponent:Bertie.Tls13utils.t_Bytes
-}
-
-type t_PublicVerificationKey =
-  | PublicVerificationKey_EcDsa : Bertie.Tls13utils.t_Bytes -> t_PublicVerificationKey
-  | PublicVerificationKey_Rsa : t_RsaVerificationKey -> t_PublicVerificationKey
-
-val aead_decrypt (k: t_AeadKey) (iv cip aad: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val aead_encrypt (k: t_AeadKey) (iv plain aad: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val verify
-      (alg: t_SignatureScheme)
-      (pk: t_PublicVerificationKey)
-      (input sig: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-type t_AeadKeyIV = {
-  f_key:t_AeadKey;
-  f_iv:Bertie.Tls13utils.t_Bytes
-}
-
-val impl__AeadKeyIV__new (key: t_AeadKey) (iv: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure t_AeadKeyIV Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Bertie.Tls13formats.Handshake_data.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13formats.Handshake_data.fst
@@ -3,97 +3,143 @@ module Bertie.Tls13formats.Handshake_data
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
+
 let t_HandshakeType_cast_to_repr (x: t_HandshakeType) =
-  match x with
-  | HandshakeType_ClientHello  -> discriminant_HandshakeType_ClientHello
-  | HandshakeType_ServerHello  -> discriminant_HandshakeType_ServerHello
-  | HandshakeType_NewSessionTicket  -> discriminant_HandshakeType_NewSessionTicket
-  | HandshakeType_EndOfEarlyData  -> discriminant_HandshakeType_EndOfEarlyData
-  | HandshakeType_EncryptedExtensions  -> discriminant_HandshakeType_EncryptedExtensions
-  | HandshakeType_Certificate  -> discriminant_HandshakeType_Certificate
-  | HandshakeType_CertificateRequest  -> discriminant_HandshakeType_CertificateRequest
-  | HandshakeType_CertificateVerify  -> discriminant_HandshakeType_CertificateVerify
-  | HandshakeType_Finished  -> discriminant_HandshakeType_Finished
-  | HandshakeType_KeyUpdate  -> discriminant_HandshakeType_KeyUpdate
-  | HandshakeType_MessageHash  -> discriminant_HandshakeType_MessageHash
+  match x <: t_HandshakeType with
+  | HandshakeType_ClientHello  -> anon_const_HandshakeType_ClientHello__anon_const_0
+  | HandshakeType_ServerHello  -> anon_const_HandshakeType_ServerHello__anon_const_0
+  | HandshakeType_NewSessionTicket  -> anon_const_HandshakeType_NewSessionTicket__anon_const_0
+  | HandshakeType_EndOfEarlyData  -> anon_const_HandshakeType_EndOfEarlyData__anon_const_0
+  | HandshakeType_EncryptedExtensions  -> anon_const_HandshakeType_EncryptedExtensions__anon_const_0
+  | HandshakeType_Certificate  -> anon_const_HandshakeType_Certificate__anon_const_0
+  | HandshakeType_CertificateRequest  -> anon_const_HandshakeType_CertificateRequest__anon_const_0
+  | HandshakeType_CertificateVerify  -> anon_const_HandshakeType_CertificateVerify__anon_const_0
+  | HandshakeType_Finished  -> anon_const_HandshakeType_Finished__anon_const_0
+  | HandshakeType_KeyUpdate  -> anon_const_HandshakeType_KeyUpdate__anon_const_0
+  | HandshakeType_MessageHash  -> anon_const_HandshakeType_MessageHash__anon_const_0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core.Clone.t_Clone t_HandshakeType
+
+let impl_2 = impl_2'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_3': Core.Marker.t_Copy t_HandshakeType
+
+let impl_3 = impl_3'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_4': Core.Fmt.t_Debug t_HandshakeType
+
+let impl_4 = impl_4'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_5': Core.Marker.t_StructuralPartialEq t_HandshakeType
+
+let impl_5 = impl_5'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_6': Core.Cmp.t_PartialEq t_HandshakeType t_HandshakeType
+
+let impl_6 = impl_6'
 
 let get_hs_type (t: u8) =
-  match t with
-  | 1uy ->
+  match t <: u8 with
+  | Rust_primitives.Integers.MkInt 1 ->
     Core.Result.Result_Ok (HandshakeType_ClientHello <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 2uy ->
+  | Rust_primitives.Integers.MkInt 2 ->
     Core.Result.Result_Ok (HandshakeType_ServerHello <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 4uy ->
+  | Rust_primitives.Integers.MkInt 4 ->
     Core.Result.Result_Ok (HandshakeType_NewSessionTicket <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 5uy ->
+  | Rust_primitives.Integers.MkInt 5 ->
     Core.Result.Result_Ok (HandshakeType_EndOfEarlyData <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 8uy ->
+  | Rust_primitives.Integers.MkInt 8 ->
     Core.Result.Result_Ok (HandshakeType_EncryptedExtensions <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 11uy ->
+  | Rust_primitives.Integers.MkInt 11 ->
     Core.Result.Result_Ok (HandshakeType_Certificate <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 13uy ->
+  | Rust_primitives.Integers.MkInt 13 ->
     Core.Result.Result_Ok (HandshakeType_CertificateRequest <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 15uy ->
+  | Rust_primitives.Integers.MkInt 15 ->
     Core.Result.Result_Ok (HandshakeType_CertificateVerify <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 20uy ->
+  | Rust_primitives.Integers.MkInt 20 ->
     Core.Result.Result_Ok (HandshakeType_Finished <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 24uy ->
+  | Rust_primitives.Integers.MkInt 24 ->
     Core.Result.Result_Ok (HandshakeType_KeyUpdate <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | 254uy ->
+  | Rust_primitives.Integers.MkInt 254 ->
     Core.Result.Result_Ok (HandshakeType_MessageHash <: t_HandshakeType)
     <:
     Core.Result.t_Result t_HandshakeType u8
-  | _ -> Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
+  | _ -> Bertie.Tls13utils.tlserr #t_HandshakeType (Bertie.Tls13utils.parse_failed () <: u8)
 
-let impl__HandshakeData__len (self: t_HandshakeData) = Bertie.Tls13utils.impl__Bytes__len self._0
+let impl_HandshakeData__len (self: t_HandshakeData) = Bertie.Tls13utils.impl_Bytes__len self._0
 
-let impl__HandshakeData__next_handshake_message (self: t_HandshakeData) =
-  if (impl__HandshakeData__len self <: usize) <. sz 4
-  then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
+let impl_HandshakeData__to_bytes (self: t_HandshakeData) =
+  Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve self._0
+
+let impl_HandshakeData__next_handshake_message (self: t_HandshakeData) =
+  if (impl_HandshakeData__len self <: usize) <. mk_usize 4
+  then
+    Bertie.Tls13utils.tlserr #(t_HandshakeData & t_HandshakeData)
+      (Bertie.Tls13utils.parse_failed () <: u8)
   else
     match
-      Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl__Bytes__raw_slice self._0
+      Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl_Bytes__raw_slice self._0
             ({
-                Core.Ops.Range.f_start = sz 1;
-                Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len self._0 <: usize
+                Core.Ops.Range.f_start = mk_usize 1;
+                Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len self._0 <: usize
               }
               <:
               Core.Ops.Range.t_Range usize)
           <:
           t_Slice u8)
+      <:
+      Core.Result.t_Result usize u8
     with
     | Core.Result.Result_Ok len ->
       let message:Bertie.Tls13utils.t_Bytes =
-        Bertie.Tls13utils.impl__Bytes__slice_range self._0
-          ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 4 +! len <: usize }
+        Bertie.Tls13utils.impl_Bytes__slice_range self._0
+          ({
+              Core.Ops.Range.f_start = mk_usize 0;
+              Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
+            }
             <:
             Core.Ops.Range.t_Range usize)
       in
       let rest:Bertie.Tls13utils.t_Bytes =
-        Bertie.Tls13utils.impl__Bytes__slice_range self._0
+        Bertie.Tls13utils.impl_Bytes__slice_range self._0
           ({
-              Core.Ops.Range.f_start = sz 4 +! len <: usize;
-              Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len self._0 <: usize
+              Core.Ops.Range.f_start = mk_usize 4 +! len <: usize;
+              Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len self._0 <: usize
             }
             <:
             Core.Ops.Range.t_Range usize)
@@ -107,16 +153,22 @@ let impl__HandshakeData__next_handshake_message (self: t_HandshakeData) =
     | Core.Result.Result_Err err ->
       Core.Result.Result_Err err <: Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
 
-let impl__HandshakeData__as_handshake_message
+let impl_HandshakeData__as_handshake_message
       (self: t_HandshakeData)
       (expected_type: t_HandshakeType)
      =
-  match impl__HandshakeData__next_handshake_message self with
+  match
+    impl_HandshakeData__next_handshake_message self
+    <:
+    Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+  with
   | Core.Result.Result_Ok (message, payload_rest) ->
     (match
-        if (impl__HandshakeData__len payload_rest <: usize) <>. sz 0
-        then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-        else Core.Result.Result_Ok message <: Core.Result.t_Result t_HandshakeData u8
+        (if (impl_HandshakeData__len payload_rest <: usize) <>. mk_usize 0
+          then Bertie.Tls13utils.tlserr #t_HandshakeData (Bertie.Tls13utils.parse_failed () <: u8)
+          else Core.Result.Result_Ok message <: Core.Result.t_Result t_HandshakeData u8)
+        <:
+        Core.Result.t_Result t_HandshakeData u8
       with
       | Core.Result.Result_Ok (HandshakeData tagged_message_bytes) ->
         let expected_bytes:Bertie.Tls13utils.t_Bytes =
@@ -124,22 +176,24 @@ let impl__HandshakeData__as_handshake_message
         in
         (match
             Bertie.Tls13utils.check_eq expected_bytes
-              (Bertie.Tls13utils.impl__Bytes__slice_range tagged_message_bytes
-                  ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 1 }
+              (Bertie.Tls13utils.impl_Bytes__slice_range tagged_message_bytes
+                  ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = mk_usize 1 }
                     <:
                     Core.Ops.Range.t_Range usize)
                 <:
                 Bertie.Tls13utils.t_Bytes)
+            <:
+            Core.Result.t_Result Prims.unit u8
           with
           | Core.Result.Result_Ok _ ->
             Core.Result.Result_Ok
             (HandshakeData
-              (Bertie.Tls13utils.impl__Bytes__slice_range tagged_message_bytes
+              (Bertie.Tls13utils.impl_Bytes__slice_range tagged_message_bytes
                   ({
-                      Core.Ops.Range.f_start = sz 4;
+                      Core.Ops.Range.f_start = mk_usize 4;
                       Core.Ops.Range.f_end
                       =
-                      Bertie.Tls13utils.impl__Bytes__len tagged_message_bytes <: usize
+                      Bertie.Tls13utils.impl_Bytes__len tagged_message_bytes <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize))
@@ -154,19 +208,62 @@ let impl__HandshakeData__as_handshake_message
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result t_HandshakeData u8
 
-let impl__HandshakeData__to_bytes (self: t_HandshakeData) = Core.Clone.f_clone self._0
-
-let impl__HandshakeData__to_four (self: t_HandshakeData) =
-  match impl__HandshakeData__next_handshake_message self with
+let impl_HandshakeData__to_two (self: t_HandshakeData) =
+  match
+    impl_HandshakeData__next_handshake_message self
+    <:
+    Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+  with
   | Core.Result.Result_Ok (message1, payload_rest) ->
-    (match impl__HandshakeData__next_handshake_message payload_rest with
+    (match
+        impl_HandshakeData__next_handshake_message payload_rest
+        <:
+        Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+      with
       | Core.Result.Result_Ok (message2, payload_rest) ->
-        (match impl__HandshakeData__next_handshake_message payload_rest with
+        if (impl_HandshakeData__len payload_rest <: usize) <>. mk_usize 0
+        then
+          Bertie.Tls13utils.tlserr #(t_HandshakeData & t_HandshakeData)
+            (Bertie.Tls13utils.parse_failed () <: u8)
+        else
+          Core.Result.Result_Ok (message1, message2 <: (t_HandshakeData & t_HandshakeData))
+          <:
+          Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+
+let impl_HandshakeData__to_four (self: t_HandshakeData) =
+  match
+    impl_HandshakeData__next_handshake_message self
+    <:
+    Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+  with
+  | Core.Result.Result_Ok (message1, payload_rest) ->
+    (match
+        impl_HandshakeData__next_handshake_message payload_rest
+        <:
+        Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+      with
+      | Core.Result.Result_Ok (message2, payload_rest) ->
+        (match
+            impl_HandshakeData__next_handshake_message payload_rest
+            <:
+            Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+          with
           | Core.Result.Result_Ok (message3, payload_rest) ->
-            (match impl__HandshakeData__next_handshake_message payload_rest with
+            (match
+                impl_HandshakeData__next_handshake_message payload_rest
+                <:
+                Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+              with
               | Core.Result.Result_Ok (message4, payload_rest) ->
-                if (impl__HandshakeData__len payload_rest <: usize) <>. sz 0
-                then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
+                if (impl_HandshakeData__len payload_rest <: usize) <>. mk_usize 0
+                then
+                  Bertie.Tls13utils.tlserr #(t_HandshakeData & t_HandshakeData & t_HandshakeData &
+                      t_HandshakeData)
+                    (Bertie.Tls13utils.parse_failed () <: u8)
                 else
                   Core.Result.Result_Ok
                   (message1, message2, message3, message4
@@ -195,47 +292,34 @@ let impl__HandshakeData__to_four (self: t_HandshakeData) =
     <:
     Core.Result.t_Result (t_HandshakeData & t_HandshakeData & t_HandshakeData & t_HandshakeData) u8
 
-let impl__HandshakeData__to_two (self: t_HandshakeData) =
-  match impl__HandshakeData__next_handshake_message self with
-  | Core.Result.Result_Ok (message1, payload_rest) ->
-    (match impl__HandshakeData__next_handshake_message payload_rest with
-      | Core.Result.Result_Ok (message2, payload_rest) ->
-        if (impl__HandshakeData__len payload_rest <: usize) <>. sz 0
-        then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-        else
-          Core.Result.Result_Ok (message1, message2 <: (t_HandshakeData & t_HandshakeData))
-          <:
-          Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core.Convert.t_From t_HandshakeData Bertie.Tls13utils.t_Bytes =
+  {
+    f_from_pre = (fun (value: Bertie.Tls13utils.t_Bytes) -> true);
+    f_from_post = (fun (value: Bertie.Tls13utils.t_Bytes) (out: t_HandshakeData) -> true);
+    f_from = fun (value: Bertie.Tls13utils.t_Bytes) -> HandshakeData value <: t_HandshakeData
+  }
 
-let impl__HandshakeData__concat (self other: t_HandshakeData) =
-  let message1:Bertie.Tls13utils.t_Bytes = impl__HandshakeData__to_bytes self in
-  let message2:Bertie.Tls13utils.t_Bytes = impl__HandshakeData__to_bytes other in
-  let message1:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.impl__Bytes__extend_from_slice message1 message2
-  in
-  Core.Convert.f_from message1
-
-let impl__HandshakeData__from_bytes
+let impl_HandshakeData__from_bytes
       (handshake_type: t_HandshakeType)
       (handshake_bytes: Bertie.Tls13utils.t_Bytes)
      =
-  match Bertie.Tls13utils.encode_length_u24 handshake_bytes with
-  | Core.Result.Result_Ok hoist138 ->
+  match
+    Bertie.Tls13utils.encode_length_u24 handshake_bytes
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist1 ->
     Core.Result.Result_Ok
-    (Core.Convert.f_from (Bertie.Tls13utils.impl__Bytes__prefix hoist138
-            (Rust_primitives.unsize (let list =
-                    [
-                      Bertie.Tls13utils.v_U8 (t_HandshakeType_cast_to_repr handshake_type <: u8)
-                      <:
-                      u8
-                    ]
-                  in
-                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                  Rust_primitives.Hax.array_of_list 1 list)
+    (Core.Convert.f_from #t_HandshakeData
+        #Bertie.Tls13utils.t_Bytes
+        #FStar.Tactics.Typeclasses.solve
+        (Bertie.Tls13utils.impl_Bytes__prefix hoist1
+            ((let list =
+                  [Bertie.Tls13utils.v_U8 (t_HandshakeType_cast_to_repr handshake_type <: u8)]
+                in
+                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                Rust_primitives.Hax.array_of_list 1 list)
               <:
               t_Slice u8)
           <:
@@ -245,24 +329,37 @@ let impl__HandshakeData__from_bytes
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result t_HandshakeData u8
 
-let rec impl__HandshakeData__find_handshake_message
+let impl_HandshakeData__concat (self other: t_HandshakeData) =
+  let message1:Bertie.Tls13utils.t_Bytes = impl_HandshakeData__to_bytes self in
+  let message2:Bertie.Tls13utils.t_Bytes = impl_HandshakeData__to_bytes other in
+  let message1:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13utils.impl_Bytes__extend_from_slice message1 message2
+  in
+  Core.Convert.f_from #t_HandshakeData
+    #Bertie.Tls13utils.t_Bytes
+    #FStar.Tactics.Typeclasses.solve
+    message1
+
+let rec impl_HandshakeData__find_handshake_message
       (self: t_HandshakeData)
       (handshake_type: t_HandshakeType)
       (start: usize)
      =
-  if (impl__HandshakeData__len self <: usize) <. (start +! sz 4 <: usize)
+  if (impl_HandshakeData__len self <: usize) <. (start +! mk_usize 4 <: usize)
   then false
   else
     match
-      Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl__Bytes__raw_slice self._0
+      Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl_Bytes__raw_slice self._0
             ({
-                Core.Ops.Range.f_start = start +! sz 1 <: usize;
-                Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len self._0 <: usize
+                Core.Ops.Range.f_start = start +! mk_usize 1 <: usize;
+                Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len self._0 <: usize
               }
               <:
               Core.Ops.Range.t_Range usize)
           <:
           t_Slice u8)
+      <:
+      Core.Result.t_Result usize u8
     with
     | Core.Result.Result_Err _ -> false
     | Core.Result.Result_Ok len ->
@@ -271,6 +368,6 @@ let rec impl__HandshakeData__find_handshake_message
           (Bertie.Tls13utils.v_U8 (t_HandshakeType_cast_to_repr handshake_type <: u8) <: u8)
       then true
       else
-        impl__HandshakeData__find_handshake_message self
+        impl_HandshakeData__find_handshake_message self
           handshake_type
-          ((start +! sz 4 <: usize) +! len <: usize)
+          ((start +! mk_usize 4 <: usize) +! len <: usize)

--- a/proofs/fstar/extraction/Bertie.Tls13formats.Handshake_data.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13formats.Handshake_data.fsti
@@ -3,26 +3,28 @@ module Bertie.Tls13formats.Handshake_data
 open Core
 open FStar.Mul
 
-let discriminant_HandshakeType_Certificate: u8 = 11uy
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
 
-let discriminant_HandshakeType_CertificateRequest: u8 = 13uy
-
-let discriminant_HandshakeType_CertificateVerify: u8 = 15uy
-
-let discriminant_HandshakeType_ClientHello: u8 = 1uy
-
-let discriminant_HandshakeType_EncryptedExtensions: u8 = 8uy
-
-let discriminant_HandshakeType_EndOfEarlyData: u8 = 5uy
-
-let discriminant_HandshakeType_Finished: u8 = 20uy
-
-let discriminant_HandshakeType_KeyUpdate: u8 = 24uy
-
-let discriminant_HandshakeType_MessageHash: u8 = 254uy
-
-let discriminant_HandshakeType_NewSessionTicket: u8 = 4uy
-
+/// ```TLS
+/// enum {
+///     client_hello(1),
+///     server_hello(2),
+///     new_session_ticket(4),
+///     end_of_early_data(5),
+///     encrypted_extensions(8),
+///     certificate(11),
+///     certificate_request(13),
+///     certificate_verify(15),
+///     finished(20),
+///     key_update(24),
+///     message_hash(254),
+///     (255)
+/// } HandshakeType;
+/// ```
 type t_HandshakeType =
   | HandshakeType_ClientHello : t_HandshakeType
   | HandshakeType_ServerHello : t_HandshakeType
@@ -36,59 +38,115 @@ type t_HandshakeType =
   | HandshakeType_KeyUpdate : t_HandshakeType
   | HandshakeType_MessageHash : t_HandshakeType
 
-let discriminant_HandshakeType_ServerHello: u8 = 2uy
+let anon_const_HandshakeType_ClientHello__anon_const_0: u8 = mk_u8 1
+
+let anon_const_HandshakeType_ServerHello__anon_const_0: u8 = mk_u8 2
+
+let anon_const_HandshakeType_NewSessionTicket__anon_const_0: u8 = mk_u8 4
+
+let anon_const_HandshakeType_EndOfEarlyData__anon_const_0: u8 = mk_u8 5
+
+let anon_const_HandshakeType_EncryptedExtensions__anon_const_0: u8 = mk_u8 8
+
+let anon_const_HandshakeType_Certificate__anon_const_0: u8 = mk_u8 11
+
+let anon_const_HandshakeType_CertificateRequest__anon_const_0: u8 = mk_u8 13
+
+let anon_const_HandshakeType_CertificateVerify__anon_const_0: u8 = mk_u8 15
+
+let anon_const_HandshakeType_Finished__anon_const_0: u8 = mk_u8 20
+
+let anon_const_HandshakeType_KeyUpdate__anon_const_0: u8 = mk_u8 24
+
+let anon_const_HandshakeType_MessageHash__anon_const_0: u8 = mk_u8 254
 
 val t_HandshakeType_cast_to_repr (x: t_HandshakeType)
     : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_2:Core.Clone.t_Clone t_HandshakeType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_3:Core.Marker.t_Copy t_HandshakeType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_4:Core.Fmt.t_Debug t_HandshakeType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_5:Core.Marker.t_StructuralPartialEq t_HandshakeType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_6:Core.Cmp.t_PartialEq t_HandshakeType t_HandshakeType
+
 val get_hs_type (t: u8)
     : Prims.Pure (Core.Result.t_Result t_HandshakeType u8) Prims.l_True (fun _ -> Prims.l_True)
 
+/// Hadshake data of the TLS handshake.
 type t_HandshakeData = | HandshakeData : Bertie.Tls13utils.t_Bytes -> t_HandshakeData
 
-val impl__HandshakeData__len (self: t_HandshakeData)
+/// Returns the length, in bytes.
+val impl_HandshakeData__len (self: t_HandshakeData)
     : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__HandshakeData__next_handshake_message (self: t_HandshakeData)
+/// Returns the handshake data bytes.
+val impl_HandshakeData__to_bytes (self: t_HandshakeData)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Attempt to parse a handshake message from the beginning of the payload.
+/// If successful, returns the parsed message and the unparsed rest of the
+/// payload. Returns a [TLSError] if the payload is too short to contain a
+/// handshake message or if the payload is shorter than the expected length
+/// encoded in its first three bytes.
+val impl_HandshakeData__next_handshake_message (self: t_HandshakeData)
     : Prims.Pure (Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__HandshakeData__as_handshake_message
+/// Attempt to parse exactly one handshake message of the `expected_type` from
+/// `payload`.
+/// If successful, returns the parsed handshake message. Returns a [TLSError] if
+/// parsing is unsuccessful or the type of the parsed message disagrees with the
+/// expected type.
+val impl_HandshakeData__as_handshake_message
       (self: t_HandshakeData)
       (expected_type: t_HandshakeType)
     : Prims.Pure (Core.Result.t_Result t_HandshakeData u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__HandshakeData__to_bytes (self: t_HandshakeData)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__HandshakeData__to_four (self: t_HandshakeData)
-    : Prims.Pure
-      (Core.Result.t_Result (t_HandshakeData & t_HandshakeData & t_HandshakeData & t_HandshakeData)
-          u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__HandshakeData__to_two (self: t_HandshakeData)
+/// Attempt to parse exactly two handshake messages from `payload`.
+/// If successful, returns the parsed handshake messages. Returns a [TLSError]
+/// if parsing of either message fails or if the payload is not fully consumed
+/// by parsing two messages.
+val impl_HandshakeData__to_two (self: t_HandshakeData)
     : Prims.Pure (Core.Result.t_Result (t_HandshakeData & t_HandshakeData) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// Attempt to parse exactly four handshake messages from `payload`.
+/// If successful, returns the parsed handshake messages. Returns a [TLSError]
+/// if parsing of any message fails or if the payload is not fully consumed
+/// by parsing four messages.
+val impl_HandshakeData__to_four (self: t_HandshakeData)
+    : Prims.Pure
+      (Core.Result.t_Result (t_HandshakeData & t_HandshakeData & t_HandshakeData & t_HandshakeData)
+          u8) Prims.l_True (fun _ -> Prims.l_True)
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_1: Core.Convert.t_From t_HandshakeData Bertie.Tls13utils.t_Bytes =
-  {
-    f_from_pre = (fun (value: Bertie.Tls13utils.t_Bytes) -> true);
-    f_from_post = (fun (value: Bertie.Tls13utils.t_Bytes) (out: t_HandshakeData) -> true);
-    f_from = fun (value: Bertie.Tls13utils.t_Bytes) -> HandshakeData value <: t_HandshakeData
-  }
+val impl_1:Core.Convert.t_From t_HandshakeData Bertie.Tls13utils.t_Bytes
 
-val impl__HandshakeData__concat (self other: t_HandshakeData)
-    : Prims.Pure t_HandshakeData Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__HandshakeData__from_bytes
+/// Generate a new [`HandshakeData`] from [`Bytes`] and the [`HandshakeType`].
+val impl_HandshakeData__from_bytes
       (handshake_type: t_HandshakeType)
       (handshake_bytes: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result t_HandshakeData u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__HandshakeData__find_handshake_message
+/// Returns a new [`HandshakeData`] that contains the bytes of
+/// `other` appended to the bytes of `self`.
+val impl_HandshakeData__concat (self other: t_HandshakeData)
+    : Prims.Pure t_HandshakeData Prims.l_True (fun _ -> Prims.l_True)
+
+/// Beginning at offset `start`, attempt to find a message of type `handshake_type` in `payload`.
+/// Returns `true`` if `payload` contains a message of the given type, `false` otherwise.
+val impl_HandshakeData__find_handshake_message
       (self: t_HandshakeData)
       (handshake_type: t_HandshakeType)
       (start: usize)

--- a/proofs/fstar/extraction/Bertie.Tls13formats.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13formats.fst
@@ -3,132 +3,157 @@ module Bertie.Tls13formats
 open Core
 open FStar.Mul
 
-let t_AlertDescription_cast_to_repr (x: t_AlertDescription) =
-  match x with
-  | AlertDescription_CloseNotify  -> discriminant_AlertDescription_CloseNotify
-  | AlertDescription_UnexpectedMessage  -> discriminant_AlertDescription_UnexpectedMessage
-  | AlertDescription_BadRecordMac  -> discriminant_AlertDescription_BadRecordMac
-  | AlertDescription_RecordOverflow  -> discriminant_AlertDescription_RecordOverflow
-  | AlertDescription_HandshakeFailure  -> discriminant_AlertDescription_HandshakeFailure
-  | AlertDescription_BadCertificate  -> discriminant_AlertDescription_BadCertificate
-  | AlertDescription_UnsupportedCertificate  -> discriminant_AlertDescription_UnsupportedCertificate
-  | AlertDescription_CertificateRevoked  -> discriminant_AlertDescription_CertificateRevoked
-  | AlertDescription_CertificateExpired  -> discriminant_AlertDescription_CertificateExpired
-  | AlertDescription_CertificateUnknown  -> discriminant_AlertDescription_CertificateUnknown
-  | AlertDescription_IllegalParameter  -> discriminant_AlertDescription_IllegalParameter
-  | AlertDescription_UnknownCa  -> discriminant_AlertDescription_UnknownCa
-  | AlertDescription_AccessDenied  -> discriminant_AlertDescription_AccessDenied
-  | AlertDescription_DecodeError  -> discriminant_AlertDescription_DecodeError
-  | AlertDescription_DecryptError  -> discriminant_AlertDescription_DecryptError
-  | AlertDescription_ProtocolVersion  -> discriminant_AlertDescription_ProtocolVersion
-  | AlertDescription_InsufficientSecurity  -> discriminant_AlertDescription_InsufficientSecurity
-  | AlertDescription_InternalError  -> discriminant_AlertDescription_InternalError
-  | AlertDescription_InappropriateFallback  -> discriminant_AlertDescription_InappropriateFallback
-  | AlertDescription_UserCanceled  -> discriminant_AlertDescription_UserCanceled
-  | AlertDescription_MissingExtension  -> discriminant_AlertDescription_MissingExtension
-  | AlertDescription_UnsupportedExtension  -> discriminant_AlertDescription_UnsupportedExtension
-  | AlertDescription_UnrecognizedName  -> discriminant_AlertDescription_UnrecognizedName
-  | AlertDescription_BadCertificateStatusResponse  ->
-    discriminant_AlertDescription_BadCertificateStatusResponse
-  | AlertDescription_UnknownPskIdentity  -> discriminant_AlertDescription_UnknownPskIdentity
-  | AlertDescription_CertificateRequired  -> discriminant_AlertDescription_CertificateRequired
-  | AlertDescription_NoApplicationProtocol  -> discriminant_AlertDescription_NoApplicationProtocol
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
 
-let t_AlertLevel_cast_to_repr (x: t_AlertLevel) =
-  match x with
-  | AlertLevel_Warning  -> discriminant_AlertLevel_Warning
-  | AlertLevel_Fatal  -> discriminant_AlertLevel_Fatal
-
-let t_ContentType_cast_to_repr (x: t_ContentType) =
-  match x with
-  | ContentType_Invalid  -> discriminant_ContentType_Invalid
-  | ContentType_ChangeCipherSpec  -> discriminant_ContentType_ChangeCipherSpec
-  | ContentType_Alert  -> discriminant_ContentType_Alert
-  | ContentType_Handshake  -> discriminant_ContentType_Handshake
-  | ContentType_ApplicationData  -> discriminant_ContentType_ApplicationData
-
-let application_data_instead_of_handshake (_: Prims.unit) =
-  Core.Result.Result_Err Bertie.Tls13utils.v_APPLICATION_DATA_INSTEAD_OF_HANDSHAKE
-  <:
-  Core.Result.t_Result Prims.unit u8
-
-let invalid_compression_list (_: Prims.unit) =
-  Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_COMPRESSION_LIST
-  <:
-  Core.Result.t_Result Prims.unit u8
-
-let invalid_compression_method_alert (_: Prims.unit) =
-  Core.Result.Result_Err Bertie.Tls13utils.v_DECODE_ERROR <: Core.Result.t_Result Prims.unit u8
-
-let protocol_version_alert (_: Prims.unit) =
-  Core.Result.Result_Err Bertie.Tls13utils.v_PROTOCOL_VERSION_ALERT
-  <:
-  Core.Result.t_Result Prims.unit u8
-
-let unsupported_cipher_alert (_: Prims.unit) =
-  Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
-  <:
-  Core.Result.t_Result Prims.unit u8
-
-let impl__ContentType__try_from_u8 (t: u8) =
-  match t with
-  | 20uy ->
-    Core.Result.Result_Ok (ContentType_ChangeCipherSpec <: t_ContentType)
+let build_server_name (name: Bertie.Tls13utils.t_Bytes) =
+  match
+    Bertie.Tls13utils.encode_length_u16 (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+          #FStar.Tactics.Typeclasses.solve
+          name
+        <:
+        Bertie.Tls13utils.t_Bytes)
     <:
-    Core.Result.t_Result t_ContentType u8
-  | 21uy ->
-    Core.Result.Result_Ok (ContentType_Alert <: t_ContentType)
-    <:
-    Core.Result.t_Result t_ContentType u8
-  | 22uy ->
-    Core.Result.Result_Ok (ContentType_Handshake <: t_ContentType)
-    <:
-    Core.Result.t_Result t_ContentType u8
-  | 23uy ->
-    Core.Result.Result_Ok (ContentType_ApplicationData <: t_ContentType)
-    <:
-    Core.Result.t_Result t_ContentType u8
-  | _ ->
-    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
-    <:
-    Core.Result.t_Result t_ContentType u8
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist4 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl_Bytes__prefix hoist4
+              (build_server_name__v_PREFIX2 <: t_Slice u8)
+            <:
+            Bertie.Tls13utils.t_Bytes)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist7 ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 hoist7
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist9 ->
+            Core.Result.Result_Ok
+            (Bertie.Tls13utils.impl_Bytes__prefix hoist9
+                (build_server_name__v_PREFIX1 <: t_Slice u8))
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
-let check_r_len (rlen: usize) =
-  if rlen <. sz 32 || rlen >. sz 33
-  then
-    Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
+let check_server_name (extension: t_Slice u8) =
+  match
+    Bertie.Tls13utils.check_length_encoding_u16_slice extension
     <:
     Core.Result.t_Result Prims.unit u8
-  else Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
-
-let check_psk_key_exchange_modes (client_hello: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u8_slice client_hello with
+  with
   | Core.Result.Result_Ok _ ->
-    Bertie.Tls13utils.check_eq_with_slice (Rust_primitives.unsize (let list =
-              [Bertie.Tls13utils.v_U8 1uy <: u8]
-            in
-            FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-            Rust_primitives.Hax.array_of_list 1 list)
+    (match
+        Bertie.Tls13utils.check_eq_with_slice ((let list = [Bertie.Tls13utils.v_U8 (mk_u8 0)] in
+              FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+              Rust_primitives.Hax.array_of_list 1 list)
+            <:
+            t_Slice u8)
+          extension
+          (mk_usize 2)
+          (mk_usize 3)
+        <:
+        Core.Result.t_Result Prims.unit u8
+      with
+      | Core.Result.Result_Ok _ ->
+        (match
+            Bertie.Tls13utils.check_length_encoding_u16_slice (extension.[ {
+                    Core.Ops.Range.f_start = mk_usize 3;
+                    Core.Ops.Range.f_end = Core.Slice.impl__len #u8 extension <: usize
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            Core.Result.Result_Ok
+            (Core.Convert.f_into #(t_Slice u8)
+                #Bertie.Tls13utils.t_Bytes
+                #FStar.Tactics.Typeclasses.solve
+                (extension.[ {
+                      Core.Ops.Range.f_start = mk_usize 5;
+                      Core.Ops.Range.f_end = Core.Slice.impl__len #u8 extension <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8))
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let supported_versions (_: Prims.unit) =
+  match
+    Bertie.Tls13utils.encode_length_u8 ((let list =
+            [Bertie.Tls13utils.v_U8 (mk_u8 3); Bertie.Tls13utils.v_U8 (mk_u8 4)]
+          in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+          Rust_primitives.Hax.array_of_list 2 list)
         <:
         t_Slice u8)
-      client_hello
-      (sz 1)
-      (sz 2)
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist11 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 hoist11
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist13 ->
+        Core.Result.Result_Ok
+        (Bertie.Tls13utils.impl_Bytes__concat (Core.Convert.f_from #Bertie.Tls13utils.t_Bytes
+                #(t_Array u8 (mk_usize 2))
+                #FStar.Tactics.Typeclasses.solve
+                (let list = [mk_u8 0; mk_u8 43] in
+                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                  Rust_primitives.Hax.array_of_list 2 list)
+              <:
+              Bertie.Tls13utils.t_Bytes)
+            hoist13)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
 let check_supported_versions (client_hello: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u8_slice client_hello with
+  match
+    Bertie.Tls13utils.check_length_encoding_u8_slice client_hello
+    <:
+    Core.Result.t_Result Prims.unit u8
+  with
   | Core.Result.Result_Ok _ ->
-    Bertie.Tls13utils.check_mem (Rust_primitives.unsize (let list =
-              [Bertie.Tls13utils.v_U8 3uy <: u8; Bertie.Tls13utils.v_U8 4uy <: u8]
-            in
-            FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-            Rust_primitives.Hax.array_of_list 2 list)
+    Bertie.Tls13utils.check_mem ((let list =
+            [Bertie.Tls13utils.v_U8 (mk_u8 3); Bertie.Tls13utils.v_U8 (mk_u8 4)]
+          in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+          Rust_primitives.Hax.array_of_list 2 list)
         <:
         t_Slice u8)
       (client_hello.[ {
-            Core.Ops.Range.f_start = sz 1;
-            Core.Ops.Range.f_end = Core.Slice.impl__len client_hello <: usize
+            Core.Ops.Range.f_start = mk_usize 1;
+            Core.Ops.Range.f_end = Core.Slice.impl__len #u8 client_hello <: usize
           }
           <:
           Core.Ops.Range.t_Range usize ]
@@ -136,527 +161,55 @@ let check_supported_versions (client_hello: t_Slice u8) =
         t_Slice u8)
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
 
-let merge_opts (#v_T: Type) (o1 o2: Core.Option.t_Option v_T) =
-  match o1, o2 <: (Core.Option.t_Option v_T & Core.Option.t_Option v_T) with
-  | Core.Option.Option_None , Core.Option.Option_Some o ->
-    Core.Result.Result_Ok (Core.Option.Option_Some o <: Core.Option.t_Option v_T)
-    <:
-    Core.Result.t_Result (Core.Option.t_Option v_T) u8
-  | Core.Option.Option_Some o, Core.Option.Option_None  ->
-    Core.Result.Result_Ok (Core.Option.Option_Some o <: Core.Option.t_Option v_T)
-    <:
-    Core.Result.t_Result (Core.Option.t_Option v_T) u8
-  | Core.Option.Option_None , Core.Option.Option_None  ->
-    Core.Result.Result_Ok (Core.Option.Option_None <: Core.Option.t_Option v_T)
-    <:
-    Core.Result.t_Result (Core.Option.t_Option v_T) u8
-  | _ -> Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-
-let check_psk_shared_key (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
-  match Bertie.Tls13utils.length_u16_encoded ch with
-  | Core.Result.Result_Ok len_id ->
-    (match
-        Bertie.Tls13utils.length_u16_encoded (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = sz 2 +! len_id <: usize
-              }
-              <:
-              Core.Ops.Range.t_Range usize ]
-            <:
-            t_Slice u8)
-      with
-      | Core.Result.Result_Ok len_tkt ->
-        if len_id =. (len_tkt +! sz 6 <: usize)
-        then
-          match
-            Bertie.Tls13utils.check_length_encoding_u16_slice (ch.[ {
-                    Core.Ops.Range.f_start = sz 2 +! len_id <: usize;
-                    Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
-                  }
-                  <:
-                  Core.Ops.Range.t_Range usize ]
-                <:
-                t_Slice u8)
-          with
-          | Core.Result.Result_Ok _ ->
-            (match
-                Bertie.Tls13utils.check_length_encoding_u8_slice (ch.[ {
-                        Core.Ops.Range.f_start = sz 4 +! len_id <: usize;
-                        Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
-                      }
-                      <:
-                      Core.Ops.Range.t_Range usize ]
-                    <:
-                    t_Slice u8)
-              with
-              | Core.Result.Result_Ok _ ->
-                if
-                  (((Core.Slice.impl__len ch <: usize) -! sz 5 <: usize) -! len_id <: usize) <>.
-                  (Bertie.Tls13crypto.impl__HashAlgorithm__hash_len (Bertie.Tls13crypto.impl__Algorithms__hash
-                          algs
-                        <:
-                        Bertie.Tls13crypto.t_HashAlgorithm)
-                    <:
-                    usize)
-                then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-                else Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
-        else Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
-
-let check_server_psk_shared_key (v__algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  Bertie.Tls13utils.check_eq_slice (Rust_primitives.unsize (let list =
-            [Bertie.Tls13utils.v_U8 0uy <: u8; Bertie.Tls13utils.v_U8 0uy <: u8]
-          in
-          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-          Rust_primitives.Hax.array_of_list 2 list)
-      <:
-      t_Slice u8)
-    b
-
-let check_server_supported_version (v__algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  Bertie.Tls13utils.check_eq_slice (Rust_primitives.unsize (let list =
-            [Bertie.Tls13utils.v_U8 3uy <: u8; Bertie.Tls13utils.v_U8 4uy <: u8]
-          in
-          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-          Rust_primitives.Hax.array_of_list 2 list)
-      <:
-      t_Slice u8)
-    b
-
-let check_server_name (extension: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u16_slice extension with
-  | Core.Result.Result_Ok _ ->
-    (match
-        Bertie.Tls13utils.check_eq_with_slice (Rust_primitives.unsize (let list =
-                  [Bertie.Tls13utils.v_U8 0uy <: u8]
-                in
-                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                Rust_primitives.Hax.array_of_list 1 list)
-            <:
-            t_Slice u8)
-          extension
-          (sz 2)
-          (sz 3)
-      with
-      | Core.Result.Result_Ok _ ->
-        (match
-            Bertie.Tls13utils.check_length_encoding_u16_slice (extension.[ {
-                    Core.Ops.Range.f_start = sz 3;
-                    Core.Ops.Range.f_end = Core.Slice.impl__len extension <: usize
-                  }
-                  <:
-                  Core.Ops.Range.t_Range usize ]
-                <:
-                t_Slice u8)
-          with
-          | Core.Result.Result_Ok _ ->
-            Core.Result.Result_Ok
-            (Core.Convert.f_into (extension.[ {
-                      Core.Ops.Range.f_start = sz 5;
-                      Core.Ops.Range.f_end = Core.Slice.impl__len extension <: usize
-                    }
-                    <:
-                    Core.Ops.Range.t_Range usize ]
-                  <:
-                  t_Slice u8))
-            <:
-            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let check_server_key_share (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-  | Core.Result.Result_Ok hoist21 ->
-    (match
-        Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw hoist21
-            <:
-            t_Slice u8)
-          b
-          (sz 0)
-          (sz 2)
-      with
-      | Core.Result.Result_Ok _ ->
-        (match
-            Bertie.Tls13utils.check_length_encoding_u16_slice (b.[ {
-                    Core.Ops.Range.f_start = sz 2;
-                    Core.Ops.Range.f_end = Core.Slice.impl__len b <: usize
-                  }
-                  <:
-                  Core.Ops.Range.t_Range usize ]
-                <:
-                t_Slice u8)
-          with
-          | Core.Result.Result_Ok _ ->
-            Core.Result.Result_Ok
-            (Core.Convert.f_from (b.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = Core.Slice.impl__len b <: usize
-                    }
-                    <:
-                    Core.Ops.Range.t_Range usize ]
-                  <:
-                  t_Slice u8))
-            <:
-            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let check_server_extension (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  Rust_primitives.Hax.Control_flow_monad.Mexception.run (if
-        (Core.Slice.impl__len b <: usize) <. sz 4 <: bool
-      then
-        Core.Ops.Control_flow.ControlFlow_Continue
-        (Core.Result.Result_Err (Bertie.Tls13utils.parse_failed () <: u8)
-          <:
-          Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+let server_supported_version (e_algorithms: Bertie.Tls13crypto.t_Algorithms) =
+  match
+    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 4)
         <:
-        Core.Ops.Control_flow.t_ControlFlow
-          (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-          (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-      else
-        let l0:usize = cast (Bertie.Tls13utils.f_declassify (b.[ sz 0 ] <: u8) <: u8) <: usize in
-        let l1:usize = cast (Bertie.Tls13utils.f_declassify (b.[ sz 1 ] <: u8) <: u8) <: usize in
-        match
-          Bertie.Tls13utils.length_u16_encoded (b.[ {
-                  Core.Ops.Range.f_start = sz 2;
-                  Core.Ops.Range.f_end = Core.Slice.impl__len b <: usize
-                }
-                <:
-                Core.Ops.Range.t_Range usize ]
-              <:
-              t_Slice u8)
-        with
-        | Core.Result.Result_Ok len ->
-          let out:Core.Option.t_Option Bertie.Tls13utils.t_Bytes =
-            Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes
-          in
-          let! out:Core.Option.t_Option Bertie.Tls13utils.t_Bytes =
-            match (cast (l0 <: usize) <: u8), (cast (l1 <: usize) <: u8) <: (u8 & u8) with
-            | 0uy, 43uy ->
-              (match
-                  check_server_supported_version algs
-                    (b.[ {
-                          Core.Ops.Range.f_start = sz 4;
-                          Core.Ops.Range.f_end = sz 4 +! len <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize ]
-                      <:
-                      t_Slice u8)
-                with
-                | Core.Result.Result_Ok ok ->
-                  Core.Ops.Control_flow.ControlFlow_Continue out
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                | Core.Result.Result_Err err ->
-                  let! _:Prims.unit =
-                    Core.Ops.Control_flow.ControlFlow_Break
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                          u8) Prims.unit
-                  in
-                  Core.Ops.Control_flow.ControlFlow_Continue out
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
-            | 0uy, 51uy ->
-              (match
-                  check_server_key_share algs
-                    (b.[ {
-                          Core.Ops.Range.f_start = sz 4;
-                          Core.Ops.Range.f_end = sz 4 +! len <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize ]
-                      <:
-                      t_Slice u8)
-                with
-                | Core.Result.Result_Ok gx ->
-                  Core.Ops.Control_flow.ControlFlow_Continue
-                  (Core.Option.Option_Some gx <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                | Core.Result.Result_Err err ->
-                  let! _:Prims.unit =
-                    Core.Ops.Control_flow.ControlFlow_Break
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                          u8) Prims.unit
-                  in
-                  Core.Ops.Control_flow.ControlFlow_Continue out
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
-            | 0uy, 41uy ->
-              (match
-                  check_server_psk_shared_key algs
-                    (b.[ {
-                          Core.Ops.Range.f_start = sz 4;
-                          Core.Ops.Range.f_end = sz 4 +! len <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize ]
-                      <:
-                      t_Slice u8)
-                with
-                | Core.Result.Result_Ok ok ->
-                  Core.Ops.Control_flow.ControlFlow_Continue out
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                | Core.Result.Result_Err err ->
-                  let! _:Prims.unit =
-                    Core.Ops.Control_flow.ControlFlow_Break
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                          u8) Prims.unit
-                  in
-                  Core.Ops.Control_flow.ControlFlow_Continue out
-                  <:
-                  Core.Ops.Control_flow.t_ControlFlow
-                    (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                        u8) (Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
-            | _ ->
-              Core.Ops.Control_flow.ControlFlow_Continue out
-              <:
-              Core.Ops.Control_flow.t_ControlFlow
-                (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-                (Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-          in
-          Core.Ops.Control_flow.ControlFlow_Continue
-          (Core.Result.Result_Ok
-            (sz 4 +! len, out <: (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
-            <:
-            Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-          <:
-          Core.Ops.Control_flow.t_ControlFlow
-            (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-            (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-        | Core.Result.Result_Err err ->
-          Core.Ops.Control_flow.ControlFlow_Continue
-          (Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-          <:
-          Core.Ops.Control_flow.t_ControlFlow
-            (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-            (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8))
-
-let check_signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u16_slice ch with
-  | Core.Result.Result_Ok _ ->
-    (match Bertie.Tls13crypto.impl__Algorithms__signature_algorithm algs with
-      | Core.Result.Result_Ok hoist24 ->
-        Bertie.Tls13utils.check_mem (Bertie.Tls13utils.impl__Bytes__as_raw hoist24 <: t_Slice u8)
-          (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
-              }
-              <:
-              Core.Ops.Range.t_Range usize ]
-            <:
-            t_Slice u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
-
-let check_supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u16_slice ch with
-  | Core.Result.Result_Ok _ ->
-    (match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-      | Core.Result.Result_Ok hoist26 ->
-        Bertie.Tls13utils.check_mem (Bertie.Tls13utils.impl__Bytes__as_raw hoist26 <: t_Slice u8)
-          (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
-              }
-              <:
-              Core.Ops.Range.t_Range usize ]
-            <:
-            t_Slice u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
-
-let parse_ecdsa_signature (sig: Bertie.Tls13utils.t_Bytes) =
-  if (Bertie.Tls13utils.impl__Bytes__len sig <: usize) <. sz 4
-  then
-    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+        Bertie.Tls13utils.t_Bytes)
     <:
     Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  else
-    match
-      Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 48uy <: Bertie.Tls13utils.t_Bytes)
-        (Bertie.Tls13utils.impl__Bytes__slice_range sig
-            ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 1 }
-              <:
-              Core.Ops.Range.t_Range usize)
-          <:
-          Bertie.Tls13utils.t_Bytes)
-    with
-    | Core.Result.Result_Ok _ ->
-      (match
-          Bertie.Tls13utils.check_length_encoding_u8 (Bertie.Tls13utils.impl__Bytes__slice_range sig
-                ({
-                    Core.Ops.Range.f_start = sz 1;
-                    Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sig <: usize
-                  }
-                  <:
-                  Core.Ops.Range.t_Range usize)
-              <:
-              Bertie.Tls13utils.t_Bytes)
-        with
-        | Core.Result.Result_Ok _ ->
-          (match
-              Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 2uy <: Bertie.Tls13utils.t_Bytes)
-                (Bertie.Tls13utils.impl__Bytes__slice_range sig
-                    ({ Core.Ops.Range.f_start = sz 2; Core.Ops.Range.f_end = sz 3 }
-                      <:
-                      Core.Ops.Range.t_Range usize)
-                  <:
-                  Bertie.Tls13utils.t_Bytes)
-            with
-            | Core.Result.Result_Ok _ ->
-              (match
-                  Bertie.Tls13utils.length_u8_encoded (sig.[ {
-                          Core.Ops.Range.f_start = sz 3;
-                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sig <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize ]
-                      <:
-                      t_Slice u8)
-                with
-                | Core.Result.Result_Ok rlen ->
-                  (match check_r_len rlen with
-                    | Core.Result.Result_Ok _ ->
-                      let r:Bertie.Tls13utils.t_Bytes =
-                        Bertie.Tls13utils.impl__Bytes__slice sig
-                          ((sz 4 +! rlen <: usize) -! sz 32 <: usize)
-                          (sz 32)
-                      in
-                      if
-                        (Bertie.Tls13utils.impl__Bytes__len sig <: usize) <.
-                        ((sz 6 +! rlen <: usize) +! sz 32 <: usize)
-                      then
-                        Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
-                        <:
-                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-                      else
-                        (match
-                            Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 2uy
-                                <:
-                                Bertie.Tls13utils.t_Bytes)
-                              (Bertie.Tls13utils.impl__Bytes__slice_range sig
-                                  ({
-                                      Core.Ops.Range.f_start = sz 4 +! rlen <: usize;
-                                      Core.Ops.Range.f_end = sz 5 +! rlen <: usize
-                                    }
-                                    <:
-                                    Core.Ops.Range.t_Range usize)
-                                <:
-                                Bertie.Tls13utils.t_Bytes)
-                          with
-                          | Core.Result.Result_Ok _ ->
-                            (match
-                                Bertie.Tls13utils.check_length_encoding_u8 (Bertie.Tls13utils.impl__Bytes__slice_range
-                                      sig
-                                      ({
-                                          Core.Ops.Range.f_start = sz 5 +! rlen <: usize;
-                                          Core.Ops.Range.f_end
-                                          =
-                                          Bertie.Tls13utils.impl__Bytes__len sig <: usize
-                                        }
-                                        <:
-                                        Core.Ops.Range.t_Range usize)
-                                    <:
-                                    Bertie.Tls13utils.t_Bytes)
-                              with
-                              | Core.Result.Result_Ok _ ->
-                                let s:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__slice sig
-                                    ((Bertie.Tls13utils.impl__Bytes__len sig <: usize) -! sz 32
-                                      <:
-                                      usize)
-                                    (sz 32)
-                                in
-                                Core.Result.Result_Ok (Bertie.Tls13utils.impl__Bytes__concat r s)
-                                <:
-                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-                              | Core.Result.Result_Err err ->
-                                Core.Result.Result_Err err
-                                <:
-                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                          | Core.Result.Result_Err err ->
-                            Core.Result.Result_Err err
-                            <:
-                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                    | Core.Result.Result_Err err ->
-                      Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                | Core.Result.Result_Err err ->
-                  Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-            | Core.Result.Result_Err err ->
-              Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-        | Core.Result.Result_Err err ->
-          Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-    | Core.Result.Result_Err err ->
-      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let build_server_name (name: Bertie.Tls13utils.t_Bytes) =
-  match
-    Bertie.Tls13utils.encode_length_u16 (Core.Clone.f_clone name <: Bertie.Tls13utils.t_Bytes)
   with
-  | Core.Result.Result_Ok hoist50 ->
+  | Core.Result.Result_Ok hoist15 ->
+    Core.Result.Result_Ok
+    (Bertie.Tls13utils.impl_Bytes__prefix hoist15
+        (server_supported_version__v_SUPPORTED_VERSION_PREFIX <: t_Slice u8))
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let check_server_supported_version (e_algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
+  Bertie.Tls13utils.check_eq_slice ((let list =
+          [Bertie.Tls13utils.v_U8 (mk_u8 3); Bertie.Tls13utils.v_U8 (mk_u8 4)]
+        in
+        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+        Rust_primitives.Hax.array_of_list 2 list)
+      <:
+      t_Slice u8)
+    b
+
+let supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) =
+  match
+    Bertie.Tls13crypto.impl_Algorithms__supported_group algs
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist17 ->
     (match
-        Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl__Bytes__prefix hoist50
-              (Rust_primitives.unsize build_server_name__PREFIX2 <: t_Slice u8)
-            <:
-            Bertie.Tls13utils.t_Bytes)
+        Bertie.Tls13utils.encode_length_u16 hoist17
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
-      | Core.Result.Result_Ok hoist53 ->
-        (match Bertie.Tls13utils.encode_length_u16 hoist53 with
-          | Core.Result.Result_Ok hoist55 ->
+      | Core.Result.Result_Ok hoist19 ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 hoist19
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist21 ->
             Core.Result.Result_Ok
-            (Bertie.Tls13utils.impl__Bytes__prefix hoist55
-                (Rust_primitives.unsize build_server_name__PREFIX1 <: t_Slice u8))
+            (Bertie.Tls13utils.impl_Bytes__prefix hoist21
+                (supported_groups__v_SUPPORTED_GROUPS_PREFIX <: t_Slice u8))
             <:
             Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           | Core.Result.Result_Err err ->
@@ -666,19 +219,157 @@ let build_server_name (name: Bertie.Tls13utils.t_Bytes) =
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
+let check_supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
+  match
+    Bertie.Tls13utils.check_length_encoding_u16_slice ch <: Core.Result.t_Result Prims.unit u8
+  with
+  | Core.Result.Result_Ok _ ->
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__supported_group algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist23 ->
+        Bertie.Tls13utils.check_mem (Bertie.Tls13utils.impl_Bytes__as_raw hoist23 <: t_Slice u8)
+          (ch.[ {
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+
+let signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) =
+  match
+    Bertie.Tls13crypto.impl_Algorithms__signature_algorithm algs
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist25 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 hoist25
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist27 ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 hoist27
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist29 ->
+            Core.Result.Result_Ok
+            (Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.bytes2 (mk_u8 0) (mk_u8 13)
+                  <:
+                  Bertie.Tls13utils.t_Bytes)
+                hoist29)
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let check_signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
+  match
+    Bertie.Tls13utils.check_length_encoding_u16_slice ch <: Core.Result.t_Result Prims.unit u8
+  with
+  | Core.Result.Result_Ok _ ->
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__signature_algorithm algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist31 ->
+        Bertie.Tls13utils.check_mem (Bertie.Tls13utils.impl_Bytes__as_raw hoist31 <: t_Slice u8)
+          (ch.[ {
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+
+let psk_key_exchange_modes (_: Prims.unit) =
+  match
+    Bertie.Tls13utils.encode_length_u8 ((let list = [Bertie.Tls13utils.v_U8 (mk_u8 1)] in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+          Rust_primitives.Hax.array_of_list 1 list)
+        <:
+        t_Slice u8)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist33 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 hoist33
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist35 ->
+        Core.Result.Result_Ok
+        (Bertie.Tls13utils.impl_Bytes__prefix hoist35
+            (psk_key_exchange_modes__v_PSK_MODE_PREFIX <: t_Slice u8))
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let check_psk_key_exchange_modes (client_hello: t_Slice u8) =
+  match
+    Bertie.Tls13utils.check_length_encoding_u8_slice client_hello
+    <:
+    Core.Result.t_Result Prims.unit u8
+  with
+  | Core.Result.Result_Ok _ ->
+    Bertie.Tls13utils.check_eq_with_slice ((let list = [Bertie.Tls13utils.v_U8 (mk_u8 1)] in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+          Rust_primitives.Hax.array_of_list 1 list)
+        <:
+        t_Slice u8)
+      client_hello
+      (mk_usize 1)
+      (mk_usize 2)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+
 let key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes) =
-  match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-  | Core.Result.Result_Ok hoist58 ->
-    (match Bertie.Tls13utils.encode_length_u16 gx with
-      | Core.Result.Result_Ok hoist57 ->
-        let ks:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl__Bytes__concat hoist58 hoist57 in
-        (match Bertie.Tls13utils.encode_length_u16 ks with
-          | Core.Result.Result_Ok hoist59 ->
-            (match Bertie.Tls13utils.encode_length_u16 hoist59 with
-              | Core.Result.Result_Ok hoist61 ->
+  match
+    Bertie.Tls13crypto.impl_Algorithms__supported_group algs
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist38 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 gx <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist37 ->
+        let ks:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl_Bytes__concat hoist38 hoist37 in
+        (match
+            Bertie.Tls13utils.encode_length_u16 ks
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist39 ->
+            (match
+                Bertie.Tls13utils.encode_length_u16 hoist39
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok hoist41 ->
                 Core.Result.Result_Ok
-                (Bertie.Tls13utils.impl__Bytes__prefix hoist61
-                    (Rust_primitives.unsize key_shares__PREFIX <: t_Slice u8))
+                (Bertie.Tls13utils.impl_Bytes__prefix hoist41 (key_shares__v_PREFIX <: t_Slice u8))
                 <:
                 Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
               | Core.Result.Result_Err err ->
@@ -691,18 +382,28 @@ let key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
 let server_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes) =
-  match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-  | Core.Result.Result_Ok hoist64 ->
-    (match Bertie.Tls13utils.encode_length_u16 gx with
-      | Core.Result.Result_Ok hoist63 ->
-        let ks:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl__Bytes__concat hoist64 hoist63 in
-        (match Bertie.Tls13utils.encode_length_u16 ks with
-          | Core.Result.Result_Ok hoist65 ->
+  match
+    Bertie.Tls13crypto.impl_Algorithms__supported_group algs
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist45 ->
+    (match
+        Bertie.Tls13utils.encode_length_u16 gx <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist44 ->
+        let ks:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl_Bytes__concat hoist45 hoist44 in
+        (match
+            Bertie.Tls13utils.encode_length_u16 ks
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist46 ->
             Core.Result.Result_Ok
-            (Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.bytes2 0uy 51uy
+            (Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.bytes2 (mk_u8 0) (mk_u8 51)
                   <:
                   Bertie.Tls13utils.t_Bytes)
-                hoist65)
+                hoist46)
             <:
             Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           | Core.Result.Result_Err err ->
@@ -712,50 +413,49 @@ let server_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13u
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
-let server_pre_shared_key (v__algs: Bertie.Tls13crypto.t_Algorithms) =
+let check_server_key_share (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
   match
-    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.bytes2 0uy 0uy
-        <:
-        Bertie.Tls13utils.t_Bytes)
-  with
-  | Core.Result.Result_Ok hoist67 ->
-    Core.Result.Result_Ok
-    (Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.bytes2 0uy 41uy
-          <:
-          Bertie.Tls13utils.t_Bytes)
-        hoist67)
+    Bertie.Tls13crypto.impl_Algorithms__supported_group algs
     <:
     Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let server_supported_version (v__algorithms: Bertie.Tls13crypto.t_Algorithms) =
-  match
-    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.bytes2 3uy 4uy
-        <:
-        Bertie.Tls13utils.t_Bytes)
   with
-  | Core.Result.Result_Ok hoist69 ->
-    Core.Result.Result_Ok
-    (Bertie.Tls13utils.impl__Bytes__prefix hoist69
-        (Rust_primitives.unsize server_supported_version__SUPPORTED_VERSION_PREFIX <: t_Slice u8))
-    <:
-    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) =
-  match Bertie.Tls13crypto.impl__Algorithms__signature_algorithm algs with
-  | Core.Result.Result_Ok hoist71 ->
-    (match Bertie.Tls13utils.encode_length_u16 hoist71 with
-      | Core.Result.Result_Ok hoist73 ->
-        (match Bertie.Tls13utils.encode_length_u16 hoist73 with
-          | Core.Result.Result_Ok hoist75 ->
-            Core.Result.Result_Ok
-            (Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.bytes2 0uy 13uy
+  | Core.Result.Result_Ok hoist48 ->
+    (match
+        Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw hoist48
+            <:
+            t_Slice u8)
+          b
+          (mk_usize 0)
+          (mk_usize 2)
+        <:
+        Core.Result.t_Result Prims.unit u8
+      with
+      | Core.Result.Result_Ok _ ->
+        (match
+            Bertie.Tls13utils.check_length_encoding_u16_slice (b.[ {
+                    Core.Ops.Range.f_start = mk_usize 2;
+                    Core.Ops.Range.f_end = Core.Slice.impl__len #u8 b <: usize
+                  }
                   <:
-                  Bertie.Tls13utils.t_Bytes)
-                hoist75)
+                  Core.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            Core.Result.Result_Ok
+            (Core.Convert.f_from #Bertie.Tls13utils.t_Bytes
+                #(t_Slice u8)
+                #FStar.Tactics.Typeclasses.solve
+                (b.[ {
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = Core.Slice.impl__len #u8 b <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8))
             <:
             Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           | Core.Result.Result_Err err ->
@@ -764,140 +464,69 @@ let signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) =
         Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) =
-  match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-  | Core.Result.Result_Ok hoist77 ->
-    (match Bertie.Tls13utils.encode_length_u16 hoist77 with
-      | Core.Result.Result_Ok hoist79 ->
-        (match Bertie.Tls13utils.encode_length_u16 hoist79 with
-          | Core.Result.Result_Ok hoist81 ->
-            Core.Result.Result_Ok
-            (Bertie.Tls13utils.impl__Bytes__prefix hoist81
-                (Rust_primitives.unsize supported_groups__SUPPORTED_GROUPS_PREFIX <: t_Slice u8))
-            <:
-            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let ecdsa_signature (sv: Bertie.Tls13utils.t_Bytes) =
-  if (Bertie.Tls13utils.impl__Bytes__len sv <: usize) <>. sz 64
-  then
-    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
-    <:
-    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  else
-    let b0:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 0uy in
-    let b1:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 48uy in
-    let b2:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 2uy in
-    let (r: Bertie.Tls13utils.t_Bytes):Bertie.Tls13utils.t_Bytes =
-      Bertie.Tls13utils.impl__Bytes__slice sv (sz 0) (sz 32)
-    in
-    let (s: Bertie.Tls13utils.t_Bytes):Bertie.Tls13utils.t_Bytes =
-      Bertie.Tls13utils.impl__Bytes__slice sv (sz 32) (sz 32)
-    in
-    let r:Bertie.Tls13utils.t_Bytes =
-      if (Bertie.Tls13utils.f_declassify (r.[ sz 0 ] <: u8) <: u8) >=. 128uy
-      then
-        let r:Bertie.Tls13utils.t_Bytes =
-          Bertie.Tls13utils.impl__Bytes__concat (Core.Clone.f_clone b0 <: Bertie.Tls13utils.t_Bytes)
-            r
-        in
-        r
-      else r
-    in
-    let s:Bertie.Tls13utils.t_Bytes =
-      if (Bertie.Tls13utils.f_declassify (s.[ sz 0 ] <: u8) <: u8) >=. 128uy
-      then
-        let s:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl__Bytes__concat b0 s in
-        s
-      else s
-    in
-    match
-      Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw r <: t_Slice u8)
-    with
-    | Core.Result.Result_Ok hoist83 ->
-      (match
-          Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw s <: t_Slice u8)
-        with
-        | Core.Result.Result_Ok hoist85 ->
-          (match
-              Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw (Bertie.Tls13utils.impl__Bytes__concat
-                        (Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__concat
-                                (Core.Clone.f_clone b2 <: Bertie.Tls13utils.t_Bytes)
-                                hoist83
-                              <:
-                              Bertie.Tls13utils.t_Bytes)
-                            b2
-                          <:
-                          Bertie.Tls13utils.t_Bytes)
-                        hoist85
-                      <:
-                      Bertie.Tls13utils.t_Bytes)
-                  <:
-                  t_Slice u8)
-            with
-            | Core.Result.Result_Ok hoist90 ->
-              Core.Result.Result_Ok (Bertie.Tls13utils.impl__Bytes__concat b1 hoist90)
-              <:
-              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-            | Core.Result.Result_Err err ->
-              Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-        | Core.Result.Result_Err err ->
-          Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-    | Core.Result.Result_Err err ->
-      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
 let pre_shared_key
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (session_ticket: Bertie.Tls13utils.t_Bytes)
      =
   match
-    Bertie.Tls13utils.encode_length_u16 (Core.Clone.f_clone session_ticket
+    Bertie.Tls13utils.encode_length_u16 (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+          #FStar.Tactics.Typeclasses.solve
+          session_ticket
         <:
         Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
-  | Core.Result.Result_Ok hoist92 ->
+  | Core.Result.Result_Ok hoist51 ->
     (match
-        Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl__Bytes__concat_array (sz 4)
-              hoist92
-              (Bertie.Tls13utils.u32_as_be_bytes (Bertie.Tls13utils.v_U32 4294967295ul <: u32)
+        Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl_Bytes__concat_array (mk_usize 4)
+              hoist51
+              (Bertie.Tls13utils.u32_as_be_bytes (Bertie.Tls13utils.v_U32 (mk_u32 4294967295) <: u32
+                  )
                 <:
-                t_Array u8 (sz 4))
+                t_Array u8 (mk_usize 4))
             <:
             Bertie.Tls13utils.t_Bytes)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
       | Core.Result.Result_Ok identities ->
         (match
-            Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw (Bertie.Tls13crypto.zero_key
-                      (Bertie.Tls13crypto.impl__Algorithms__hash algs
+            Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw (Bertie.Tls13crypto.zero_key
+                      (Bertie.Tls13crypto.impl_Algorithms__hash algs
                         <:
                         Bertie.Tls13crypto.t_HashAlgorithm)
                     <:
                     Bertie.Tls13utils.t_Bytes)
                 <:
                 t_Slice u8)
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           with
-          | Core.Result.Result_Ok hoist95 ->
-            (match Bertie.Tls13utils.encode_length_u16 hoist95 with
+          | Core.Result.Result_Ok hoist54 ->
+            (match
+                Bertie.Tls13utils.encode_length_u16 hoist54
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
               | Core.Result.Result_Ok binders ->
-                let binders_len:usize = Bertie.Tls13utils.impl__Bytes__len binders in
+                let binders_len:usize = Bertie.Tls13utils.impl_Bytes__len binders in
                 (match
-                    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl__Bytes__concat identities
+                    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl_Bytes__concat identities
                           binders
                         <:
                         Bertie.Tls13utils.t_Bytes)
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                   with
-                  | Core.Result.Result_Ok hoist97 ->
+                  | Core.Result.Result_Ok hoist56 ->
                     let ext:Bertie.Tls13utils.t_Bytes =
-                      Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.bytes2 0uy 41uy
+                      Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.bytes2 (mk_u8 0)
+                            (mk_u8 41)
                           <:
                           Bertie.Tls13utils.t_Bytes)
-                        hoist97
+                        hoist56
                     in
                     Core.Result.Result_Ok (ext, binders_len <: (Bertie.Tls13utils.t_Bytes & usize))
                     <:
@@ -919,95 +548,144 @@ let pre_shared_key
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & usize) u8
 
-let psk_key_exchange_modes (_: Prims.unit) =
-  match
-    Bertie.Tls13utils.encode_length_u8 (Rust_primitives.unsize (let list =
-              [Bertie.Tls13utils.v_U8 1uy <: u8]
-            in
-            FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-            Rust_primitives.Hax.array_of_list 1 list)
-        <:
-        t_Slice u8)
-  with
-  | Core.Result.Result_Ok hoist98 ->
-    (match Bertie.Tls13utils.encode_length_u16 hoist98 with
-      | Core.Result.Result_Ok hoist100 ->
-        Core.Result.Result_Ok
-        (Bertie.Tls13utils.impl__Bytes__prefix hoist100
-            (Rust_primitives.unsize psk_key_exchange_modes__PSK_MODE_PREFIX <: t_Slice u8))
-        <:
-        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let get_psk_extensions
-      (algorithms: Bertie.Tls13crypto.t_Algorithms)
-      (session_ticket extensions: Bertie.Tls13utils.t_Bytes)
-     =
-  match psk_key_exchange_modes () with
-  | Core.Result.Result_Ok pskm ->
-    (match pre_shared_key algorithms session_ticket with
-      | Core.Result.Result_Ok (psk, len) ->
-        let extensions:Bertie.Tls13utils.t_Bytes =
-          Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__concat extensions
-                pskm
+let check_psk_shared_key (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
+  match Bertie.Tls13utils.length_u16_encoded ch <: Core.Result.t_Result usize u8 with
+  | Core.Result.Result_Ok len_id ->
+    (match
+        Bertie.Tls13utils.length_u16_encoded (ch.[ {
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = mk_usize 2 +! len_id <: usize
+              }
               <:
-              Bertie.Tls13utils.t_Bytes)
-            psk
-        in
-        Core.Result.Result_Ok (len, extensions <: (usize & Bertie.Tls13utils.t_Bytes))
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
         <:
-        Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
-
-let supported_versions (_: Prims.unit) =
-  match
-    Bertie.Tls13utils.encode_length_u8 (Rust_primitives.unsize (let list =
-              [Bertie.Tls13utils.v_U8 3uy <: u8; Bertie.Tls13utils.v_U8 4uy <: u8]
-            in
-            FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-            Rust_primitives.Hax.array_of_list 2 list)
-        <:
-        t_Slice u8)
-  with
-  | Core.Result.Result_Ok hoist102 ->
-    (match Bertie.Tls13utils.encode_length_u16 hoist102 with
-      | Core.Result.Result_Ok hoist104 ->
-        Core.Result.Result_Ok
-        (Bertie.Tls13utils.impl__Bytes__concat (Core.Convert.f_from (let list = [0uy; 43uy] in
-                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-                  Rust_primitives.Hax.array_of_list 2 list)
-              <:
-              Bertie.Tls13utils.t_Bytes)
-            hoist104)
-        <:
-        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let impl__Extensions__merge (self e2: t_Extensions) =
-  match merge_opts self.f_sni e2.f_sni with
-  | Core.Result.Result_Ok hoist136 ->
-    (match merge_opts self.f_key_share e2.f_key_share with
-      | Core.Result.Result_Ok hoist135 ->
-        (match merge_opts self.f_ticket e2.f_ticket with
-          | Core.Result.Result_Ok hoist134 ->
-            (match merge_opts self.f_binder e2.f_binder with
-              | Core.Result.Result_Ok hoist133 ->
-                Core.Result.Result_Ok
-                ({
-                    f_sni = hoist136;
-                    f_key_share = hoist135;
-                    f_ticket = hoist134;
-                    f_binder = hoist133
+        Core.Result.t_Result usize u8
+      with
+      | Core.Result.Result_Ok len_tkt ->
+        if len_id =. (len_tkt +! mk_usize 6 <: usize)
+        then
+          match
+            Bertie.Tls13utils.check_length_encoding_u16_slice (ch.[ {
+                    Core.Ops.Range.f_start = mk_usize 2 +! len_id <: usize;
+                    Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
                   }
+                  <:
+                  Core.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            (match
+                Bertie.Tls13utils.check_length_encoding_u8_slice (ch.[ {
+                        Core.Ops.Range.f_start = mk_usize 4 +! len_id <: usize;
+                        Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
+                      }
+                      <:
+                      Core.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                <:
+                Core.Result.t_Result Prims.unit u8
+              with
+              | Core.Result.Result_Ok _ ->
+                if
+                  (((Core.Slice.impl__len #u8 ch <: usize) -! mk_usize 5 <: usize) -! len_id
+                    <:
+                    usize) <>.
+                  (Bertie.Tls13crypto.impl_HashAlgorithm__hash_len (Bertie.Tls13crypto.impl_Algorithms__hash
+                          algs
+                        <:
+                        Bertie.Tls13crypto.t_HashAlgorithm)
+                    <:
+                    usize)
+                then Bertie.Tls13utils.tlserr #Prims.unit (Bertie.Tls13utils.parse_failed () <: u8)
+                else Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+        else Bertie.Tls13utils.tlserr #Prims.unit (Bertie.Tls13utils.parse_failed () <: u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+
+let server_pre_shared_key (e_algs: Bertie.Tls13crypto.t_Algorithms) =
+  match
+    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.bytes2 (mk_u8 0) (mk_u8 0)
+        <:
+        Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist57 ->
+    Core.Result.Result_Ok
+    (Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.bytes2 (mk_u8 0) (mk_u8 41)
+          <:
+          Bertie.Tls13utils.t_Bytes)
+        hoist57)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let check_server_psk_shared_key (e_algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
+  Bertie.Tls13utils.check_eq_slice ((let list =
+          [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 0)]
+        in
+        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+        Rust_primitives.Hax.array_of_list 2 list)
+      <:
+      t_Slice u8)
+    b
+
+let merge_opts (#v_T: Type0) (o1 o2: Core.Option.t_Option v_T) =
+  match o1, o2 <: (Core.Option.t_Option v_T & Core.Option.t_Option v_T) with
+  | Core.Option.Option_None , Core.Option.Option_Some o ->
+    Core.Result.Result_Ok (Core.Option.Option_Some o <: Core.Option.t_Option v_T)
+    <:
+    Core.Result.t_Result (Core.Option.t_Option v_T) u8
+  | Core.Option.Option_Some o, Core.Option.Option_None  ->
+    Core.Result.Result_Ok (Core.Option.Option_Some o <: Core.Option.t_Option v_T)
+    <:
+    Core.Result.t_Result (Core.Option.t_Option v_T) u8
+  | Core.Option.Option_None , Core.Option.Option_None  ->
+    Core.Result.Result_Ok (Core.Option.Option_None <: Core.Option.t_Option v_T)
+    <:
+    Core.Result.t_Result (Core.Option.t_Option v_T) u8
+  | _ ->
+    Bertie.Tls13utils.tlserr #(Core.Option.t_Option v_T) (Bertie.Tls13utils.parse_failed () <: u8)
+
+let impl_Extensions__merge (self e2: t_Extensions) =
+  match
+    merge_opts #Bertie.Tls13utils.t_Bytes self.f_sni e2.f_sni
+    <:
+    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+  with
+  | Core.Result.Result_Ok hoist62 ->
+    (match
+        merge_opts #Bertie.Tls13utils.t_Bytes self.f_key_share e2.f_key_share
+        <:
+        Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+      with
+      | Core.Result.Result_Ok hoist61 ->
+        (match
+            merge_opts #Bertie.Tls13utils.t_Bytes self.f_ticket e2.f_ticket
+            <:
+            Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+          with
+          | Core.Result.Result_Ok hoist60 ->
+            (match
+                merge_opts #Bertie.Tls13utils.t_Bytes self.f_binder e2.f_binder
+                <:
+                Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+              with
+              | Core.Result.Result_Ok hoist59 ->
+                Core.Result.Result_Ok
+                ({ f_sni = hoist62; f_key_share = hoist61; f_ticket = hoist60; f_binder = hoist59 }
                   <:
                   t_Extensions)
                 <:
@@ -1020,350 +698,451 @@ let impl__Extensions__merge (self e2: t_Extensions) =
         Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8)
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8
 
-let certificate_verify (algs: Bertie.Tls13crypto.t_Algorithms) (cv: Bertie.Tls13utils.t_Bytes) =
-  match
-    match algs.Bertie.Tls13crypto.f_signature with
-    | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
-      Core.Result.Result_Ok (Core.Clone.f_clone cv)
-      <:
-      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-    | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
-      if (Bertie.Tls13utils.impl__Bytes__len cv <: usize) <>. sz 64
-      then
-        Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
-        <:
-        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-      else ecdsa_signature cv
-    | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
-      Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
-      <:
-      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  with
-  | Core.Result.Result_Ok sv ->
-    (match Bertie.Tls13crypto.impl__Algorithms__signature_algorithm algs with
-      | Core.Result.Result_Ok hoist142 ->
-        (match Bertie.Tls13utils.encode_length_u16 sv with
-          | Core.Result.Result_Ok hoist141 ->
-            let sig:Bertie.Tls13utils.t_Bytes =
-              Bertie.Tls13utils.impl__Bytes__concat hoist142 hoist141
-            in
-            Bertie.Tls13formats.Handshake_data.impl__HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_CertificateVerify
-                <:
-                Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-              sig
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
+let check_server_extension (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
+  if (Core.Slice.impl__len #u8 b <: usize) <. mk_usize 4
+  then
+    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
     <:
-    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-
-let check_handshake_record (p: Bertie.Tls13utils.t_Bytes) =
-  Rust_primitives.Hax.Control_flow_monad.Mexception.run (if
-        (Bertie.Tls13utils.impl__Bytes__len p <: usize) <. sz 5 <: bool
-      then
-        Core.Ops.Control_flow.ControlFlow_Continue
-        (Core.Result.Result_Err (Bertie.Tls13utils.parse_failed () <: u8)
+    Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+  else
+    let l0:usize =
+      cast (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (b.[ mk_usize 0 ] <: u8)
           <:
-          Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-        <:
-        Core.Ops.Control_flow.t_ControlFlow
-          (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-          (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-      else
-        let ty:Bertie.Tls13utils.t_Bytes =
-          Bertie.Tls13utils.bytes1 (cast (discriminant_ContentType_Handshake +! 0uy <: u8) <: u8)
-        in
-        let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 3uy 3uy in
-        let! _:Prims.unit =
-          match
-            Bertie.Tls13utils.check_eq ty
-              (Bertie.Tls13utils.impl__Bytes__slice_range p
-                  ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 1 }
-                    <:
-                    Core.Ops.Range.t_Range usize)
-                <:
-                Bertie.Tls13utils.t_Bytes)
-          with
-          | Core.Result.Result_Ok _ ->
-            Core.Ops.Control_flow.ControlFlow_Continue (() <: Prims.unit)
+          u8)
+      <:
+      usize
+    in
+    let l1:usize =
+      cast (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (b.[ mk_usize 1 ] <: u8)
+          <:
+          u8)
+      <:
+      usize
+    in
+    match
+      Bertie.Tls13utils.length_u16_encoded (b.[ {
+              Core.Ops.Range.f_start = mk_usize 2;
+              Core.Ops.Range.f_end = Core.Slice.impl__len #u8 b <: usize
+            }
             <:
-            Core.Ops.Control_flow.t_ControlFlow
-              (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-              Prims.unit
-          | Core.Result.Result_Err _ ->
-            match application_data_instead_of_handshake () with
-            | Core.Result.Result_Ok ok ->
-              Core.Ops.Control_flow.ControlFlow_Continue ok
-              <:
-              Core.Ops.Control_flow.t_ControlFlow
-                (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
-                    u8) Prims.unit
-            | Core.Result.Result_Err err ->
-              Core.Ops.Control_flow.ControlFlow_Break
-              (Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
-              )
-              <:
-              Core.Ops.Control_flow.t_ControlFlow
-                (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
-                    u8) Prims.unit
-        in
-        let! _:Prims.unit =
-          match
-            Bertie.Tls13utils.check_eq ver
-              (Bertie.Tls13utils.impl__Bytes__slice_range p
-                  ({ Core.Ops.Range.f_start = sz 1; Core.Ops.Range.f_end = sz 3 }
+            Core.Ops.Range.t_Range usize ]
+          <:
+          t_Slice u8)
+      <:
+      Core.Result.t_Result usize u8
+    with
+    | Core.Result.Result_Ok len ->
+      let out:Core.Option.t_Option Bertie.Tls13utils.t_Bytes =
+        Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes
+      in
+      (match (cast (l0 <: usize) <: u8), (cast (l1 <: usize) <: u8) <: (u8 & u8) with
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 43 ->
+          (match
+              check_server_supported_version algs
+                (b.[ {
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
+                    }
                     <:
-                    Core.Ops.Range.t_Range usize)
-                <:
-                Bertie.Tls13utils.t_Bytes)
-          with
-          | Core.Result.Result_Ok _ ->
-            Core.Ops.Control_flow.ControlFlow_Continue (() <: Prims.unit)
-            <:
-            Core.Ops.Control_flow.t_ControlFlow
-              (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-              Prims.unit
-          | Core.Result.Result_Err _ ->
-            match protocol_version_alert () with
-            | Core.Result.Result_Ok ok ->
-              Core.Ops.Control_flow.ControlFlow_Continue ok
-              <:
-              Core.Ops.Control_flow.t_ControlFlow
-                (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
-                    u8) Prims.unit
-            | Core.Result.Result_Err err ->
-              Core.Ops.Control_flow.ControlFlow_Break
-              (Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
-              )
-              <:
-              Core.Ops.Control_flow.t_ControlFlow
-                (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
-                    u8) Prims.unit
-        in
-        Core.Ops.Control_flow.ControlFlow_Continue
-        (match
-            Bertie.Tls13utils.length_u16_encoded (p.[ {
-                    Core.Ops.Range.f_start = sz 3;
-                    Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len p <: usize
-                  }
+                    Core.Ops.Range.t_Range usize ]
                   <:
-                  Core.Ops.Range.t_Range usize ]
-                <:
-                t_Slice u8)
-          with
-          | Core.Result.Result_Ok len ->
-            Core.Result.Result_Ok
-            ((Bertie.Tls13formats.Handshake_data.HandshakeData
-                (Bertie.Tls13utils.impl__Bytes__slice_range p
-                    ({ Core.Ops.Range.f_start = sz 5; Core.Ops.Range.f_end = sz 5 +! len <: usize }
-                      <:
-                      Core.Ops.Range.t_Range usize))
-                <:
-                Bertie.Tls13formats.Handshake_data.t_HandshakeData),
-              sz 5 +! len
+                  t_Slice u8)
               <:
-              (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize))
-            <:
-            Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-        <:
-        Core.Ops.Control_flow.t_ControlFlow
-          (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-          (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8))
-
-let rec check_server_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  match check_server_extension algs b with
-  | Core.Result.Result_Ok (len, out) ->
-    if len =. (Core.Slice.impl__len b <: usize)
-    then
-      Core.Result.Result_Ok out
-      <:
-      Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
-    else
-      (match
-          check_server_extensions algs
-            (b.[ {
-                  Core.Ops.Range.f_start = len;
-                  Core.Ops.Range.f_end = Core.Slice.impl__len b <: usize
-                }
-                <:
-                Core.Ops.Range.t_Range usize ]
+              Core.Result.t_Result Prims.unit u8
+            with
+            | Core.Result.Result_Ok ok ->
+              Core.Result.Result_Ok
+              (mk_usize 4 +! len, out <: (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
               <:
-              t_Slice u8)
-        with
-        | Core.Result.Result_Ok out_rest -> merge_opts out out_rest
-        | Core.Result.Result_Err err ->
-          Core.Result.Result_Err err
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 51 ->
+          (match
+              check_server_key_share algs
+                (b.[ {
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+            with
+            | Core.Result.Result_Ok gx ->
+              let out:Core.Option.t_Option Bertie.Tls13utils.t_Bytes =
+                Core.Option.Option_Some gx <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes
+              in
+              Core.Result.Result_Ok
+              (mk_usize 4 +! len, out <: (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
+              <:
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 41 ->
+          (match
+              check_server_psk_shared_key algs
+                (b.[ {
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
+            with
+            | Core.Result.Result_Ok ok ->
+              Core.Result.Result_Ok
+              (mk_usize 4 +! len, out <: (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
+              <:
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+        | _ ->
+          Core.Result.Result_Ok
+          (mk_usize 4 +! len, out <: (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes))
           <:
-          Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+          Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err
+      <:
+      Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+
+let t_AlertLevel_cast_to_repr (x: t_AlertLevel) =
+  match x <: t_AlertLevel with
+  | AlertLevel_Warning  -> anon_const_AlertLevel_Warning__anon_const_0
+  | AlertLevel_Fatal  -> anon_const_AlertLevel_Fatal__anon_const_0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_6': Core.Clone.t_Clone t_AlertLevel
+
+let impl_6 = impl_6'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_7': Core.Marker.t_Copy t_AlertLevel
+
+let impl_7 = impl_7'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_8': Core.Fmt.t_Debug t_AlertLevel
+
+let impl_8 = impl_8'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_9': Core.Marker.t_StructuralPartialEq t_AlertLevel
+
+let impl_9 = impl_9'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_10': Core.Cmp.t_PartialEq t_AlertLevel t_AlertLevel
+
+let impl_10 = impl_10'
+
+let t_AlertDescription_cast_to_repr (x: t_AlertDescription) =
+  match x <: t_AlertDescription with
+  | AlertDescription_CloseNotify  -> anon_const_AlertDescription_CloseNotify__anon_const_0
+  | AlertDescription_UnexpectedMessage  ->
+    anon_const_AlertDescription_UnexpectedMessage__anon_const_0
+  | AlertDescription_BadRecordMac  -> anon_const_AlertDescription_BadRecordMac__anon_const_0
+  | AlertDescription_RecordOverflow  -> anon_const_AlertDescription_RecordOverflow__anon_const_0
+  | AlertDescription_HandshakeFailure  -> anon_const_AlertDescription_HandshakeFailure__anon_const_0
+  | AlertDescription_BadCertificate  -> anon_const_AlertDescription_BadCertificate__anon_const_0
+  | AlertDescription_UnsupportedCertificate  ->
+    anon_const_AlertDescription_UnsupportedCertificate__anon_const_0
+  | AlertDescription_CertificateRevoked  ->
+    anon_const_AlertDescription_CertificateRevoked__anon_const_0
+  | AlertDescription_CertificateExpired  ->
+    anon_const_AlertDescription_CertificateExpired__anon_const_0
+  | AlertDescription_CertificateUnknown  ->
+    anon_const_AlertDescription_CertificateUnknown__anon_const_0
+  | AlertDescription_IllegalParameter  -> anon_const_AlertDescription_IllegalParameter__anon_const_0
+  | AlertDescription_UnknownCa  -> anon_const_AlertDescription_UnknownCa__anon_const_0
+  | AlertDescription_AccessDenied  -> anon_const_AlertDescription_AccessDenied__anon_const_0
+  | AlertDescription_DecodeError  -> anon_const_AlertDescription_DecodeError__anon_const_0
+  | AlertDescription_DecryptError  -> anon_const_AlertDescription_DecryptError__anon_const_0
+  | AlertDescription_ProtocolVersion  -> anon_const_AlertDescription_ProtocolVersion__anon_const_0
+  | AlertDescription_InsufficientSecurity  ->
+    anon_const_AlertDescription_InsufficientSecurity__anon_const_0
+  | AlertDescription_InternalError  -> anon_const_AlertDescription_InternalError__anon_const_0
+  | AlertDescription_InappropriateFallback  ->
+    anon_const_AlertDescription_InappropriateFallback__anon_const_0
+  | AlertDescription_UserCanceled  -> anon_const_AlertDescription_UserCanceled__anon_const_0
+  | AlertDescription_MissingExtension  -> anon_const_AlertDescription_MissingExtension__anon_const_0
+  | AlertDescription_UnsupportedExtension  ->
+    anon_const_AlertDescription_UnsupportedExtension__anon_const_0
+  | AlertDescription_UnrecognizedName  -> anon_const_AlertDescription_UnrecognizedName__anon_const_0
+  | AlertDescription_BadCertificateStatusResponse  ->
+    anon_const_AlertDescription_BadCertificateStatusResponse__anon_const_0
+  | AlertDescription_UnknownPskIdentity  ->
+    anon_const_AlertDescription_UnknownPskIdentity__anon_const_0
+  | AlertDescription_CertificateRequired  ->
+    anon_const_AlertDescription_CertificateRequired__anon_const_0
+  | AlertDescription_NoApplicationProtocol  ->
+    anon_const_AlertDescription_NoApplicationProtocol__anon_const_0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_11': Core.Clone.t_Clone t_AlertDescription
+
+let impl_11 = impl_11'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_12': Core.Marker.t_Copy t_AlertDescription
+
+let impl_12 = impl_12'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_13': Core.Fmt.t_Debug t_AlertDescription
+
+let impl_13 = impl_13'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_14': Core.Marker.t_StructuralPartialEq t_AlertDescription
+
+let impl_14 = impl_14'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_15': Core.Cmp.t_PartialEq t_AlertDescription t_AlertDescription
+
+let impl_15 = impl_15'
+
+let get_psk_extensions
+      (algorithms: Bertie.Tls13crypto.t_Algorithms)
+      (session_ticket extensions: Bertie.Tls13utils.t_Bytes)
+     =
+  match psk_key_exchange_modes () <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 with
+  | Core.Result.Result_Ok pskm ->
+    (match
+        pre_shared_key algorithms session_ticket
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & usize) u8
+      with
+      | Core.Result.Result_Ok (psk, len) ->
+        let extensions:Bertie.Tls13utils.t_Bytes =
+          Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__concat extensions pskm
+              <:
+              Bertie.Tls13utils.t_Bytes)
+            psk
+        in
+        Core.Result.Result_Ok (len, extensions <: (usize & Bertie.Tls13utils.t_Bytes))
+        <:
+        Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8)
   | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+    Core.Result.Result_Err err <: Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
 
 let client_hello
       (algorithms: Bertie.Tls13crypto.t_Algorithms)
       (client_random kem_pk server_name: Bertie.Tls13utils.t_Bytes)
       (session_ticket: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
      =
-  let version:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 3uy 3uy in
-  let compression_methods:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 1uy 0uy in
+  let version:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+  let compression_methods:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13utils.bytes2 (mk_u8 1) (mk_u8 0)
+  in
   match
-    Bertie.Tls13utils.encode_length_u8 (Rust_primitives.unsize (Rust_primitives.Hax.repeat (Bertie.Tls13utils.v_U8
-                  0uy
-                <:
-                u8)
-              (sz 32)
+    Bertie.Tls13utils.encode_length_u8 (Rust_primitives.Hax.repeat (Bertie.Tls13utils.v_U8 (mk_u8 0)
             <:
-            t_Array u8 (sz 32))
+            u8)
+          (mk_usize 32)
         <:
         t_Slice u8)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
   | Core.Result.Result_Ok legacy_session_id ->
-    (match Bertie.Tls13crypto.impl__Algorithms__ciphersuite algorithms with
-      | Core.Result.Result_Ok hoist143 ->
-        (match Bertie.Tls13utils.encode_length_u16 hoist143 with
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__ciphersuite algorithms
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist68 ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 hoist68
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
           | Core.Result.Result_Ok cipher_suites ->
-            (match build_server_name server_name with
+            (match
+                build_server_name server_name <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
               | Core.Result.Result_Ok server_name ->
-                (match supported_versions () with
+                (match
+                    supported_versions () <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  with
                   | Core.Result.Result_Ok supported_versions ->
-                    (match supported_groups algorithms with
+                    (match
+                        supported_groups algorithms
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                      with
                       | Core.Result.Result_Ok supported_groups ->
-                        (match signature_algorithms algorithms with
+                        (match
+                            signature_algorithms algorithms
+                            <:
+                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                          with
                           | Core.Result.Result_Ok signature_algorithms ->
                             (match
                                 key_shares algorithms
-                                  (Core.Clone.f_clone kem_pk <: Bertie.Tls13utils.t_Bytes)
+                                  (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+                                      #FStar.Tactics.Typeclasses.solve
+                                      kem_pk
+                                    <:
+                                    Bertie.Tls13utils.t_Bytes)
+                                <:
+                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                               with
                               | Core.Result.Result_Ok key_shares ->
                                 let len:usize =
-                                  (Bertie.Tls13utils.impl__Bytes__len server_name <: usize) +!
-                                  (Bertie.Tls13utils.impl__Bytes__len supported_versions <: usize)
+                                  (Bertie.Tls13utils.impl_Bytes__len server_name <: usize) +!
+                                  (Bertie.Tls13utils.impl_Bytes__len supported_versions <: usize)
                                 in
                                 let len:usize =
                                   len +!
-                                  (Bertie.Tls13utils.impl__Bytes__len supported_groups <: usize)
+                                  (Bertie.Tls13utils.impl_Bytes__len supported_groups <: usize)
                                 in
                                 let len:usize =
                                   len +!
-                                  (Bertie.Tls13utils.impl__Bytes__len signature_algorithms <: usize)
+                                  (Bertie.Tls13utils.impl_Bytes__len signature_algorithms <: usize)
                                 in
                                 let len:usize =
-                                  len +! (Bertie.Tls13utils.impl__Bytes__len key_shares <: usize)
+                                  len +! (Bertie.Tls13utils.impl_Bytes__len key_shares <: usize)
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__new_alloc len
+                                  Bertie.Tls13utils.impl_Bytes__new_alloc len
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__append out server_name
+                                  Bertie.Tls13utils.impl_Bytes__append out server_name
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__append out supported_versions
+                                  Bertie.Tls13utils.impl_Bytes__append out supported_versions
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__append out supported_groups
+                                  Bertie.Tls13utils.impl_Bytes__append out supported_groups
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__append out signature_algorithms
+                                  Bertie.Tls13utils.impl_Bytes__append out signature_algorithms
                                 in
                                 let out:Bertie.Tls13utils.t_Bytes =
-                                  Bertie.Tls13utils.impl__Bytes__append out key_shares
+                                  Bertie.Tls13utils.impl_Bytes__append out key_shares
                                 in
                                 let extensions:Bertie.Tls13utils.t_Bytes = out in
                                 (match
-                                    match
-                                      Bertie.Tls13crypto.impl__Algorithms__psk_mode algorithms,
-                                      session_ticket
-                                      <:
-                                      (bool & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-                                    with
-                                    | true, Core.Option.Option_Some session_ticket ->
-                                      get_psk_extensions algorithms session_ticket extensions
-                                    | false, Core.Option.Option_None  ->
-                                      Core.Result.Result_Ok
-                                      (sz 0, extensions <: (usize & Bertie.Tls13utils.t_Bytes))
-                                      <:
-                                      Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
-                                    | _ ->
-                                      Bertie.Tls13utils.tlserr Bertie.Tls13utils.v_PSK_MODE_MISMATCH
+                                    (match
+                                        Bertie.Tls13crypto.impl_Algorithms__psk_mode algorithms,
+                                        session_ticket
+                                        <:
+                                        (bool & Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+                                      with
+                                      | true, Core.Option.Option_Some session_ticket ->
+                                        get_psk_extensions algorithms session_ticket extensions
+                                      | false, Core.Option.Option_None  ->
+                                        Core.Result.Result_Ok
+                                        (mk_usize 0, extensions
+                                          <:
+                                          (usize & Bertie.Tls13utils.t_Bytes))
+                                        <:
+                                        Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
+                                      | _ ->
+                                        Bertie.Tls13utils.tlserr #(usize & Bertie.Tls13utils.t_Bytes
+                                          )
+                                          Bertie.Tls13utils.v_PSK_MODE_MISMATCH)
+                                    <:
+                                    Core.Result.t_Result (usize & Bertie.Tls13utils.t_Bytes) u8
                                   with
                                   | Core.Result.Result_Ok (trunc_len, extensions) ->
-                                    (match Bertie.Tls13utils.encode_length_u16 extensions with
+                                    (match
+                                        Bertie.Tls13utils.encode_length_u16 extensions
+                                        <:
+                                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                                      with
                                       | Core.Result.Result_Ok encoded_extensions ->
                                         let len:usize =
-                                          (Bertie.Tls13utils.impl__Bytes__len version <: usize) +!
-                                          (Bertie.Tls13utils.impl__Bytes__len client_random <: usize
-                                          )
+                                          (Bertie.Tls13utils.impl_Bytes__len version <: usize) +!
+                                          (Bertie.Tls13utils.impl_Bytes__len client_random <: usize)
                                         in
                                         let len:usize =
                                           len +!
-                                          (Bertie.Tls13utils.impl__Bytes__len legacy_session_id
+                                          (Bertie.Tls13utils.impl_Bytes__len legacy_session_id
                                             <:
                                             usize)
                                         in
                                         let len:usize =
                                           len +!
-                                          (Bertie.Tls13utils.impl__Bytes__len cipher_suites <: usize
-                                          )
+                                          (Bertie.Tls13utils.impl_Bytes__len cipher_suites <: usize)
                                         in
                                         let len:usize =
                                           len +!
-                                          (Bertie.Tls13utils.impl__Bytes__len compression_methods
+                                          (Bertie.Tls13utils.impl_Bytes__len compression_methods
                                             <:
                                             usize)
                                         in
                                         let len:usize =
                                           len +!
-                                          (Bertie.Tls13utils.impl__Bytes__len encoded_extensions
+                                          (Bertie.Tls13utils.impl_Bytes__len encoded_extensions
                                             <:
                                             usize)
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__new_alloc len
+                                          Bertie.Tls13utils.impl_Bytes__new_alloc len
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out version
+                                          Bertie.Tls13utils.impl_Bytes__append out version
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out client_random
+                                          Bertie.Tls13utils.impl_Bytes__append out client_random
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out
-                                            legacy_session_id
+                                          Bertie.Tls13utils.impl_Bytes__append out legacy_session_id
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out cipher_suites
+                                          Bertie.Tls13utils.impl_Bytes__append out cipher_suites
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out
+                                          Bertie.Tls13utils.impl_Bytes__append out
                                             compression_methods
                                         in
                                         let out:Bertie.Tls13utils.t_Bytes =
-                                          Bertie.Tls13utils.impl__Bytes__append out
+                                          Bertie.Tls13utils.impl_Bytes__append out
                                             encoded_extensions
                                         in
                                         let handshake_bytes:Bertie.Tls13utils.t_Bytes = out in
                                         (match
-                                            Bertie.Tls13formats.Handshake_data.impl__HandshakeData__from_bytes
+                                            Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes
                                               (Bertie.Tls13formats.Handshake_data.HandshakeType_ClientHello
                                                 <:
                                                 Bertie.Tls13formats.Handshake_data.t_HandshakeType)
                                               handshake_bytes
+                                            <:
+                                            Core.Result.t_Result
+                                              Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
                                           with
                                           | Core.Result.Result_Ok client_hello ->
                                             Core.Result.Result_Ok
@@ -1431,26 +1210,269 @@ let client_hello
     <:
     Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
 
-let encrypted_extensions (v__algs: Bertie.Tls13crypto.t_Algorithms) =
+let set_client_hello_binder
+      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
+      (binder: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (trunc_len: Core.Option.t_Option usize)
+     =
+  let Bertie.Tls13formats.Handshake_data.HandshakeData ch:Bertie.Tls13formats.Handshake_data.t_HandshakeData
+  =
+    client_hello
+  in
+  let chlen:usize = Bertie.Tls13utils.impl_Bytes__len ch in
+  let hlen:usize =
+    Bertie.Tls13crypto.impl_HashAlgorithm__hash_len (Bertie.Tls13crypto.impl_Algorithms__hash ciphersuite
+
+        <:
+        Bertie.Tls13crypto.t_HashAlgorithm)
+  in
+  match
+    binder, trunc_len
+    <:
+    (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & Core.Option.t_Option usize)
+  with
+  | Core.Option.Option_Some m, Core.Option.Option_Some trunc_len ->
+    if (chlen -! hlen <: usize) =. trunc_len
+    then
+      Core.Result.Result_Ok
+      (Bertie.Tls13formats.Handshake_data.HandshakeData
+        (Bertie.Tls13utils.impl_Bytes__update_slice ch trunc_len m (mk_usize 0) hlen)
+        <:
+        Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      <:
+      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+    else
+      Bertie.Tls13utils.tlserr #Bertie.Tls13formats.Handshake_data.t_HandshakeData
+        (Bertie.Tls13utils.parse_failed () <: u8)
+  | Core.Option.Option_None , Core.Option.Option_None  ->
+    Core.Result.Result_Ok
+    (Bertie.Tls13formats.Handshake_data.HandshakeData ch
+      <:
+      Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  | _, _ ->
+    Bertie.Tls13utils.tlserr #Bertie.Tls13formats.Handshake_data.t_HandshakeData
+      (Bertie.Tls13utils.parse_failed () <: u8)
+
+let invalid_compression_list (_: Prims.unit) =
+  Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_COMPRESSION_LIST
+  <:
+  Core.Result.t_Result Prims.unit u8
+
+let server_hello (algs: Bertie.Tls13crypto.t_Algorithms) (sr sid gy: Bertie.Tls13utils.t_Bytes) =
+  let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+  match
+    Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw sid <: t_Slice u8)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok sid ->
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__ciphersuite algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok cip ->
+        let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 (mk_u8 0) in
+        (match
+            server_key_shares algs
+              (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve gy
+                <:
+                Bertie.Tls13utils.t_Bytes)
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok ks ->
+            (match
+                server_supported_version algs <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok sv ->
+                let exts:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl_Bytes__concat ks sv in
+                if Bertie.Tls13crypto.impl_Algorithms__psk_mode algs
+                then
+                  match
+                    server_pre_shared_key algs <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  with
+                  | Core.Result.Result_Ok hoist70 ->
+                    let exts:Bertie.Tls13utils.t_Bytes =
+                      Bertie.Tls13utils.impl_Bytes__concat exts hoist70
+                    in
+                    (match
+                        Bertie.Tls13utils.encode_length_u16 exts
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                      with
+                      | Core.Result.Result_Ok encoded_extensions ->
+                        let len:usize =
+                          (Bertie.Tls13utils.impl_Bytes__len ver <: usize) +!
+                          (Bertie.Tls13utils.impl_Bytes__len sr <: usize)
+                        in
+                        let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len sid <: usize) in
+                        let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len cip <: usize) in
+                        let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len comp <: usize) in
+                        let len:usize =
+                          len +! (Bertie.Tls13utils.impl_Bytes__len encoded_extensions <: usize)
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__new_alloc len
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out ver
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out sr
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out sid
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out cip
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out comp
+                        in
+                        let out:Bertie.Tls13utils.t_Bytes =
+                          Bertie.Tls13utils.impl_Bytes__append out encoded_extensions
+                        in
+                        (match
+                            Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_ServerHello
+                                <:
+                                Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+                              out
+                            <:
+                            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
+                              u8
+                          with
+                          | Core.Result.Result_Ok sh ->
+                            Core.Result.Result_Ok sh
+                            <:
+                            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
+                              u8
+                          | Core.Result.Result_Err err ->
+                            Core.Result.Result_Err err
+                            <:
+                            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
+                              u8)
+                      | Core.Result.Result_Err err ->
+                        Core.Result.Result_Err err
+                        <:
+                        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err
+                    <:
+                    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+                else
+                  (match
+                      Bertie.Tls13utils.encode_length_u16 exts
+                      <:
+                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                    with
+                    | Core.Result.Result_Ok encoded_extensions ->
+                      let len:usize =
+                        (Bertie.Tls13utils.impl_Bytes__len ver <: usize) +!
+                        (Bertie.Tls13utils.impl_Bytes__len sr <: usize)
+                      in
+                      let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len sid <: usize) in
+                      let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len cip <: usize) in
+                      let len:usize = len +! (Bertie.Tls13utils.impl_Bytes__len comp <: usize) in
+                      let len:usize =
+                        len +! (Bertie.Tls13utils.impl_Bytes__len encoded_extensions <: usize)
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__new_alloc len
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out ver
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out sr
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out sid
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out cip
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out comp
+                      in
+                      let out:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__append out encoded_extensions
+                      in
+                      (match
+                          Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_ServerHello
+                              <:
+                              Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+                            out
+                          <:
+                          Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+                        with
+                        | Core.Result.Result_Ok sh ->
+                          Core.Result.Result_Ok sh
+                          <:
+                          Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+                        | Core.Result.Result_Err err ->
+                          Core.Result.Result_Err err
+                          <:
+                          Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+                      )
+                    | Core.Result.Result_Err err ->
+                      Core.Result.Result_Err err
+                      <:
+                      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+
+let unsupported_cipher_alert (_: Prims.unit) =
+  Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
+  <:
+  Core.Result.t_Result Prims.unit u8
+
+let invalid_compression_method_alert (_: Prims.unit) =
+  Core.Result.Result_Err Bertie.Tls13utils.v_DECODE_ERROR <: Core.Result.t_Result Prims.unit u8
+
+let encrypted_extensions (e_algs: Bertie.Tls13crypto.t_Algorithms) =
   let handshake_type:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.bytes1 (cast (Bertie.Tls13formats.Handshake_data.discriminant_HandshakeType_EncryptedExtensions +!
-            0uy
+    Bertie.Tls13utils.bytes1 (cast (Bertie.Tls13formats.Handshake_data.anon_const_HandshakeType_EncryptedExtensions__anon_const_0 +!
+            mk_u8 0
             <:
             u8)
         <:
         u8)
   in
   match
-    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl__Bytes__new ()
+    Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl_Bytes__new ()
         <:
         Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
-  | Core.Result.Result_Ok hoist145 ->
-    (match Bertie.Tls13utils.encode_length_u24 hoist145 with
-      | Core.Result.Result_Ok hoist147 ->
+  | Core.Result.Result_Ok hoist74 ->
+    (match
+        Bertie.Tls13utils.encode_length_u24 hoist74
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist76 ->
         Core.Result.Result_Ok
         (Bertie.Tls13formats.Handshake_data.HandshakeData
-          (Bertie.Tls13utils.impl__Bytes__concat handshake_type hoist147)
+          (Bertie.Tls13utils.impl_Bytes__concat handshake_type hoist76)
           <:
           Bertie.Tls13formats.Handshake_data.t_HandshakeData)
         <:
@@ -1464,13 +1486,1010 @@ let encrypted_extensions (v__algs: Bertie.Tls13crypto.t_Algorithms) =
     <:
     Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
 
+let parse_encrypted_extensions
+      (e_algs: Bertie.Tls13crypto.t_Algorithms)
+      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+     =
+  let Bertie.Tls13formats.Handshake_data.HandshakeData encrypted_extension_bytes:Bertie.Tls13formats.Handshake_data.t_HandshakeData
+  =
+    encrypted_extensions
+  in
+  let expected_handshake_type:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13utils.bytes1 (cast (Bertie.Tls13formats.Handshake_data.anon_const_HandshakeType_EncryptedExtensions__anon_const_0 +!
+            mk_u8 0
+            <:
+            u8)
+        <:
+        u8)
+  in
+  match
+    Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw expected_handshake_type
+
+        <:
+        t_Slice u8)
+      (Bertie.Tls13utils.impl_Bytes__as_raw encrypted_extension_bytes <: t_Slice u8)
+      (mk_usize 0)
+      (mk_usize 1)
+    <:
+    Core.Result.t_Result Prims.unit u8
+  with
+  | Core.Result.Result_Ok _ ->
+    Bertie.Tls13utils.check_length_encoding_u24 (Bertie.Tls13utils.impl_Bytes__raw_slice encrypted_extension_bytes
+          ({
+              Core.Ops.Range.f_start = mk_usize 1;
+              Core.Ops.Range.f_end
+              =
+              Bertie.Tls13utils.impl_Bytes__len encrypted_extension_bytes <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        t_Slice u8)
+  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
+
+let server_certificate (e_algs: Bertie.Tls13crypto.t_Algorithms) (cert: Bertie.Tls13utils.t_Bytes) =
+  match
+    Bertie.Tls13utils.encode_length_u8 ((let list:Prims.list u8 = [] in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
+          Rust_primitives.Hax.array_of_list 0 list)
+        <:
+        t_Slice u8)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok creq ->
+    (match
+        Bertie.Tls13utils.encode_length_u24 cert
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok crt ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl_Bytes__new ()
+                <:
+                Bertie.Tls13utils.t_Bytes)
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok ext ->
+            (match
+                Bertie.Tls13utils.encode_length_u24 (Bertie.Tls13utils.impl_Bytes__concat crt ext
+                    <:
+                    Bertie.Tls13utils.t_Bytes)
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok crts ->
+                Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_Certificate
+                    <:
+                    Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+                  (Bertie.Tls13utils.impl_Bytes__concat creq crts <: Bertie.Tls13utils.t_Bytes)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+
+let parse_server_certificate (certificate: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
+  match
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__as_handshake_message certificate
+      (Bertie.Tls13formats.Handshake_data.HandshakeType_Certificate
+        <:
+        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
+  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData sc) ->
+    let next:usize = mk_usize 0 in
+    (match
+        Bertie.Tls13utils.length_u8_encoded (sc.[ {
+                Core.Ops.Range.f_start = mk_usize 0;
+                Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sc <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+        <:
+        Core.Result.t_Result usize u8
+      with
+      | Core.Result.Result_Ok creqlen ->
+        let next:usize = (next +! mk_usize 1 <: usize) +! creqlen in
+        (match
+            Bertie.Tls13utils.check_length_encoding_u24 (Bertie.Tls13utils.impl_Bytes__raw_slice sc
+                  ({
+                      Core.Ops.Range.f_start = next;
+                      Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sc <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize)
+                <:
+                t_Slice u8)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            let next:usize = next +! mk_usize 3 in
+            (match
+                Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl_Bytes__raw_slice sc
+                      ({
+                          Core.Ops.Range.f_start = next;
+                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sc <: usize
+                        }
+                        <:
+                        Core.Ops.Range.t_Range usize)
+                    <:
+                    t_Slice u8)
+                <:
+                Core.Result.t_Result usize u8
+              with
+              | Core.Result.Result_Ok crtlen ->
+                let next:usize = next +! mk_usize 3 in
+                let crt:Bertie.Tls13utils.t_Bytes =
+                  Bertie.Tls13utils.impl_Bytes__slice_range sc
+                    ({
+                        Core.Ops.Range.f_start = next;
+                        Core.Ops.Range.f_end = next +! crtlen <: usize
+                      }
+                      <:
+                      Core.Ops.Range.t_Range usize)
+                in
+                let next:usize = next +! crtlen in
+                (match
+                    Bertie.Tls13utils.length_u16_encoded (sc.[ {
+                            Core.Ops.Range.f_start = next;
+                            Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sc <: usize
+                          }
+                          <:
+                          Core.Ops.Range.t_Range usize ]
+                        <:
+                        t_Slice u8)
+                    <:
+                    Core.Result.t_Result usize u8
+                  with
+                  | Core.Result.Result_Ok e_extlen ->
+                    Core.Result.Result_Ok crt <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let ecdsa_signature (sv: Bertie.Tls13utils.t_Bytes) =
+  if (Bertie.Tls13utils.impl_Bytes__len sv <: usize) <>. mk_usize 64
+  then
+    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  else
+    let b0:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 (mk_u8 0) in
+    let b1:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 (mk_u8 48) in
+    let b2:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 (mk_u8 2) in
+    let (r: Bertie.Tls13utils.t_Bytes):Bertie.Tls13utils.t_Bytes =
+      Bertie.Tls13utils.impl_Bytes__slice sv (mk_usize 0) (mk_usize 32)
+    in
+    let (s: Bertie.Tls13utils.t_Bytes):Bertie.Tls13utils.t_Bytes =
+      Bertie.Tls13utils.impl_Bytes__slice sv (mk_usize 32) (mk_usize 32)
+    in
+    let r:Bertie.Tls13utils.t_Bytes =
+      if
+        (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (r.[ mk_usize 0 ] <: u8)
+          <:
+          u8) >=.
+        mk_u8 128
+      then
+        let r:Bertie.Tls13utils.t_Bytes =
+          Bertie.Tls13utils.impl_Bytes__concat (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+                #FStar.Tactics.Typeclasses.solve
+                b0
+              <:
+              Bertie.Tls13utils.t_Bytes)
+            r
+        in
+        r
+      else r
+    in
+    let s:Bertie.Tls13utils.t_Bytes =
+      if
+        (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (s.[ mk_usize 0 ] <: u8)
+          <:
+          u8) >=.
+        mk_u8 128
+      then
+        let s:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl_Bytes__concat b0 s in
+        s
+      else s
+    in
+    match
+      Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw r <: t_Slice u8)
+      <:
+      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+    with
+    | Core.Result.Result_Ok hoist79 ->
+      (match
+          Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw s <: t_Slice u8)
+          <:
+          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+        with
+        | Core.Result.Result_Ok hoist81 ->
+          (match
+              Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw (Bertie.Tls13utils.impl_Bytes__concat
+                        (Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__concat (
+                                  Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+                                    #FStar.Tactics.Typeclasses.solve
+                                    b2
+                                  <:
+                                  Bertie.Tls13utils.t_Bytes)
+                                hoist79
+                              <:
+                              Bertie.Tls13utils.t_Bytes)
+                            b2
+                          <:
+                          Bertie.Tls13utils.t_Bytes)
+                        hoist81
+                      <:
+                      Bertie.Tls13utils.t_Bytes)
+                  <:
+                  t_Slice u8)
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+            with
+            | Core.Result.Result_Ok hoist86 ->
+              Core.Result.Result_Ok (Bertie.Tls13utils.impl_Bytes__concat b1 hoist86)
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+        | Core.Result.Result_Err err ->
+          Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let check_r_len (rlen: usize) =
+  if rlen <. mk_usize 32 || rlen >. mk_usize 33
+  then
+    Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
+    <:
+    Core.Result.t_Result Prims.unit u8
+  else Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
+
+let parse_ecdsa_signature (sig: Bertie.Tls13utils.t_Bytes) =
+  if (Bertie.Tls13utils.impl_Bytes__len sig <: usize) <. mk_usize 4
+  then
+    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  else
+    match
+      Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 (mk_u8 48) <: Bertie.Tls13utils.t_Bytes)
+        (Bertie.Tls13utils.impl_Bytes__slice_range sig
+            ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = mk_usize 1 }
+              <:
+              Core.Ops.Range.t_Range usize)
+          <:
+          Bertie.Tls13utils.t_Bytes)
+      <:
+      Core.Result.t_Result Prims.unit u8
+    with
+    | Core.Result.Result_Ok _ ->
+      (match
+          Bertie.Tls13utils.check_length_encoding_u8 (Bertie.Tls13utils.impl_Bytes__slice_range sig
+                ({
+                    Core.Ops.Range.f_start = mk_usize 1;
+                    Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sig <: usize
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Bertie.Tls13utils.t_Bytes)
+          <:
+          Core.Result.t_Result Prims.unit u8
+        with
+        | Core.Result.Result_Ok _ ->
+          (match
+              Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 (mk_u8 2)
+                  <:
+                  Bertie.Tls13utils.t_Bytes)
+                (Bertie.Tls13utils.impl_Bytes__slice_range sig
+                    ({ Core.Ops.Range.f_start = mk_usize 2; Core.Ops.Range.f_end = mk_usize 3 }
+                      <:
+                      Core.Ops.Range.t_Range usize)
+                  <:
+                  Bertie.Tls13utils.t_Bytes)
+              <:
+              Core.Result.t_Result Prims.unit u8
+            with
+            | Core.Result.Result_Ok _ ->
+              (match
+                  Bertie.Tls13utils.length_u8_encoded (sig.[ {
+                          Core.Ops.Range.f_start = mk_usize 3;
+                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len sig <: usize
+                        }
+                        <:
+                        Core.Ops.Range.t_Range usize ]
+                      <:
+                      t_Slice u8)
+                  <:
+                  Core.Result.t_Result usize u8
+                with
+                | Core.Result.Result_Ok rlen ->
+                  (match check_r_len rlen <: Core.Result.t_Result Prims.unit u8 with
+                    | Core.Result.Result_Ok _ ->
+                      let r:Bertie.Tls13utils.t_Bytes =
+                        Bertie.Tls13utils.impl_Bytes__slice sig
+                          ((mk_usize 4 +! rlen <: usize) -! mk_usize 32 <: usize)
+                          (mk_usize 32)
+                      in
+                      if
+                        (Bertie.Tls13utils.impl_Bytes__len sig <: usize) <.
+                        ((mk_usize 6 +! rlen <: usize) +! mk_usize 32 <: usize)
+                      then
+                        Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                      else
+                        (match
+                            Bertie.Tls13utils.check_eq (Bertie.Tls13utils.bytes1 (mk_u8 2)
+                                <:
+                                Bertie.Tls13utils.t_Bytes)
+                              (Bertie.Tls13utils.impl_Bytes__slice_range sig
+                                  ({
+                                      Core.Ops.Range.f_start = mk_usize 4 +! rlen <: usize;
+                                      Core.Ops.Range.f_end = mk_usize 5 +! rlen <: usize
+                                    }
+                                    <:
+                                    Core.Ops.Range.t_Range usize)
+                                <:
+                                Bertie.Tls13utils.t_Bytes)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
+                          with
+                          | Core.Result.Result_Ok _ ->
+                            (match
+                                Bertie.Tls13utils.check_length_encoding_u8 (Bertie.Tls13utils.impl_Bytes__slice_range
+                                      sig
+                                      ({
+                                          Core.Ops.Range.f_start = mk_usize 5 +! rlen <: usize;
+                                          Core.Ops.Range.f_end
+                                          =
+                                          Bertie.Tls13utils.impl_Bytes__len sig <: usize
+                                        }
+                                        <:
+                                        Core.Ops.Range.t_Range usize)
+                                    <:
+                                    Bertie.Tls13utils.t_Bytes)
+                                <:
+                                Core.Result.t_Result Prims.unit u8
+                              with
+                              | Core.Result.Result_Ok _ ->
+                                let s:Bertie.Tls13utils.t_Bytes =
+                                  Bertie.Tls13utils.impl_Bytes__slice sig
+                                    ((Bertie.Tls13utils.impl_Bytes__len sig <: usize) -! mk_usize 32
+                                      <:
+                                      usize)
+                                    (mk_usize 32)
+                                in
+                                Core.Result.Result_Ok (Bertie.Tls13utils.impl_Bytes__concat r s)
+                                <:
+                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                              | Core.Result.Result_Err err ->
+                                Core.Result.Result_Err err
+                                <:
+                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                          | Core.Result.Result_Err err ->
+                            Core.Result.Result_Err err
+                            <:
+                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                    | Core.Result.Result_Err err ->
+                      Core.Result.Result_Err err
+                      <:
+                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                | Core.Result.Result_Err err ->
+                  Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+        | Core.Result.Result_Err err ->
+          Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let certificate_verify (algs: Bertie.Tls13crypto.t_Algorithms) (cv: Bertie.Tls13utils.t_Bytes) =
+  match
+    (match algs.Bertie.Tls13crypto.f_signature <: Bertie.Tls13crypto.t_SignatureScheme with
+      | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
+        Core.Result.Result_Ok
+        (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve cv)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
+        if (Bertie.Tls13utils.impl_Bytes__len cv <: usize) <>. mk_usize 64
+        then
+          Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+          <:
+          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+        else ecdsa_signature cv
+      | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
+        Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok sv ->
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__signature_algorithm algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist89 ->
+        (match
+            Bertie.Tls13utils.encode_length_u16 sv
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok hoist88 ->
+            let sig:Bertie.Tls13utils.t_Bytes =
+              Bertie.Tls13utils.impl_Bytes__concat hoist89 hoist88
+            in
+            Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_CertificateVerify
+                <:
+                Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+              sig
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+
+let parse_certificate_verify
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (certificate_verify: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+     =
+  match
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__as_handshake_message certificate_verify
+      (Bertie.Tls13formats.Handshake_data.HandshakeType_CertificateVerify
+        <:
+        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
+  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData cv) ->
+    let sa:Bertie.Tls13crypto.t_SignatureScheme =
+      Bertie.Tls13crypto.impl_Algorithms__signature algs
+    in
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__signature_algorithm algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist90 ->
+        (match
+            Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw hoist90
+                <:
+                t_Slice u8)
+              (Bertie.Tls13utils.impl_Bytes__as_raw cv <: t_Slice u8)
+              (mk_usize 0)
+              (mk_usize 2)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            (match
+                Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl_Bytes__slice_range
+                      cv
+                      ({
+                          Core.Ops.Range.f_start = mk_usize 2;
+                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len cv <: usize
+                        }
+                        <:
+                        Core.Ops.Range.t_Range usize)
+                    <:
+                    Bertie.Tls13utils.t_Bytes)
+                <:
+                Core.Result.t_Result Prims.unit u8
+              with
+              | Core.Result.Result_Ok _ ->
+                (match sa <: Bertie.Tls13crypto.t_SignatureScheme with
+                  | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
+                    parse_ecdsa_signature (Bertie.Tls13utils.impl_Bytes__slice_range cv
+                          ({
+                              Core.Ops.Range.f_start = mk_usize 4;
+                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len cv <: usize
+                            }
+                            <:
+                            Core.Ops.Range.t_Range usize)
+                        <:
+                        Bertie.Tls13utils.t_Bytes)
+                  | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
+                    Core.Result.Result_Ok
+                    (Bertie.Tls13utils.impl_Bytes__slice_range cv
+                        ({
+                            Core.Ops.Range.f_start = mk_usize 4;
+                            Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len cv <: usize
+                          }
+                          <:
+                          Core.Ops.Range.t_Range usize))
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
+                    if
+                      ((Bertie.Tls13utils.impl_Bytes__len cv <: usize) -! mk_usize 4 <: usize) =.
+                      mk_usize 64
+                    then
+                      Core.Result.Result_Ok
+                      (Bertie.Tls13utils.impl_Bytes__slice_range cv
+                          ({
+                              Core.Ops.Range.f_start = mk_usize 4;
+                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len cv <: usize
+                            }
+                            <:
+                            Core.Ops.Range.t_Range usize))
+                      <:
+                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                    else
+                      Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
+                      <:
+                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let finished (vd: Bertie.Tls13utils.t_Bytes) =
+  Bertie.Tls13formats.Handshake_data.impl_HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_Finished
+      <:
+      Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    vd
+
+let parse_finished (finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
+  match
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__as_handshake_message finished
+      (Bertie.Tls13formats.Handshake_data.HandshakeType_Finished
+        <:
+        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
+  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData fin) ->
+    Core.Result.Result_Ok fin <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let t_ContentType_cast_to_repr (x: t_ContentType) =
+  match x <: t_ContentType with
+  | ContentType_Invalid  -> anon_const_ContentType_Invalid__anon_const_0
+  | ContentType_ChangeCipherSpec  -> anon_const_ContentType_ChangeCipherSpec__anon_const_0
+  | ContentType_Alert  -> anon_const_ContentType_Alert__anon_const_0
+  | ContentType_Handshake  -> anon_const_ContentType_Handshake__anon_const_0
+  | ContentType_ApplicationData  -> anon_const_ContentType_ApplicationData__anon_const_0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_16': Core.Clone.t_Clone t_ContentType
+
+let impl_16 = impl_16'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_17': Core.Marker.t_Copy t_ContentType
+
+let impl_17 = impl_17'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_18': Core.Fmt.t_Debug t_ContentType
+
+let impl_18 = impl_18'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_19': Core.Marker.t_StructuralPartialEq t_ContentType
+
+let impl_19 = impl_19'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_20': Core.Cmp.t_PartialEq t_ContentType t_ContentType
+
+let impl_20 = impl_20'
+
+let impl_ContentType__try_from_u8 (t: u8) =
+  match t <: u8 with
+  | Rust_primitives.Integers.MkInt 20 ->
+    Core.Result.Result_Ok (ContentType_ChangeCipherSpec <: t_ContentType)
+    <:
+    Core.Result.t_Result t_ContentType u8
+  | Rust_primitives.Integers.MkInt 21 ->
+    Core.Result.Result_Ok (ContentType_Alert <: t_ContentType)
+    <:
+    Core.Result.t_Result t_ContentType u8
+  | Rust_primitives.Integers.MkInt 22 ->
+    Core.Result.Result_Ok (ContentType_Handshake <: t_ContentType)
+    <:
+    Core.Result.t_Result t_ContentType u8
+  | Rust_primitives.Integers.MkInt 23 ->
+    Core.Result.Result_Ok (ContentType_ApplicationData <: t_ContentType)
+    <:
+    Core.Result.t_Result t_ContentType u8
+  | _ ->
+    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+    <:
+    Core.Result.t_Result t_ContentType u8
+
+let handshake_record (p: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
+  let ty:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13utils.bytes1 (cast (anon_const_ContentType_Handshake__anon_const_0 +! mk_u8 0 <: u8)
+        <:
+        u8)
+  in
+  let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+  match
+    Bertie.Tls13utils.encode_length_u16 p.Bertie.Tls13formats.Handshake_data._0
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok hoist93 ->
+    Core.Result.Result_Ok
+    (Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__concat ty ver
+          <:
+          Bertie.Tls13utils.t_Bytes)
+        hoist93)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let protocol_version_alert (_: Prims.unit) =
+  Core.Result.Result_Err Bertie.Tls13utils.v_PROTOCOL_VERSION_ALERT
+  <:
+  Core.Result.t_Result Prims.unit u8
+
+let application_data_instead_of_handshake (_: Prims.unit) =
+  Core.Result.Result_Err Bertie.Tls13utils.v_APPLICATION_DATA_INSTEAD_OF_HANDSHAKE
+  <:
+  Core.Result.t_Result Prims.unit u8
+
+let check_handshake_record (p: Bertie.Tls13utils.t_Bytes) =
+  if (Bertie.Tls13utils.impl_Bytes__len p <: usize) <. mk_usize 5
+  then
+    Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+    <:
+    Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+  else
+    let ty:Bertie.Tls13utils.t_Bytes =
+      Bertie.Tls13utils.bytes1 (cast (anon_const_ContentType_Handshake__anon_const_0 +! mk_u8 0
+              <:
+              u8)
+          <:
+          u8)
+    in
+    let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+    match
+      Bertie.Tls13utils.check_eq ty
+        (Bertie.Tls13utils.impl_Bytes__slice_range p
+            ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = mk_usize 1 }
+              <:
+              Core.Ops.Range.t_Range usize)
+          <:
+          Bertie.Tls13utils.t_Bytes)
+      <:
+      Core.Result.t_Result Prims.unit u8
+    with
+    | Core.Result.Result_Ok _ ->
+      let _:Prims.unit = () <: Prims.unit in
+      (match
+          Bertie.Tls13utils.check_eq ver
+            (Bertie.Tls13utils.impl_Bytes__slice_range p
+                ({ Core.Ops.Range.f_start = mk_usize 1; Core.Ops.Range.f_end = mk_usize 3 }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Bertie.Tls13utils.t_Bytes)
+          <:
+          Core.Result.t_Result Prims.unit u8
+        with
+        | Core.Result.Result_Ok _ ->
+          let _:Prims.unit = () <: Prims.unit in
+          (match
+              Bertie.Tls13utils.length_u16_encoded (p.[ {
+                      Core.Ops.Range.f_start = mk_usize 3;
+                      Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len p <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+              <:
+              Core.Result.t_Result usize u8
+            with
+            | Core.Result.Result_Ok len ->
+              Core.Result.Result_Ok
+              ((Bertie.Tls13formats.Handshake_data.HandshakeData
+                  (Bertie.Tls13utils.impl_Bytes__slice_range p
+                      ({
+                          Core.Ops.Range.f_start = mk_usize 5;
+                          Core.Ops.Range.f_end = mk_usize 5 +! len <: usize
+                        }
+                        <:
+                        Core.Ops.Range.t_Range usize))
+                  <:
+                  Bertie.Tls13formats.Handshake_data.t_HandshakeData),
+                mk_usize 5 +! len
+                <:
+                (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize))
+              <:
+              Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
+        | Core.Result.Result_Err _ ->
+          match protocol_version_alert () <: Core.Result.t_Result Prims.unit u8 with
+          | Core.Result.Result_Ok ok ->
+            let _:Prims.unit = ok in
+            (match
+                Bertie.Tls13utils.length_u16_encoded (p.[ {
+                        Core.Ops.Range.f_start = mk_usize 3;
+                        Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len p <: usize
+                      }
+                      <:
+                      Core.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                <:
+                Core.Result.t_Result usize u8
+              with
+              | Core.Result.Result_Ok len ->
+                Core.Result.Result_Ok
+                ((Bertie.Tls13formats.Handshake_data.HandshakeData
+                    (Bertie.Tls13utils.impl_Bytes__slice_range p
+                        ({
+                            Core.Ops.Range.f_start = mk_usize 5;
+                            Core.Ops.Range.f_end = mk_usize 5 +! len <: usize
+                          }
+                          <:
+                          Core.Ops.Range.t_Range usize))
+                    <:
+                    Bertie.Tls13formats.Handshake_data.t_HandshakeData),
+                  mk_usize 5 +! len
+                  <:
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize))
+                <:
+                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+            )
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
+    | Core.Result.Result_Err _ ->
+      match application_data_instead_of_handshake () <: Core.Result.t_Result Prims.unit u8 with
+      | Core.Result.Result_Ok ok ->
+        let _:Prims.unit = ok in
+        (match
+            Bertie.Tls13utils.check_eq ver
+              (Bertie.Tls13utils.impl_Bytes__slice_range p
+                  ({ Core.Ops.Range.f_start = mk_usize 1; Core.Ops.Range.f_end = mk_usize 3 }
+                    <:
+                    Core.Ops.Range.t_Range usize)
+                <:
+                Bertie.Tls13utils.t_Bytes)
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            let _:Prims.unit = () <: Prims.unit in
+            (match
+                Bertie.Tls13utils.length_u16_encoded (p.[ {
+                        Core.Ops.Range.f_start = mk_usize 3;
+                        Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len p <: usize
+                      }
+                      <:
+                      Core.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                <:
+                Core.Result.t_Result usize u8
+              with
+              | Core.Result.Result_Ok len ->
+                Core.Result.Result_Ok
+                ((Bertie.Tls13formats.Handshake_data.HandshakeData
+                    (Bertie.Tls13utils.impl_Bytes__slice_range p
+                        ({
+                            Core.Ops.Range.f_start = mk_usize 5;
+                            Core.Ops.Range.f_end = mk_usize 5 +! len <: usize
+                          }
+                          <:
+                          Core.Ops.Range.t_Range usize))
+                    <:
+                    Bertie.Tls13formats.Handshake_data.t_HandshakeData),
+                  mk_usize 5 +! len
+                  <:
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize))
+                <:
+                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+            )
+          | Core.Result.Result_Err _ ->
+            match protocol_version_alert () <: Core.Result.t_Result Prims.unit u8 with
+            | Core.Result.Result_Ok ok ->
+              let _:Prims.unit = ok in
+              (match
+                  Bertie.Tls13utils.length_u16_encoded (p.[ {
+                          Core.Ops.Range.f_start = mk_usize 3;
+                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len p <: usize
+                        }
+                        <:
+                        Core.Ops.Range.t_Range usize ]
+                      <:
+                      t_Slice u8)
+                  <:
+                  Core.Result.t_Result usize u8
+                with
+                | Core.Result.Result_Ok len ->
+                  Core.Result.Result_Ok
+                  ((Bertie.Tls13formats.Handshake_data.HandshakeData
+                      (Bertie.Tls13utils.impl_Bytes__slice_range p
+                          ({
+                              Core.Ops.Range.f_start = mk_usize 5;
+                              Core.Ops.Range.f_end = mk_usize 5 +! len <: usize
+                            }
+                            <:
+                            Core.Ops.Range.t_Range usize))
+                      <:
+                      Bertie.Tls13formats.Handshake_data.t_HandshakeData),
+                    mk_usize 5 +! len
+                    <:
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize))
+                  <:
+                  Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
+                    u8
+                | Core.Result.Result_Err err ->
+                  Core.Result.Result_Err err
+                  <:
+                  Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize)
+                    u8)
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+
+let get_handshake_record (p: Bertie.Tls13utils.t_Bytes) =
+  match
+    check_handshake_record p
+    <:
+    Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
+  with
+  | Core.Result.Result_Ok (hd, len) ->
+    if len =. (Bertie.Tls13utils.impl_Bytes__len p <: usize)
+    then
+      Core.Result.Result_Ok hd
+      <:
+      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+    else
+      Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
+      <:
+      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+
+let impl_Transcript__new (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm) =
+  {
+    f_hash_algorithm = hash_algorithm;
+    f_transcript
+    =
+    Bertie.Tls13formats.Handshake_data.HandshakeData (Bertie.Tls13utils.impl_Bytes__new ())
+    <:
+    Bertie.Tls13formats.Handshake_data.t_HandshakeData
+  }
+  <:
+  t_Transcript
+
+let impl_Transcript__add
+      (self: t_Transcript)
+      (msg: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+     =
+  let self:t_Transcript =
+    {
+      self with
+      f_transcript
+      =
+      Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat self.f_transcript msg
+    }
+    <:
+    t_Transcript
+  in
+  self
+
+let impl_Transcript__transcript_hash (self: t_Transcript) =
+  match
+    Bertie.Tls13crypto.impl_HashAlgorithm__hash self.f_hash_algorithm
+      self.f_transcript.Bertie.Tls13formats.Handshake_data._0
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok th ->
+    Core.Result.Result_Ok th <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let impl_Transcript__transcript_hash_without_client_hello
+      (self: t_Transcript)
+      (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (trunc_len: usize)
+     =
+  let Bertie.Tls13formats.Handshake_data.HandshakeData ch:Bertie.Tls13formats.Handshake_data.t_HandshakeData
+  =
+    client_hello
+  in
+  Bertie.Tls13crypto.impl_HashAlgorithm__hash self.f_hash_algorithm
+    (Bertie.Tls13utils.impl_Bytes__concat (Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes
+            #FStar.Tactics.Typeclasses.solve
+            self.f_transcript.Bertie.Tls13formats.Handshake_data._0
+          <:
+          Bertie.Tls13utils.t_Bytes)
+        (Bertie.Tls13utils.impl_Bytes__slice_range client_hello
+              .Bertie.Tls13formats.Handshake_data._0
+            ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = trunc_len }
+              <:
+              Core.Ops.Range.t_Range usize)
+          <:
+          Bertie.Tls13utils.t_Bytes)
+      <:
+      Bertie.Tls13utils.t_Bytes)
+
 let rec find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8) =
-  if (Core.Slice.impl__len ch <: usize) <. sz 4
-  then Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
+  if (Core.Slice.impl__len #u8 ch <: usize) <. mk_usize 4
+  then Bertie.Tls13utils.tlserr #Bertie.Tls13utils.t_Bytes (Bertie.Tls13utils.parse_failed () <: u8)
   else
     if
-      Bertie.Tls13utils.eq_slice (Bertie.Tls13utils.impl__Bytes__as_raw g <: t_Slice u8)
-        (ch.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 2 }
+      Bertie.Tls13utils.eq_slice (Bertie.Tls13utils.impl_Bytes__as_raw g <: t_Slice u8)
+        (ch.[ { Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = mk_usize 2 }
             <:
             Core.Ops.Range.t_Range usize ]
           <:
@@ -1478,19 +2497,24 @@ let rec find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8) =
     then
       match
         Bertie.Tls13utils.length_u16_encoded_slice (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
               }
               <:
               Core.Ops.Range.t_Range usize ]
             <:
             t_Slice u8)
+        <:
+        Core.Result.t_Result usize u8
       with
       | Core.Result.Result_Ok len ->
         Core.Result.Result_Ok
-        (Core.Convert.f_into (ch.[ {
-                  Core.Ops.Range.f_start = sz 4;
-                  Core.Ops.Range.f_end = sz 4 +! len <: usize
+        (Core.Convert.f_into #(t_Slice u8)
+            #Bertie.Tls13utils.t_Bytes
+            #FStar.Tactics.Typeclasses.solve
+            (ch.[ {
+                  Core.Ops.Range.f_start = mk_usize 4;
+                  Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                 }
                 <:
                 Core.Ops.Range.t_Range usize ]
@@ -1503,19 +2527,21 @@ let rec find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8) =
     else
       match
         Bertie.Tls13utils.length_u16_encoded_slice (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
               }
               <:
               Core.Ops.Range.t_Range usize ]
             <:
             t_Slice u8)
+        <:
+        Core.Result.t_Result usize u8
       with
       | Core.Result.Result_Ok len ->
         find_key_share g
           (ch.[ {
-                Core.Ops.Range.f_start = sz 4 +! len <: usize;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
+                Core.Ops.Range.f_start = mk_usize 4 +! len <: usize;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
               }
               <:
               Core.Ops.Range.t_Range usize ]
@@ -1524,15 +2550,57 @@ let rec find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8) =
       | Core.Result.Result_Err err ->
         Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
+let rec check_server_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
+  match
+    check_server_extension algs b
+    <:
+    Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+  with
+  | Core.Result.Result_Ok (len, out) ->
+    if len =. (Core.Slice.impl__len #u8 b <: usize)
+    then
+      Core.Result.Result_Ok out
+      <:
+      Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+    else
+      (match
+          check_server_extensions algs
+            (b.[ {
+                  Core.Ops.Range.f_start = len;
+                  Core.Ops.Range.f_end = Core.Slice.impl__len #u8 b <: usize
+                }
+                <:
+                Core.Ops.Range.t_Range usize ]
+              <:
+              t_Slice u8)
+          <:
+          Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+        with
+        | Core.Result.Result_Ok out_rest -> merge_opts #Bertie.Tls13utils.t_Bytes out out_rest
+        | Core.Result.Result_Err err ->
+          Core.Result.Result_Err err
+          <:
+          Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
+
 let check_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
-  match Bertie.Tls13utils.check_length_encoding_u16_slice ch with
+  match
+    Bertie.Tls13utils.check_length_encoding_u16_slice ch <: Core.Result.t_Result Prims.unit u8
+  with
   | Core.Result.Result_Ok _ ->
-    (match Bertie.Tls13crypto.impl__Algorithms__supported_group algs with
-      | Core.Result.Result_Ok hoist150 ->
-        find_key_share hoist150
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__supported_group algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok hoist43 ->
+        find_key_share hoist43
           (ch.[ {
-                Core.Ops.Range.f_start = sz 2;
-                Core.Ops.Range.f_end = Core.Slice.impl__len ch <: usize
+                Core.Ops.Range.f_start = mk_usize 2;
+                Core.Ops.Range.f_end = Core.Slice.impl__len #u8 ch <: usize
               }
               <:
               Core.Ops.Range.t_Range usize ]
@@ -1544,23 +2612,43 @@ let check_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8) =
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
 let check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8) =
-  if (Core.Slice.impl__len bytes <: usize) <. sz 4
+  if (Core.Slice.impl__len #u8 bytes <: usize) <. mk_usize 4
   then
     Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
     <:
     Core.Result.t_Result (usize & t_Extensions) u8
   else
-    let l0:usize = cast (Bertie.Tls13utils.f_declassify (bytes.[ sz 0 ] <: u8) <: u8) <: usize in
-    let l1:usize = cast (Bertie.Tls13utils.f_declassify (bytes.[ sz 1 ] <: u8) <: u8) <: usize in
+    let l0:usize =
+      cast (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (bytes.[ mk_usize 0 ] <: u8)
+          <:
+          u8)
+      <:
+      usize
+    in
+    let l1:usize =
+      cast (Bertie.Tls13utils.f_declassify #u8
+            #u8
+            #FStar.Tactics.Typeclasses.solve
+            (bytes.[ mk_usize 1 ] <: u8)
+          <:
+          u8)
+      <:
+      usize
+    in
     match
       Bertie.Tls13utils.length_u16_encoded_slice (bytes.[ {
-              Core.Ops.Range.f_start = sz 2;
-              Core.Ops.Range.f_end = Core.Slice.impl__len bytes <: usize
+              Core.Ops.Range.f_start = mk_usize 2;
+              Core.Ops.Range.f_end = Core.Slice.impl__len #u8 bytes <: usize
             }
             <:
             Core.Ops.Range.t_Range usize ]
           <:
           t_Slice u8)
+      <:
+      Core.Result.t_Result usize u8
     with
     | Core.Result.Result_Ok len ->
       let out:t_Extensions =
@@ -1574,24 +2662,26 @@ let check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8) 
         t_Extensions
       in
       (match (cast (l0 <: usize) <: u8), (cast (l1 <: usize) <: u8) <: (u8 & u8) with
-        | 0uy, 0uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 0 ->
           (match
               check_server_name (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
             with
-            | Core.Result.Result_Ok hoist151 ->
+            | Core.Result.Result_Ok hoist64 ->
               Core.Result.Result_Ok
-              (sz 4 +! len,
+              (mk_usize 4 +! len,
                 ({
                     f_sni
                     =
-                    Core.Option.Option_Some hoist151
+                    Core.Option.Option_Some hoist64
                     <:
                     Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
                     f_key_share
@@ -1612,91 +2702,101 @@ let check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8) 
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
-        | 0uy, 45uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 45 ->
           (match
               check_psk_key_exchange_modes (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
             with
             | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+              Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
-        | 0uy, 43uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 43 ->
           (match
               check_supported_versions (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
             with
             | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+              Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
-        | 0uy, 10uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 10 ->
           (match
               check_supported_groups algs
                 (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
             with
             | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+              Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
-        | 0uy, 13uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 13 ->
           (match
               check_signature_algorithms algs
                 (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
             with
             | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+              Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
-        | 0uy, 51uy ->
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 51 ->
           (match
               check_key_shares algs
                 (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
             with
             | Core.Result.Result_Ok gx ->
               Core.Result.Result_Ok
-              (sz 4 +! len,
+              (mk_usize 4 +! len,
                 ({
                     f_sni
                     =
@@ -1718,418 +2818,191 @@ let check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8) 
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err _ ->
-              Bertie.Tls13utils.tlserr Bertie.Tls13utils.v_MISSING_KEY_SHARE)
-        | 0uy, 41uy ->
+              Bertie.Tls13utils.tlserr #(usize & t_Extensions) Bertie.Tls13utils.v_MISSING_KEY_SHARE
+          )
+        | Rust_primitives.Integers.MkInt 0, Rust_primitives.Integers.MkInt 41 ->
           (match
               check_psk_shared_key algs
                 (bytes.[ {
-                      Core.Ops.Range.f_start = sz 4;
-                      Core.Ops.Range.f_end = sz 4 +! len <: usize
+                      Core.Ops.Range.f_start = mk_usize 4;
+                      Core.Ops.Range.f_end = mk_usize 4 +! len <: usize
                     }
                     <:
                     Core.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
+              <:
+              Core.Result.t_Result Prims.unit u8
             with
             | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+              Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
               <:
               Core.Result.t_Result (usize & t_Extensions) u8
             | Core.Result.Result_Err err ->
               Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8)
         | _ ->
-          Core.Result.Result_Ok (sz 4 +! len, out <: (usize & t_Extensions))
+          Core.Result.Result_Ok (mk_usize 4 +! len, out <: (usize & t_Extensions))
           <:
           Core.Result.t_Result (usize & t_Extensions) u8)
     | Core.Result.Result_Err err ->
       Core.Result.Result_Err err <: Core.Result.t_Result (usize & t_Extensions) u8
-
-let finished (vd: Bertie.Tls13utils.t_Bytes) =
-  Bertie.Tls13formats.Handshake_data.impl__HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_Finished
-      <:
-      Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-    vd
-
-let get_handshake_record (p: Bertie.Tls13utils.t_Bytes) =
-  match check_handshake_record p with
-  | Core.Result.Result_Ok (hd, len) ->
-    if len =. (Bertie.Tls13utils.impl__Bytes__len p <: usize)
-    then
-      Core.Result.Result_Ok hd
-      <:
-      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-    else
-      Core.Result.Result_Err (Bertie.Tls13utils.parse_failed ())
-      <:
-      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-
-let handshake_record (p: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
-  let ty:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.bytes1 (cast (discriminant_ContentType_Handshake +! 0uy <: u8) <: u8)
-  in
-  let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 3uy 3uy in
-  match Bertie.Tls13utils.encode_length_u16 p.Bertie.Tls13formats.Handshake_data._0 with
-  | Core.Result.Result_Ok hoist155 ->
-    Core.Result.Result_Ok
-    (Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__concat ty ver
-          <:
-          Bertie.Tls13utils.t_Bytes)
-        hoist155)
-    <:
-    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let parse_certificate_verify
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (certificate_verify: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-     =
-  match
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__as_handshake_message certificate_verify
-      (Bertie.Tls13formats.Handshake_data.HandshakeType_CertificateVerify
-        <:
-        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-  with
-  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData cv) ->
-    let sa:Bertie.Tls13crypto.t_SignatureScheme =
-      Bertie.Tls13crypto.impl__Algorithms__signature algs
-    in
-    (match Bertie.Tls13crypto.impl__Algorithms__signature_algorithm algs with
-      | Core.Result.Result_Ok hoist157 ->
-        (match
-            Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw hoist157
-                <:
-                t_Slice u8)
-              (Bertie.Tls13utils.impl__Bytes__as_raw cv <: t_Slice u8)
-              (sz 0)
-              (sz 2)
-          with
-          | Core.Result.Result_Ok _ ->
-            (match
-                Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl__Bytes__slice_range
-                      cv
-                      ({
-                          Core.Ops.Range.f_start = sz 2;
-                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len cv <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize)
-                    <:
-                    Bertie.Tls13utils.t_Bytes)
-              with
-              | Core.Result.Result_Ok _ ->
-                (match sa with
-                  | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
-                    parse_ecdsa_signature (Bertie.Tls13utils.impl__Bytes__slice_range cv
-                          ({
-                              Core.Ops.Range.f_start = sz 4;
-                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len cv <: usize
-                            }
-                            <:
-                            Core.Ops.Range.t_Range usize)
-                        <:
-                        Bertie.Tls13utils.t_Bytes)
-                  | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
-                    Core.Result.Result_Ok
-                    (Bertie.Tls13utils.impl__Bytes__slice_range cv
-                        ({
-                            Core.Ops.Range.f_start = sz 4;
-                            Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len cv <: usize
-                          }
-                          <:
-                          Core.Ops.Range.t_Range usize))
-                    <:
-                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-                  | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
-                    if ((Bertie.Tls13utils.impl__Bytes__len cv <: usize) -! sz 4 <: usize) =. sz 64
-                    then
-                      Core.Result.Result_Ok
-                      (Bertie.Tls13utils.impl__Bytes__slice_range cv
-                          ({
-                              Core.Ops.Range.f_start = sz 4;
-                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len cv <: usize
-                            }
-                            <:
-                            Core.Ops.Range.t_Range usize))
-                      <:
-                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-                    else
-                      Core.Result.Result_Err Bertie.Tls13utils.v_INVALID_SIGNATURE
-                      <:
-                      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let parse_encrypted_extensions
-      (v__algs: Bertie.Tls13crypto.t_Algorithms)
-      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-     =
-  let Bertie.Tls13formats.Handshake_data.HandshakeData encrypted_extension_bytes:Bertie.Tls13formats.Handshake_data.t_HandshakeData
-  =
-    encrypted_extensions
-  in
-  let expected_handshake_type:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.bytes1 (cast (Bertie.Tls13formats.Handshake_data.discriminant_HandshakeType_EncryptedExtensions +!
-            0uy
-            <:
-            u8)
-        <:
-        u8)
-  in
-  match
-    Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw expected_handshake_type
-
-        <:
-        t_Slice u8)
-      (Bertie.Tls13utils.impl__Bytes__as_raw encrypted_extension_bytes <: t_Slice u8)
-      (sz 0)
-      (sz 1)
-  with
-  | Core.Result.Result_Ok _ ->
-    Bertie.Tls13utils.check_length_encoding_u24 (Bertie.Tls13utils.impl__Bytes__raw_slice encrypted_extension_bytes
-          ({
-              Core.Ops.Range.f_start = sz 1;
-              Core.Ops.Range.f_end
-              =
-              Bertie.Tls13utils.impl__Bytes__len encrypted_extension_bytes <: usize
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        t_Slice u8)
-  | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result Prims.unit u8
-
-let parse_finished (finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
-  match
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__as_handshake_message finished
-      (Bertie.Tls13formats.Handshake_data.HandshakeType_Finished
-        <:
-        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-  with
-  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData fin) ->
-    Core.Result.Result_Ok fin <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let parse_server_certificate (certificate: Bertie.Tls13formats.Handshake_data.t_HandshakeData) =
-  match
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__as_handshake_message certificate
-      (Bertie.Tls13formats.Handshake_data.HandshakeType_Certificate
-        <:
-        Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-  with
-  | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData sc) ->
-    let next:usize = sz 0 in
-    (match
-        Bertie.Tls13utils.length_u8_encoded (sc.[ {
-                Core.Ops.Range.f_start = sz 0;
-                Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sc <: usize
-              }
-              <:
-              Core.Ops.Range.t_Range usize ]
-            <:
-            t_Slice u8)
-      with
-      | Core.Result.Result_Ok creqlen ->
-        let next:usize = (next +! sz 1 <: usize) +! creqlen in
-        (match
-            Bertie.Tls13utils.check_length_encoding_u24 (Bertie.Tls13utils.impl__Bytes__raw_slice sc
-                  ({
-                      Core.Ops.Range.f_start = next;
-                      Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sc <: usize
-                    }
-                    <:
-                    Core.Ops.Range.t_Range usize)
-                <:
-                t_Slice u8)
-          with
-          | Core.Result.Result_Ok _ ->
-            let next:usize = next +! sz 3 in
-            (match
-                Bertie.Tls13utils.length_u24_encoded (Bertie.Tls13utils.impl__Bytes__raw_slice sc
-                      ({
-                          Core.Ops.Range.f_start = next;
-                          Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sc <: usize
-                        }
-                        <:
-                        Core.Ops.Range.t_Range usize)
-                    <:
-                    t_Slice u8)
-              with
-              | Core.Result.Result_Ok crtlen ->
-                let next:usize = next +! sz 3 in
-                let crt:Bertie.Tls13utils.t_Bytes =
-                  Bertie.Tls13utils.impl__Bytes__slice_range sc
-                    ({
-                        Core.Ops.Range.f_start = next;
-                        Core.Ops.Range.f_end = next +! crtlen <: usize
-                      }
-                      <:
-                      Core.Ops.Range.t_Range usize)
-                in
-                let next:usize = next +! crtlen in
-                (match
-                    Bertie.Tls13utils.length_u16_encoded (sc.[ {
-                            Core.Ops.Range.f_start = next;
-                            Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len sc <: usize
-                          }
-                          <:
-                          Core.Ops.Range.t_Range usize ]
-                        <:
-                        t_Slice u8)
-                  with
-                  | Core.Result.Result_Ok v__extlen ->
-                    Core.Result.Result_Ok crt <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
 
 let parse_server_hello
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (server_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
      =
   match
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__as_handshake_message server_hello
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__as_handshake_message server_hello
       (Bertie.Tls13formats.Handshake_data.HandshakeType_ServerHello
         <:
         Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
   with
   | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData server_hello) ->
-    let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 3uy 3uy in
-    (match Bertie.Tls13crypto.impl__Algorithms__ciphersuite algs with
+    let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+    (match
+        Bertie.Tls13crypto.impl_Algorithms__ciphersuite algs
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
       | Core.Result.Result_Ok cip ->
-        let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 0uy in
-        let next:usize = sz 0 in
+        let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 (mk_u8 0) in
+        let next:usize = mk_usize 0 in
         (match
-            match
-              Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw ver
-                  <:
-                  t_Slice u8)
-                (Bertie.Tls13utils.impl__Bytes__as_raw server_hello <: t_Slice u8)
-                next
-                (next +! sz 2 <: usize)
-            with
-            | Core.Result.Result_Ok _ ->
-              Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
-            | Core.Result.Result_Err _ -> protocol_version_alert ()
+            (match
+                Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw ver
+                    <:
+                    t_Slice u8)
+                  (Bertie.Tls13utils.impl_Bytes__as_raw server_hello <: t_Slice u8)
+                  next
+                  (next +! mk_usize 2 <: usize)
+                <:
+                Core.Result.t_Result Prims.unit u8
+              with
+              | Core.Result.Result_Ok _ ->
+                Core.Result.Result_Ok (() <: Prims.unit) <: Core.Result.t_Result Prims.unit u8
+              | Core.Result.Result_Err _ -> protocol_version_alert ())
+            <:
+            Core.Result.t_Result Prims.unit u8
           with
           | Core.Result.Result_Ok _ ->
-            let next:usize = next +! sz 2 in
+            let next:usize = next +! mk_usize 2 in
             (match
-                Bertie.Tls13utils.check ((Bertie.Tls13utils.impl__Bytes__len server_hello <: usize) >=.
-                    (next +! sz 32 <: usize)
+                Bertie.Tls13utils.check ((Bertie.Tls13utils.impl_Bytes__len server_hello <: usize) >=.
+                    (next +! mk_usize 32 <: usize)
                     <:
                     bool)
+                <:
+                Core.Result.t_Result Prims.unit u8
               with
               | Core.Result.Result_Ok _ ->
                 let srand:Bertie.Tls13utils.t_Bytes =
-                  Bertie.Tls13utils.impl__Bytes__slice_range server_hello
+                  Bertie.Tls13utils.impl_Bytes__slice_range server_hello
                     ({
                         Core.Ops.Range.f_start = next;
-                        Core.Ops.Range.f_end = next +! sz 32 <: usize
+                        Core.Ops.Range.f_end = next +! mk_usize 32 <: usize
                       }
                       <:
                       Core.Ops.Range.t_Range usize)
                 in
-                let next:usize = next +! sz 32 in
+                let next:usize = next +! mk_usize 32 in
                 (match
                     Bertie.Tls13utils.length_u8_encoded (server_hello.[ {
                             Core.Ops.Range.f_start = next;
                             Core.Ops.Range.f_end
                             =
-                            Bertie.Tls13utils.impl__Bytes__len server_hello <: usize
+                            Bertie.Tls13utils.impl_Bytes__len server_hello <: usize
                           }
                           <:
                           Core.Ops.Range.t_Range usize ]
                         <:
                         t_Slice u8)
+                    <:
+                    Core.Result.t_Result usize u8
                   with
                   | Core.Result.Result_Ok sidlen ->
-                    let next:usize = (next +! sz 1 <: usize) +! sidlen in
+                    let next:usize = (next +! mk_usize 1 <: usize) +! sidlen in
                     (match
-                        match
-                          Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw
-                                cip
-                              <:
-                              t_Slice u8)
-                            (Bertie.Tls13utils.impl__Bytes__as_raw server_hello <: t_Slice u8)
-                            next
-                            (next +! sz 2 <: usize)
-                        with
-                        | Core.Result.Result_Ok _ ->
-                          Core.Result.Result_Ok (() <: Prims.unit)
-                          <:
-                          Core.Result.t_Result Prims.unit u8
-                        | Core.Result.Result_Err _ -> unsupported_cipher_alert ()
-                      with
-                      | Core.Result.Result_Ok _ ->
-                        let next:usize = next +! sz 2 in
                         (match
-                            match
-                              Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw
-                                    comp
-                                  <:
-                                  t_Slice u8)
-                                (Bertie.Tls13utils.impl__Bytes__as_raw server_hello <: t_Slice u8)
-                                next
-                                (next +! sz 1 <: usize)
-                            with
-                            | Core.Result.Result_Ok _ ->
-                              Core.Result.Result_Ok (() <: Prims.unit)
-                              <:
-                              Core.Result.t_Result Prims.unit u8
-                            | Core.Result.Result_Err _ -> invalid_compression_method_alert ()
+                            Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw
+                                  cip
+                                <:
+                                t_Slice u8)
+                              (Bertie.Tls13utils.impl_Bytes__as_raw server_hello <: t_Slice u8)
+                              next
+                              (next +! mk_usize 2 <: usize)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
                           with
                           | Core.Result.Result_Ok _ ->
-                            let next:usize = next +! sz 1 in
+                            Core.Result.Result_Ok (() <: Prims.unit)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
+                          | Core.Result.Result_Err _ -> unsupported_cipher_alert ())
+                        <:
+                        Core.Result.t_Result Prims.unit u8
+                      with
+                      | Core.Result.Result_Ok _ ->
+                        let next:usize = next +! mk_usize 2 in
+                        (match
                             (match
-                                Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl__Bytes__slice_range
+                                Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw
+                                      comp
+                                    <:
+                                    t_Slice u8)
+                                  (Bertie.Tls13utils.impl_Bytes__as_raw server_hello <: t_Slice u8)
+                                  next
+                                  (next +! mk_usize 1 <: usize)
+                                <:
+                                Core.Result.t_Result Prims.unit u8
+                              with
+                              | Core.Result.Result_Ok _ ->
+                                Core.Result.Result_Ok (() <: Prims.unit)
+                                <:
+                                Core.Result.t_Result Prims.unit u8
+                              | Core.Result.Result_Err _ -> invalid_compression_method_alert ())
+                            <:
+                            Core.Result.t_Result Prims.unit u8
+                          with
+                          | Core.Result.Result_Ok _ ->
+                            let next:usize = next +! mk_usize 1 in
+                            (match
+                                Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl_Bytes__slice_range
                                       server_hello
                                       ({
                                           Core.Ops.Range.f_start = next;
                                           Core.Ops.Range.f_end
                                           =
-                                          Bertie.Tls13utils.impl__Bytes__len server_hello <: usize
+                                          Bertie.Tls13utils.impl_Bytes__len server_hello <: usize
                                         }
                                         <:
                                         Core.Ops.Range.t_Range usize)
                                     <:
                                     Bertie.Tls13utils.t_Bytes)
+                                <:
+                                Core.Result.t_Result Prims.unit u8
                               with
                               | Core.Result.Result_Ok _ ->
-                                let next:usize = next +! sz 2 in
+                                let next:usize = next +! mk_usize 2 in
                                 (match
                                     check_server_extensions algs
                                       (server_hello.[ {
                                             Core.Ops.Range.f_start = next;
                                             Core.Ops.Range.f_end
                                             =
-                                            Bertie.Tls13utils.impl__Bytes__len server_hello <: usize
+                                            Bertie.Tls13utils.impl_Bytes__len server_hello <: usize
                                           }
                                           <:
                                           Core.Ops.Range.t_Range usize ]
                                         <:
                                         t_Slice u8)
+                                    <:
+                                    Core.Result.t_Result
+                                      (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8
                                   with
                                   | Core.Result.Result_Ok gy ->
-                                    (match gy with
+                                    (match gy <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes with
                                       | Core.Option.Option_Some gy ->
                                         Core.Result.Result_Ok
                                         (srand, gy
@@ -2185,346 +3058,55 @@ let parse_server_hello
     <:
     Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8
 
-let server_certificate (v__algs: Bertie.Tls13crypto.t_Algorithms) (cert: Bertie.Tls13utils.t_Bytes) =
-  match
-    Bertie.Tls13utils.encode_length_u8 (Rust_primitives.unsize (let list:Prims.list u8 = [] in
-            FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
-            Rust_primitives.Hax.array_of_list 0 list)
-        <:
-        t_Slice u8)
-  with
-  | Core.Result.Result_Ok creq ->
-    (match Bertie.Tls13utils.encode_length_u24 cert with
-      | Core.Result.Result_Ok crt ->
-        (match
-            Bertie.Tls13utils.encode_length_u16 (Bertie.Tls13utils.impl__Bytes__new ()
-                <:
-                Bertie.Tls13utils.t_Bytes)
-          with
-          | Core.Result.Result_Ok ext ->
-            (match
-                Bertie.Tls13utils.encode_length_u24 (Bertie.Tls13utils.impl__Bytes__concat crt ext
-                    <:
-                    Bertie.Tls13utils.t_Bytes)
-              with
-              | Core.Result.Result_Ok crts ->
-                Bertie.Tls13formats.Handshake_data.impl__HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_Certificate
-                    <:
-                    Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-                  (Bertie.Tls13utils.impl__Bytes__concat creq crts <: Bertie.Tls13utils.t_Bytes)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-
-let server_hello (algs: Bertie.Tls13crypto.t_Algorithms) (sr sid gy: Bertie.Tls13utils.t_Bytes) =
-  Rust_primitives.Hax.Control_flow_monad.Mexception.run (let ver:Bertie.Tls13utils.t_Bytes =
-        Bertie.Tls13utils.bytes2 3uy 3uy
-      in
-      match
-        Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw sid <: t_Slice u8)
-      with
-      | Core.Result.Result_Ok sid ->
-        (match Bertie.Tls13crypto.impl__Algorithms__ciphersuite algs with
-          | Core.Result.Result_Ok cip ->
-            let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes1 0uy in
-            (match server_key_shares algs (Core.Clone.f_clone gy <: Bertie.Tls13utils.t_Bytes) with
-              | Core.Result.Result_Ok ks ->
-                (match server_supported_version algs with
-                  | Core.Result.Result_Ok sv ->
-                    let exts:Bertie.Tls13utils.t_Bytes =
-                      Bertie.Tls13utils.impl__Bytes__concat ks sv
-                    in
-                    let! exts:Bertie.Tls13utils.t_Bytes =
-                      match Bertie.Tls13crypto.impl__Algorithms__psk_mode algs with
-                      | true ->
-                        (match server_pre_shared_key algs with
-                          | Core.Result.Result_Ok hoist160 ->
-                            Core.Ops.Control_flow.ControlFlow_Continue
-                            (Bertie.Tls13utils.impl__Bytes__concat exts hoist160)
-                            <:
-                            Core.Ops.Control_flow.t_ControlFlow
-                              (Core.Result.t_Result
-                                  Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                              Bertie.Tls13utils.t_Bytes
-                          | Core.Result.Result_Err err ->
-                            let! _:Prims.unit =
-                              Core.Ops.Control_flow.ControlFlow_Break
-                              (Core.Result.Result_Err err
-                                <:
-                                Core.Result.t_Result
-                                  Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                              <:
-                              Core.Ops.Control_flow.t_ControlFlow
-                                (Core.Result.t_Result
-                                    Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                                Prims.unit
-                            in
-                            Core.Ops.Control_flow.ControlFlow_Continue exts
-                            <:
-                            Core.Ops.Control_flow.t_ControlFlow
-                              (Core.Result.t_Result
-                                  Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                              Bertie.Tls13utils.t_Bytes)
-                      | false ->
-                        Core.Ops.Control_flow.ControlFlow_Continue exts
-                        <:
-                        Core.Ops.Control_flow.t_ControlFlow
-                          (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
-                              u8) Bertie.Tls13utils.t_Bytes
-                    in
-                    Core.Ops.Control_flow.ControlFlow_Continue
-                    (match Bertie.Tls13utils.encode_length_u16 exts with
-                      | Core.Result.Result_Ok encoded_extensions ->
-                        let len:usize =
-                          (Bertie.Tls13utils.impl__Bytes__len ver <: usize) +!
-                          (Bertie.Tls13utils.impl__Bytes__len sr <: usize)
-                        in
-                        let len:usize = len +! (Bertie.Tls13utils.impl__Bytes__len sid <: usize) in
-                        let len:usize = len +! (Bertie.Tls13utils.impl__Bytes__len cip <: usize) in
-                        let len:usize = len +! (Bertie.Tls13utils.impl__Bytes__len comp <: usize) in
-                        let len:usize =
-                          len +! (Bertie.Tls13utils.impl__Bytes__len encoded_extensions <: usize)
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__new_alloc len
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out ver
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out sr
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out sid
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out cip
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out comp
-                        in
-                        let out:Bertie.Tls13utils.t_Bytes =
-                          Bertie.Tls13utils.impl__Bytes__append out encoded_extensions
-                        in
-                        (match
-                            Bertie.Tls13formats.Handshake_data.impl__HandshakeData__from_bytes (Bertie.Tls13formats.Handshake_data.HandshakeType_ServerHello
-                                <:
-                                Bertie.Tls13formats.Handshake_data.t_HandshakeType)
-                              out
-                          with
-                          | Core.Result.Result_Ok sh ->
-                            Core.Result.Result_Ok sh
-                            <:
-                            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
-                              u8
-                          | Core.Result.Result_Err err ->
-                            Core.Result.Result_Err err
-                            <:
-                            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData
-                              u8)
-                      | Core.Result.Result_Err err ->
-                        Core.Result.Result_Err err
-                        <:
-                        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                      (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                  | Core.Result.Result_Err err ->
-                    Core.Ops.Control_flow.ControlFlow_Continue
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                    <:
-                    Core.Ops.Control_flow.t_ControlFlow
-                      (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                      (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8))
-              | Core.Result.Result_Err err ->
-                Core.Ops.Control_flow.ControlFlow_Continue
-                (Core.Result.Result_Err err
-                  <:
-                  Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                <:
-                Core.Ops.Control_flow.t_ControlFlow
-                  (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-                  (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8))
-          | Core.Result.Result_Err err ->
-            Core.Ops.Control_flow.ControlFlow_Continue
-            (Core.Result.Result_Err err
-              <:
-              Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-            <:
-            Core.Ops.Control_flow.t_ControlFlow
-              (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-              (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8))
-      | Core.Result.Result_Err err ->
-        Core.Ops.Control_flow.ControlFlow_Continue
-        (Core.Result.Result_Err err
-          <:
-          Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-        <:
-        Core.Ops.Control_flow.t_ControlFlow
-          (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-          (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8))
-
-let set_client_hello_binder
-      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (binder: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (trunc_len: Core.Option.t_Option usize)
-     =
-  let Bertie.Tls13formats.Handshake_data.HandshakeData ch:Bertie.Tls13formats.Handshake_data.t_HandshakeData
-  =
-    client_hello
-  in
-  let chlen:usize = Bertie.Tls13utils.impl__Bytes__len ch in
-  let hlen:usize =
-    Bertie.Tls13crypto.impl__HashAlgorithm__hash_len (Bertie.Tls13crypto.impl__Algorithms__hash ciphersuite
-
-        <:
-        Bertie.Tls13crypto.t_HashAlgorithm)
-  in
-  match
-    binder, trunc_len
-    <:
-    (Core.Option.t_Option Bertie.Tls13utils.t_Bytes & Core.Option.t_Option usize)
-  with
-  | Core.Option.Option_Some m, Core.Option.Option_Some trunc_len ->
-    if (chlen -! hlen <: usize) =. trunc_len
-    then
-      Core.Result.Result_Ok
-      (Bertie.Tls13formats.Handshake_data.HandshakeData
-        (Bertie.Tls13utils.impl__Bytes__update_slice ch trunc_len m (sz 0) hlen)
-        <:
-        Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      <:
-      Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-    else Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-  | Core.Option.Option_None , Core.Option.Option_None  ->
-    Core.Result.Result_Ok
-    (Bertie.Tls13formats.Handshake_data.HandshakeData ch
-      <:
-      Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    <:
-    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
-  | _, _ -> Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-
-let impl__Transcript__add
-      (self: t_Transcript)
-      (msg: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-     =
-  let self:t_Transcript =
-    {
-      self with
-      f_transcript
-      =
-      Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat self.f_transcript msg
-    }
-    <:
-    t_Transcript
-  in
-  self
-
-let impl__Transcript__new (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm) =
-  {
-    f_hash_algorithm = hash_algorithm;
-    f_transcript
-    =
-    Bertie.Tls13formats.Handshake_data.HandshakeData (Bertie.Tls13utils.impl__Bytes__new ())
-    <:
-    Bertie.Tls13formats.Handshake_data.t_HandshakeData
-  }
-  <:
-  t_Transcript
-
-let impl__Transcript__transcript_hash (self: t_Transcript) =
-  match
-    Bertie.Tls13crypto.impl__HashAlgorithm__hash self.f_hash_algorithm
-      self.f_transcript.Bertie.Tls13formats.Handshake_data._0
-  with
-  | Core.Result.Result_Ok th ->
-    Core.Result.Result_Ok th <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let impl__Transcript__transcript_hash_without_client_hello
-      (self: t_Transcript)
-      (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (trunc_len: usize)
-     =
-  let Bertie.Tls13formats.Handshake_data.HandshakeData ch:Bertie.Tls13formats.Handshake_data.t_HandshakeData
-  =
-    client_hello
-  in
-  Bertie.Tls13crypto.impl__HashAlgorithm__hash self.f_hash_algorithm
-    (Bertie.Tls13utils.impl__Bytes__concat (Core.Clone.f_clone self.f_transcript
-              .Bertie.Tls13formats.Handshake_data._0
-          <:
-          Bertie.Tls13utils.t_Bytes)
-        (Bertie.Tls13utils.impl__Bytes__slice_range client_hello
-              .Bertie.Tls13formats.Handshake_data._0
-            ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = trunc_len }
-              <:
-              Core.Ops.Range.t_Range usize)
-          <:
-          Bertie.Tls13utils.t_Bytes)
-      <:
-      Bertie.Tls13utils.t_Bytes)
-
 let rec check_extensions_slice (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8) =
-  match check_extension algs b with
+  match check_extension algs b <: Core.Result.t_Result (usize & t_Extensions) u8 with
   | Core.Result.Result_Ok (len, out) ->
-    if len =. (Core.Slice.impl__len b <: usize)
+    if len =. (Core.Slice.impl__len #u8 b <: usize)
     then Core.Result.Result_Ok out <: Core.Result.t_Result t_Extensions u8
     else
       (match
           check_extensions_slice algs
             (b.[ {
                   Core.Ops.Range.f_start = len;
-                  Core.Ops.Range.f_end = Core.Slice.impl__len b <: usize
+                  Core.Ops.Range.f_end = Core.Slice.impl__len #u8 b <: usize
                 }
                 <:
                 Core.Ops.Range.t_Range usize ]
               <:
               t_Slice u8)
+          <:
+          Core.Result.t_Result t_Extensions u8
         with
-        | Core.Result.Result_Ok out_rest -> impl__Extensions__merge out out_rest
+        | Core.Result.Result_Ok out_rest -> impl_Extensions__merge out out_rest
         | Core.Result.Result_Err err ->
           Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8)
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8
 
 let check_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: Bertie.Tls13utils.t_Bytes) =
-  match check_extension algs (Bertie.Tls13utils.impl__Bytes__as_raw b <: t_Slice u8) with
+  match
+    check_extension algs (Bertie.Tls13utils.impl_Bytes__as_raw b <: t_Slice u8)
+    <:
+    Core.Result.t_Result (usize & t_Extensions) u8
+  with
   | Core.Result.Result_Ok (len, out) ->
-    if len =. (Bertie.Tls13utils.impl__Bytes__len b <: usize)
+    if len =. (Bertie.Tls13utils.impl_Bytes__len b <: usize)
     then Core.Result.Result_Ok out <: Core.Result.t_Result t_Extensions u8
     else
       (match
           check_extensions_slice algs
-            (Bertie.Tls13utils.impl__Bytes__raw_slice b
+            (Bertie.Tls13utils.impl_Bytes__raw_slice b
                 ({
                     Core.Ops.Range.f_start = len;
-                    Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len b <: usize
+                    Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len b <: usize
                   }
                   <:
                   Core.Ops.Range.t_Range usize)
               <:
               t_Slice u8)
+          <:
+          Core.Result.t_Result t_Extensions u8
         with
-        | Core.Result.Result_Ok out_rest -> impl__Extensions__merge out out_rest
+        | Core.Result.Result_Ok out_rest -> impl_Extensions__merge out out_rest
         | Core.Result.Result_Err err ->
           Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8)
   | Core.Result.Result_Err err -> Core.Result.Result_Err err <: Core.Result.t_Result t_Extensions u8
@@ -2534,126 +3116,147 @@ let parse_client_hello
       (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
      =
   match
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__as_handshake_message client_hello
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__as_handshake_message client_hello
       (Bertie.Tls13formats.Handshake_data.HandshakeType_ClientHello
         <:
         Bertie.Tls13formats.Handshake_data.t_HandshakeType)
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
   with
   | Core.Result.Result_Ok (Bertie.Tls13formats.Handshake_data.HandshakeData ch) ->
-    let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 3uy 3uy in
-    let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 1uy 0uy in
-    let next:usize = sz 0 in
+    let ver:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 3) (mk_u8 3) in
+    let comp:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.bytes2 (mk_u8 1) (mk_u8 0) in
+    let next:usize = mk_usize 0 in
     (match
-        Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw ver
+        Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw ver
             <:
             t_Slice u8)
-          (Bertie.Tls13utils.impl__Bytes__as_raw ch <: t_Slice u8)
+          (Bertie.Tls13utils.impl_Bytes__as_raw ch <: t_Slice u8)
           next
-          (next +! sz 2 <: usize)
+          (next +! mk_usize 2 <: usize)
+        <:
+        Core.Result.t_Result Prims.unit u8
       with
       | Core.Result.Result_Ok _ ->
-        let next:usize = next +! sz 2 in
+        let next:usize = next +! mk_usize 2 in
         (match
-            Bertie.Tls13utils.check ((Bertie.Tls13utils.impl__Bytes__len ch <: usize) >=.
-                (next +! sz 32 <: usize)
+            Bertie.Tls13utils.check ((Bertie.Tls13utils.impl_Bytes__len ch <: usize) >=.
+                (next +! mk_usize 32 <: usize)
                 <:
                 bool)
+            <:
+            Core.Result.t_Result Prims.unit u8
           with
           | Core.Result.Result_Ok _ ->
             let crand:Bertie.Tls13utils.t_Bytes =
-              Bertie.Tls13utils.impl__Bytes__slice_range ch
-                ({ Core.Ops.Range.f_start = next; Core.Ops.Range.f_end = next +! sz 32 <: usize }
+              Bertie.Tls13utils.impl_Bytes__slice_range ch
+                ({
+                    Core.Ops.Range.f_start = next;
+                    Core.Ops.Range.f_end = next +! mk_usize 32 <: usize
+                  }
                   <:
                   Core.Ops.Range.t_Range usize)
             in
-            let next:usize = next +! sz 32 in
+            let next:usize = next +! mk_usize 32 in
             (match
                 Bertie.Tls13utils.length_u8_encoded (ch.[ {
                         Core.Ops.Range.f_start = next;
-                        Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len ch <: usize
+                        Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len ch <: usize
                       }
                       <:
                       Core.Ops.Range.t_Range usize ]
                     <:
                     t_Slice u8)
+                <:
+                Core.Result.t_Result usize u8
               with
               | Core.Result.Result_Ok sidlen ->
                 let sid:Bertie.Tls13utils.t_Bytes =
-                  Bertie.Tls13utils.impl__Bytes__slice_range ch
+                  Bertie.Tls13utils.impl_Bytes__slice_range ch
                     ({
-                        Core.Ops.Range.f_start = next +! sz 1 <: usize;
-                        Core.Ops.Range.f_end = (next +! sz 1 <: usize) +! sidlen <: usize
+                        Core.Ops.Range.f_start = next +! mk_usize 1 <: usize;
+                        Core.Ops.Range.f_end = (next +! mk_usize 1 <: usize) +! sidlen <: usize
                       }
                       <:
                       Core.Ops.Range.t_Range usize)
                 in
-                let next:usize = (next +! sz 1 <: usize) +! sidlen in
+                let next:usize = (next +! mk_usize 1 <: usize) +! sidlen in
                 (match
-                    Bertie.Tls13crypto.impl__Algorithms__check ciphersuite
-                      (Bertie.Tls13utils.impl__Bytes__raw_slice ch
+                    Bertie.Tls13crypto.impl_Algorithms__check ciphersuite
+                      (Bertie.Tls13utils.impl_Bytes__raw_slice ch
                           ({
                               Core.Ops.Range.f_start = next;
-                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len ch <: usize
+                              Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len ch <: usize
                             }
                             <:
                             Core.Ops.Range.t_Range usize)
                         <:
                         t_Slice u8)
+                    <:
+                    Core.Result.t_Result usize u8
                   with
                   | Core.Result.Result_Ok cslen ->
                     let next:usize = next +! cslen in
                     (match
-                        match
-                          Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl__Bytes__as_raw
-                                comp
-                              <:
-                              t_Slice u8)
-                            (Bertie.Tls13utils.impl__Bytes__as_raw ch <: t_Slice u8)
-                            next
-                            (next +! sz 2 <: usize)
-                        with
-                        | Core.Result.Result_Ok _ ->
-                          Core.Result.Result_Ok (() <: Prims.unit)
-                          <:
-                          Core.Result.t_Result Prims.unit u8
-                        | Core.Result.Result_Err _ -> invalid_compression_list ()
+                        (match
+                            Bertie.Tls13utils.check_eq_with_slice (Bertie.Tls13utils.impl_Bytes__as_raw
+                                  comp
+                                <:
+                                t_Slice u8)
+                              (Bertie.Tls13utils.impl_Bytes__as_raw ch <: t_Slice u8)
+                              next
+                              (next +! mk_usize 2 <: usize)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
+                          with
+                          | Core.Result.Result_Ok _ ->
+                            Core.Result.Result_Ok (() <: Prims.unit)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
+                          | Core.Result.Result_Err _ -> invalid_compression_list ())
+                        <:
+                        Core.Result.t_Result Prims.unit u8
                       with
                       | Core.Result.Result_Ok _ ->
-                        let next:usize = next +! sz 2 in
+                        let next:usize = next +! mk_usize 2 in
                         (match
-                            Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl__Bytes__slice_range
+                            Bertie.Tls13utils.check_length_encoding_u16 (Bertie.Tls13utils.impl_Bytes__slice_range
                                   ch
                                   ({
                                       Core.Ops.Range.f_start = next;
                                       Core.Ops.Range.f_end
                                       =
-                                      Bertie.Tls13utils.impl__Bytes__len ch <: usize
+                                      Bertie.Tls13utils.impl_Bytes__len ch <: usize
                                     }
                                     <:
                                     Core.Ops.Range.t_Range usize)
                                 <:
                                 Bertie.Tls13utils.t_Bytes)
+                            <:
+                            Core.Result.t_Result Prims.unit u8
                           with
                           | Core.Result.Result_Ok _ ->
-                            let next:usize = next +! sz 2 in
+                            let next:usize = next +! mk_usize 2 in
                             (match
                                 check_extensions ciphersuite
-                                  (Bertie.Tls13utils.impl__Bytes__slice_range ch
+                                  (Bertie.Tls13utils.impl_Bytes__slice_range ch
                                       ({
                                           Core.Ops.Range.f_start = next;
                                           Core.Ops.Range.f_end
                                           =
-                                          Bertie.Tls13utils.impl__Bytes__len ch <: usize
+                                          Bertie.Tls13utils.impl_Bytes__len ch <: usize
                                         }
                                         <:
                                         Core.Ops.Range.t_Range usize)
                                     <:
                                     Bertie.Tls13utils.t_Bytes)
+                                <:
+                                Core.Result.t_Result t_Extensions u8
                               with
                               | Core.Result.Result_Ok exts ->
                                 let trunc_len:usize =
-                                  ((Bertie.Tls13utils.impl__Bytes__len ch <: usize) -!
-                                    (Bertie.Tls13crypto.impl__HashAlgorithm__hash_len (Bertie.Tls13crypto.impl__Algorithms__hash
+                                  ((Bertie.Tls13utils.impl_Bytes__len ch <: usize) -!
+                                    (Bertie.Tls13crypto.impl_HashAlgorithm__hash_len (Bertie.Tls13crypto.impl_Algorithms__hash
                                             ciphersuite
                                           <:
                                           Bertie.Tls13crypto.t_HashAlgorithm)
@@ -2661,10 +3264,10 @@ let parse_client_hello
                                       usize)
                                     <:
                                     usize) -!
-                                  sz 3
+                                  mk_usize 3
                                 in
                                 (match
-                                    Bertie.Tls13crypto.impl__Algorithms__psk_mode ciphersuite, exts
+                                    Bertie.Tls13crypto.impl_Algorithms__psk_mode ciphersuite, exts
                                     <:
                                     (bool & t_Extensions)
                                   with
@@ -2722,7 +3325,7 @@ let parse_client_hello
                                     Core.Result.Result_Ok
                                     (crand,
                                       sid,
-                                      Bertie.Tls13utils.impl__Bytes__new (),
+                                      Bertie.Tls13utils.impl_Bytes__new (),
                                       gx,
                                       (Core.Option.Option_Some tkt
                                         <:
@@ -2762,7 +3365,7 @@ let parse_client_hello
                                       (Core.Option.Option_None
                                         <:
                                         Core.Option.t_Option Bertie.Tls13utils.t_Bytes),
-                                      sz 0
+                                      mk_usize 0
                                       <:
                                       (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes &
                                         Bertie.Tls13utils.t_Bytes &
@@ -2786,7 +3389,7 @@ let parse_client_hello
                                     Core.Result.Result_Ok
                                     (crand,
                                       sid,
-                                      Bertie.Tls13utils.impl__Bytes__new (),
+                                      Bertie.Tls13utils.impl_Bytes__new (),
                                       gx,
                                       (Core.Option.Option_None
                                         <:
@@ -2794,7 +3397,7 @@ let parse_client_hello
                                       (Core.Option.Option_None
                                         <:
                                         Core.Option.t_Option Bertie.Tls13utils.t_Bytes),
-                                      sz 0
+                                      mk_usize 0
                                       <:
                                       (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes &
                                         Bertie.Tls13utils.t_Bytes &

--- a/proofs/fstar/extraction/Bertie.Tls13formats.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13formats.fsti
@@ -3,58 +3,376 @@ module Bertie.Tls13formats
 open Core
 open FStar.Mul
 
-let discriminant_AlertDescription_AccessDenied: u8 = 49uy
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  ()
 
-let discriminant_AlertDescription_BadCertificate: u8 = 42uy
+let v_LABEL_IV: t_Array u8 (mk_usize 2) =
+  let list = [mk_u8 105; mk_u8 118] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
 
-let discriminant_AlertDescription_BadCertificateStatusResponse: u8 = 113uy
+let v_LABEL_KEY: t_Array u8 (mk_usize 3) =
+  let list = [mk_u8 107; mk_u8 101; mk_u8 121] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 3);
+  Rust_primitives.Hax.array_of_list 3 list
 
-let discriminant_AlertDescription_BadRecordMac: u8 = 20uy
+let v_LABEL_TLS13: t_Array u8 (mk_usize 6) =
+  let list = [mk_u8 116; mk_u8 108; mk_u8 115; mk_u8 49; mk_u8 51; mk_u8 32] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 6);
+  Rust_primitives.Hax.array_of_list 6 list
 
-let discriminant_AlertDescription_CertificateExpired: u8 = 45uy
+let v_LABEL_DERIVED: t_Array u8 (mk_usize 7) =
+  let list = [mk_u8 100; mk_u8 101; mk_u8 114; mk_u8 105; mk_u8 118; mk_u8 101; mk_u8 100] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 7);
+  Rust_primitives.Hax.array_of_list 7 list
 
-let discriminant_AlertDescription_CertificateRequired: u8 = 116uy
+let v_LABEL_FINISHED: t_Array u8 (mk_usize 8) =
+  let list =
+    [mk_u8 102; mk_u8 105; mk_u8 110; mk_u8 105; mk_u8 115; mk_u8 104; mk_u8 101; mk_u8 100]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
+  Rust_primitives.Hax.array_of_list 8 list
 
-let discriminant_AlertDescription_CertificateRevoked: u8 = 44uy
+let v_LABEL_RES_BINDER: t_Array u8 (mk_usize 10) =
+  let list =
+    [
+      mk_u8 114; mk_u8 101; mk_u8 115; mk_u8 32; mk_u8 98; mk_u8 105; mk_u8 110; mk_u8 100;
+      mk_u8 101; mk_u8 114
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
+  Rust_primitives.Hax.array_of_list 10 list
 
-let discriminant_AlertDescription_CertificateUnknown: u8 = 46uy
+let v_LABEL_EXP_MASTER: t_Array u8 (mk_usize 10) =
+  let list =
+    [
+      mk_u8 101; mk_u8 120; mk_u8 112; mk_u8 32; mk_u8 109; mk_u8 97; mk_u8 115; mk_u8 116;
+      mk_u8 101; mk_u8 114
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
+  Rust_primitives.Hax.array_of_list 10 list
 
-let discriminant_AlertDescription_CloseNotify: u8 = 0uy
+let v_LABEL_RES_MASTER: t_Array u8 (mk_usize 10) =
+  let list =
+    [
+      mk_u8 114; mk_u8 101; mk_u8 115; mk_u8 32; mk_u8 109; mk_u8 97; mk_u8 115; mk_u8 116;
+      mk_u8 101; mk_u8 114
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
+  Rust_primitives.Hax.array_of_list 10 list
 
-let discriminant_AlertDescription_DecodeError: u8 = 50uy
+let v_LABEL_C_E_TRAFFIC: t_Array u8 (mk_usize 11) =
+  let list =
+    [
+      mk_u8 99; mk_u8 32; mk_u8 101; mk_u8 32; mk_u8 116; mk_u8 114; mk_u8 97; mk_u8 102; mk_u8 102;
+      mk_u8 105; mk_u8 99
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 11);
+  Rust_primitives.Hax.array_of_list 11 list
 
-let discriminant_AlertDescription_DecryptError: u8 = 51uy
+let v_LABEL_E_EXP_MASTER: t_Array u8 (mk_usize 12) =
+  let list =
+    [
+      mk_u8 101; mk_u8 32; mk_u8 101; mk_u8 120; mk_u8 112; mk_u8 32; mk_u8 109; mk_u8 97; mk_u8 115;
+      mk_u8 116; mk_u8 101; mk_u8 114
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
+  Rust_primitives.Hax.array_of_list 12 list
 
-let discriminant_AlertDescription_HandshakeFailure: u8 = 40uy
+let v_LABEL_C_HS_TRAFFIC: t_Array u8 (mk_usize 12) =
+  let list =
+    [
+      mk_u8 99; mk_u8 32; mk_u8 104; mk_u8 115; mk_u8 32; mk_u8 116; mk_u8 114; mk_u8 97; mk_u8 102;
+      mk_u8 102; mk_u8 105; mk_u8 99
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
+  Rust_primitives.Hax.array_of_list 12 list
 
-let discriminant_AlertDescription_IllegalParameter: u8 = 47uy
+let v_LABEL_S_HS_TRAFFIC: t_Array u8 (mk_usize 12) =
+  let list =
+    [
+      mk_u8 115; mk_u8 32; mk_u8 104; mk_u8 115; mk_u8 32; mk_u8 116; mk_u8 114; mk_u8 97; mk_u8 102;
+      mk_u8 102; mk_u8 105; mk_u8 99
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
+  Rust_primitives.Hax.array_of_list 12 list
 
-let discriminant_AlertDescription_InappropriateFallback: u8 = 86uy
+let v_LABEL_C_AP_TRAFFIC: t_Array u8 (mk_usize 12) =
+  let list =
+    [
+      mk_u8 99; mk_u8 32; mk_u8 97; mk_u8 112; mk_u8 32; mk_u8 116; mk_u8 114; mk_u8 97; mk_u8 102;
+      mk_u8 102; mk_u8 105; mk_u8 99
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
+  Rust_primitives.Hax.array_of_list 12 list
 
-let discriminant_AlertDescription_InsufficientSecurity: u8 = 71uy
+let v_LABEL_S_AP_TRAFFIC: t_Array u8 (mk_usize 12) =
+  let list =
+    [
+      mk_u8 115; mk_u8 32; mk_u8 97; mk_u8 112; mk_u8 32; mk_u8 116; mk_u8 114; mk_u8 97; mk_u8 102;
+      mk_u8 102; mk_u8 105; mk_u8 99
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
+  Rust_primitives.Hax.array_of_list 12 list
 
-let discriminant_AlertDescription_InternalError: u8 = 80uy
+let v_PREFIX_SERVER_SIGNATURE: t_Array u8 (mk_usize 98) =
+  let list =
+    [
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32; mk_u8 32;
+      mk_u8 32; mk_u8 84; mk_u8 76; mk_u8 83; mk_u8 32; mk_u8 49; mk_u8 46; mk_u8 51; mk_u8 44;
+      mk_u8 32; mk_u8 115; mk_u8 101; mk_u8 114; mk_u8 118; mk_u8 101; mk_u8 114; mk_u8 32; mk_u8 67;
+      mk_u8 101; mk_u8 114; mk_u8 116; mk_u8 105; mk_u8 102; mk_u8 105; mk_u8 99; mk_u8 97;
+      mk_u8 116; mk_u8 101; mk_u8 86; mk_u8 101; mk_u8 114; mk_u8 105; mk_u8 102; mk_u8 121; mk_u8 0
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 98);
+  Rust_primitives.Hax.array_of_list 98 list
 
-let discriminant_AlertDescription_MissingExtension: u8 = 109uy
+let build_server_name__v_PREFIX1: t_Array u8 (mk_usize 2) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 0)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
 
-let discriminant_AlertDescription_NoApplicationProtocol: u8 = 120uy
+let build_server_name__v_PREFIX2: t_Array u8 (mk_usize 1) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+  Rust_primitives.Hax.array_of_list 1 list
 
-let discriminant_AlertDescription_ProtocolVersion: u8 = 70uy
+/// Build the server name out of the `name` bytes for the client hello.
+val build_server_name (name: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_RecordOverflow: u8 = 22uy
+/// Check the server name for the sni extension.
+/// Returns the value for the server name indicator when successful, and a `[TLSError`]
+/// otherwise.
+val check_server_name (extension: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_UnexpectedMessage: u8 = 10uy
+/// Build the supported versions bytes for the client hello.
+val supported_versions: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_UnknownCa: u8 = 48uy
+/// Check the TLS version in the provided `client_hello`.
+val check_supported_versions (client_hello: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_UnknownPskIdentity: u8 = 115uy
+let server_supported_version__v_SUPPORTED_VERSION_PREFIX: t_Array u8 (mk_usize 2) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 43)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
 
-let discriminant_AlertDescription_UnrecognizedName: u8 = 112uy
+val server_supported_version (e_algorithms: Bertie.Tls13crypto.t_Algorithms)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_UnsupportedCertificate: u8 = 43uy
+val check_server_supported_version (e_algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-let discriminant_AlertDescription_UnsupportedExtension: u8 = 110uy
+let supported_groups__v_SUPPORTED_GROUPS_PREFIX: t_Array u8 (mk_usize 2) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 10)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
 
+val supported_groups (algs: Bertie.Tls13crypto.t_Algorithms)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+let psk_key_exchange_modes__v_PSK_MODE_PREFIX: t_Array u8 (mk_usize 2) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 45)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
+
+val psk_key_exchange_modes: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_psk_key_exchange_modes (client_hello: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+let key_shares__v_PREFIX: t_Array u8 (mk_usize 2) =
+  let list = [Bertie.Tls13utils.v_U8 (mk_u8 0); Bertie.Tls13utils.v_U8 (mk_u8 51)] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
+
+val key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val server_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_server_key_share (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val pre_shared_key
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (session_ticket: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & usize) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_psk_shared_key (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val server_pre_shared_key (e_algs: Bertie.Tls13crypto.t_Algorithms)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_server_psk_shared_key (e_algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// TLS Extensions
+type t_Extensions = {
+  f_sni:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
+  f_key_share:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
+  f_ticket:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
+  f_binder:Core.Option.t_Option Bertie.Tls13utils.t_Bytes
+}
+
+/// Merge two options as xor and return `Some(value)`, `None`, or an error if
+/// both are `Some`.
+val merge_opts (#v_T: Type0) (o1 o2: Core.Option.t_Option v_T)
+    : Prims.Pure (Core.Result.t_Result (Core.Option.t_Option v_T) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Merge the two extensions.
+/// This will fail if both have set the same extension.
+val impl_Extensions__merge (self e2: t_Extensions)
+    : Prims.Pure (Core.Result.t_Result t_Extensions u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val check_server_extension (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// ```TLS
+/// enum {
+///     warning(1),
+///     fatal(2),
+///     (255)
+/// } AlertLevel;
+/// ```
+type t_AlertLevel =
+  | AlertLevel_Warning : t_AlertLevel
+  | AlertLevel_Fatal : t_AlertLevel
+
+let anon_const_AlertLevel_Warning__anon_const_0: u8 = mk_u8 1
+
+let anon_const_AlertLevel_Fatal__anon_const_0: u8 = mk_u8 2
+
+val t_AlertLevel_cast_to_repr (x: t_AlertLevel) : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_6:Core.Clone.t_Clone t_AlertLevel
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7:Core.Marker.t_Copy t_AlertLevel
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8:Core.Fmt.t_Debug t_AlertLevel
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9:Core.Marker.t_StructuralPartialEq t_AlertLevel
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10:Core.Cmp.t_PartialEq t_AlertLevel t_AlertLevel
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core.Convert.t_TryFrom t_AlertLevel u8 =
+  {
+    f_Error = u8;
+    f_try_from_pre = (fun (value: u8) -> true);
+    f_try_from_post = (fun (value: u8) (out: Core.Result.t_Result t_AlertLevel u8) -> true);
+    f_try_from
+    =
+    fun (value: u8) ->
+      match value <: u8 with
+      | Rust_primitives.Integers.MkInt 1 ->
+        Core.Result.Result_Ok (AlertLevel_Warning <: t_AlertLevel)
+        <:
+        Core.Result.t_Result t_AlertLevel u8
+      | Rust_primitives.Integers.MkInt 2 ->
+        Core.Result.Result_Ok (AlertLevel_Fatal <: t_AlertLevel)
+        <:
+        Core.Result.t_Result t_AlertLevel u8
+      | _ -> Bertie.Tls13utils.tlserr #t_AlertLevel (Bertie.Tls13utils.parse_failed () <: u8)
+  }
+
+/// ```TLS
+/// enum {
+///     close_notify(0),
+///     unexpected_message(10),
+///     bad_record_mac(20),
+///     record_overflow(22),
+///     handshake_failure(40),
+///     bad_certificate(42),
+///     unsupported_certificate(43),
+///     certificate_revoked(44),
+///     certificate_expired(45),
+///     certificate_unknown(46),
+///     illegal_parameter(47),
+///     unknown_ca(48),
+///     access_denied(49),
+///     decode_error(50),
+///     decrypt_error(51),
+///     protocol_version(70),
+///     insufficient_security(71),
+///     internal_error(80),
+///     inappropriate_fallback(86),
+///     user_canceled(90),
+///     missing_extension(109),
+///     unsupported_extension(110),
+///     unrecognized_name(112),
+///     bad_certificate_status_response(113),
+///     unknown_psk_identity(115),
+///     certificate_required(116),
+///     no_application_protocol(120),
+///     (255)
+/// } AlertDescription;
 type t_AlertDescription =
   | AlertDescription_CloseNotify : t_AlertDescription
   | AlertDescription_UnexpectedMessage : t_AlertDescription
@@ -84,208 +402,77 @@ type t_AlertDescription =
   | AlertDescription_CertificateRequired : t_AlertDescription
   | AlertDescription_NoApplicationProtocol : t_AlertDescription
 
-let discriminant_AlertDescription_UserCanceled: u8 = 90uy
+let anon_const_AlertDescription_CloseNotify__anon_const_0: u8 = mk_u8 0
+
+let anon_const_AlertDescription_UnexpectedMessage__anon_const_0: u8 = mk_u8 10
+
+let anon_const_AlertDescription_BadRecordMac__anon_const_0: u8 = mk_u8 20
+
+let anon_const_AlertDescription_RecordOverflow__anon_const_0: u8 = mk_u8 22
+
+let anon_const_AlertDescription_HandshakeFailure__anon_const_0: u8 = mk_u8 40
+
+let anon_const_AlertDescription_BadCertificate__anon_const_0: u8 = mk_u8 42
+
+let anon_const_AlertDescription_UnsupportedCertificate__anon_const_0: u8 = mk_u8 43
+
+let anon_const_AlertDescription_CertificateRevoked__anon_const_0: u8 = mk_u8 44
+
+let anon_const_AlertDescription_CertificateExpired__anon_const_0: u8 = mk_u8 45
+
+let anon_const_AlertDescription_CertificateUnknown__anon_const_0: u8 = mk_u8 46
+
+let anon_const_AlertDescription_IllegalParameter__anon_const_0: u8 = mk_u8 47
+
+let anon_const_AlertDescription_UnknownCa__anon_const_0: u8 = mk_u8 48
+
+let anon_const_AlertDescription_AccessDenied__anon_const_0: u8 = mk_u8 49
+
+let anon_const_AlertDescription_DecodeError__anon_const_0: u8 = mk_u8 50
+
+let anon_const_AlertDescription_DecryptError__anon_const_0: u8 = mk_u8 51
+
+let anon_const_AlertDescription_ProtocolVersion__anon_const_0: u8 = mk_u8 70
+
+let anon_const_AlertDescription_InsufficientSecurity__anon_const_0: u8 = mk_u8 71
+
+let anon_const_AlertDescription_InternalError__anon_const_0: u8 = mk_u8 80
+
+let anon_const_AlertDescription_InappropriateFallback__anon_const_0: u8 = mk_u8 86
+
+let anon_const_AlertDescription_UserCanceled__anon_const_0: u8 = mk_u8 90
+
+let anon_const_AlertDescription_MissingExtension__anon_const_0: u8 = mk_u8 109
+
+let anon_const_AlertDescription_UnsupportedExtension__anon_const_0: u8 = mk_u8 110
+
+let anon_const_AlertDescription_UnrecognizedName__anon_const_0: u8 = mk_u8 112
+
+let anon_const_AlertDescription_BadCertificateStatusResponse__anon_const_0: u8 = mk_u8 113
+
+let anon_const_AlertDescription_UnknownPskIdentity__anon_const_0: u8 = mk_u8 115
+
+let anon_const_AlertDescription_CertificateRequired__anon_const_0: u8 = mk_u8 116
+
+let anon_const_AlertDescription_NoApplicationProtocol__anon_const_0: u8 = mk_u8 120
 
 val t_AlertDescription_cast_to_repr (x: t_AlertDescription)
     : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
 
-let discriminant_AlertLevel_Fatal: u8 = 2uy
-
-type t_AlertLevel =
-  | AlertLevel_Warning : t_AlertLevel
-  | AlertLevel_Fatal : t_AlertLevel
-
-let discriminant_AlertLevel_Warning: u8 = 1uy
-
-val t_AlertLevel_cast_to_repr (x: t_AlertLevel) : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
-
-let discriminant_ContentType_Alert: u8 = 21uy
-
-let discriminant_ContentType_ApplicationData: u8 = 23uy
-
-let discriminant_ContentType_ChangeCipherSpec: u8 = 20uy
-
-let discriminant_ContentType_Handshake: u8 = 22uy
-
-type t_ContentType =
-  | ContentType_Invalid : t_ContentType
-  | ContentType_ChangeCipherSpec : t_ContentType
-  | ContentType_Alert : t_ContentType
-  | ContentType_Handshake : t_ContentType
-  | ContentType_ApplicationData : t_ContentType
-
-let discriminant_ContentType_Invalid: u8 = 0uy
-
-val t_ContentType_cast_to_repr (x: t_ContentType)
-    : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
-
-let v_LABEL_C_AP_TRAFFIC: t_Array u8 (sz 12) =
-  let list = [99uy; 32uy; 97uy; 112uy; 32uy; 116uy; 114uy; 97uy; 102uy; 102uy; 105uy; 99uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
-  Rust_primitives.Hax.array_of_list 12 list
-
-let v_LABEL_C_E_TRAFFIC: t_Array u8 (sz 11) =
-  let list = [99uy; 32uy; 101uy; 32uy; 116uy; 114uy; 97uy; 102uy; 102uy; 105uy; 99uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 11);
-  Rust_primitives.Hax.array_of_list 11 list
-
-let v_LABEL_C_HS_TRAFFIC: t_Array u8 (sz 12) =
-  let list = [99uy; 32uy; 104uy; 115uy; 32uy; 116uy; 114uy; 97uy; 102uy; 102uy; 105uy; 99uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
-  Rust_primitives.Hax.array_of_list 12 list
-
-let v_LABEL_DERIVED: t_Array u8 (sz 7) =
-  let list = [100uy; 101uy; 114uy; 105uy; 118uy; 101uy; 100uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 7);
-  Rust_primitives.Hax.array_of_list 7 list
-
-let v_LABEL_EXP_MASTER: t_Array u8 (sz 10) =
-  let list = [101uy; 120uy; 112uy; 32uy; 109uy; 97uy; 115uy; 116uy; 101uy; 114uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
-  Rust_primitives.Hax.array_of_list 10 list
-
-let v_LABEL_E_EXP_MASTER: t_Array u8 (sz 12) =
-  let list = [101uy; 32uy; 101uy; 120uy; 112uy; 32uy; 109uy; 97uy; 115uy; 116uy; 101uy; 114uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
-  Rust_primitives.Hax.array_of_list 12 list
-
-let v_LABEL_FINISHED: t_Array u8 (sz 8) =
-  let list = [102uy; 105uy; 110uy; 105uy; 115uy; 104uy; 101uy; 100uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
-  Rust_primitives.Hax.array_of_list 8 list
-
-let v_LABEL_IV: t_Array u8 (sz 2) =
-  let list = [105uy; 118uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-let v_LABEL_KEY: t_Array u8 (sz 3) =
-  let list = [107uy; 101uy; 121uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 3);
-  Rust_primitives.Hax.array_of_list 3 list
-
-let v_LABEL_RES_BINDER: t_Array u8 (sz 10) =
-  let list = [114uy; 101uy; 115uy; 32uy; 98uy; 105uy; 110uy; 100uy; 101uy; 114uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
-  Rust_primitives.Hax.array_of_list 10 list
-
-let v_LABEL_RES_MASTER: t_Array u8 (sz 10) =
-  let list = [114uy; 101uy; 115uy; 32uy; 109uy; 97uy; 115uy; 116uy; 101uy; 114uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
-  Rust_primitives.Hax.array_of_list 10 list
-
-let v_LABEL_S_AP_TRAFFIC: t_Array u8 (sz 12) =
-  let list = [115uy; 32uy; 97uy; 112uy; 32uy; 116uy; 114uy; 97uy; 102uy; 102uy; 105uy; 99uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
-  Rust_primitives.Hax.array_of_list 12 list
-
-let v_LABEL_S_HS_TRAFFIC: t_Array u8 (sz 12) =
-  let list = [115uy; 32uy; 104uy; 115uy; 32uy; 116uy; 114uy; 97uy; 102uy; 102uy; 105uy; 99uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 12);
-  Rust_primitives.Hax.array_of_list 12 list
-
-let v_LABEL_TLS13: t_Array u8 (sz 6) =
-  let list = [116uy; 108uy; 115uy; 49uy; 51uy; 32uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 6);
-  Rust_primitives.Hax.array_of_list 6 list
-
-let v_PREFIX_SERVER_SIGNATURE: t_Array u8 (sz 98) =
-  let list =
-    [
-      32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy;
-      32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy;
-      32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy;
-      32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy; 32uy;
-      84uy; 76uy; 83uy; 32uy; 49uy; 46uy; 51uy; 44uy; 32uy; 115uy; 101uy; 114uy; 118uy; 101uy; 114uy;
-      32uy; 67uy; 101uy; 114uy; 116uy; 105uy; 102uy; 105uy; 99uy; 97uy; 116uy; 101uy; 86uy; 101uy;
-      114uy; 105uy; 102uy; 121uy; 0uy
-    ]
-  in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 98);
-  Rust_primitives.Hax.array_of_list 98 list
-
-let build_server_name__PREFIX1: t_Array u8 (sz 2) =
-  let list = [Bertie.Tls13utils.v_U8 0uy; Bertie.Tls13utils.v_U8 0uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-let build_server_name__PREFIX2: t_Array u8 (sz 1) =
-  let list = [Bertie.Tls13utils.v_U8 0uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-  Rust_primitives.Hax.array_of_list 1 list
-
-let key_shares__PREFIX: t_Array u8 (sz 2) =
-  let list = [Bertie.Tls13utils.v_U8 0uy; Bertie.Tls13utils.v_U8 51uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-let psk_key_exchange_modes__PSK_MODE_PREFIX: t_Array u8 (sz 2) =
-  let list = [Bertie.Tls13utils.v_U8 0uy; Bertie.Tls13utils.v_U8 45uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-let server_supported_version__SUPPORTED_VERSION_PREFIX: t_Array u8 (sz 2) =
-  let list = [Bertie.Tls13utils.v_U8 0uy; Bertie.Tls13utils.v_U8 43uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-let supported_groups__SUPPORTED_GROUPS_PREFIX: t_Array u8 (sz 2) =
-  let list = [Bertie.Tls13utils.v_U8 0uy; Bertie.Tls13utils.v_U8 10uy] in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-  Rust_primitives.Hax.array_of_list 2 list
-
-val application_data_instead_of_handshake: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val invalid_compression_list: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val invalid_compression_method_alert: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val protocol_version_alert: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val unsupported_cipher_alert: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__ContentType__try_from_u8 (t: u8)
-    : Prims.Pure (Core.Result.t_Result t_ContentType u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_r_len (rlen: usize)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_psk_key_exchange_modes (client_hello: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_supported_versions (client_hello: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val merge_opts (#v_T: Type) (o1 o2: Core.Option.t_Option v_T)
-    : Prims.Pure (Core.Result.t_Result (Core.Option.t_Option v_T) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_11:Core.Clone.t_Clone t_AlertDescription
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_1: Core.Convert.t_TryFrom t_AlertLevel u8 =
-  {
-    f_Error = u8;
-    f_try_from_pre = (fun (value: u8) -> true);
-    f_try_from_post = (fun (value: u8) (out: Core.Result.t_Result t_AlertLevel u8) -> true);
-    f_try_from
-    =
-    fun (value: u8) ->
-      match value with
-      | 1uy ->
-        Core.Result.Result_Ok (AlertLevel_Warning <: t_AlertLevel)
-        <:
-        Core.Result.t_Result t_AlertLevel u8
-      | 2uy ->
-        Core.Result.Result_Ok (AlertLevel_Fatal <: t_AlertLevel)
-        <:
-        Core.Result.t_Result t_AlertLevel u8
-      | _ -> Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
-  }
+val impl_12:Core.Marker.t_Copy t_AlertDescription
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_13:Core.Fmt.t_Debug t_AlertDescription
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core.Marker.t_StructuralPartialEq t_AlertDescription
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_15:Core.Cmp.t_PartialEq t_AlertDescription t_AlertDescription
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_3: Core.Convert.t_TryFrom t_AlertDescription u8 =
@@ -296,204 +483,117 @@ let impl_3: Core.Convert.t_TryFrom t_AlertDescription u8 =
     f_try_from
     =
     fun (value: u8) ->
-      match value with
-      | 0uy ->
+      match value <: u8 with
+      | Rust_primitives.Integers.MkInt 0 ->
         Core.Result.Result_Ok (AlertDescription_CloseNotify <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 10uy ->
+      | Rust_primitives.Integers.MkInt 10 ->
         Core.Result.Result_Ok (AlertDescription_UnexpectedMessage <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 20uy ->
+      | Rust_primitives.Integers.MkInt 20 ->
         Core.Result.Result_Ok (AlertDescription_BadRecordMac <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 22uy ->
+      | Rust_primitives.Integers.MkInt 22 ->
         Core.Result.Result_Ok (AlertDescription_RecordOverflow <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 40uy ->
+      | Rust_primitives.Integers.MkInt 40 ->
         Core.Result.Result_Ok (AlertDescription_HandshakeFailure <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 42uy ->
+      | Rust_primitives.Integers.MkInt 42 ->
         Core.Result.Result_Ok (AlertDescription_BadCertificate <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 43uy ->
+      | Rust_primitives.Integers.MkInt 43 ->
         Core.Result.Result_Ok (AlertDescription_UnsupportedCertificate <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 44uy ->
+      | Rust_primitives.Integers.MkInt 44 ->
         Core.Result.Result_Ok (AlertDescription_CertificateRevoked <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 45uy ->
+      | Rust_primitives.Integers.MkInt 45 ->
         Core.Result.Result_Ok (AlertDescription_CertificateExpired <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 46uy ->
+      | Rust_primitives.Integers.MkInt 46 ->
         Core.Result.Result_Ok (AlertDescription_CertificateUnknown <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 47uy ->
+      | Rust_primitives.Integers.MkInt 47 ->
         Core.Result.Result_Ok (AlertDescription_IllegalParameter <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 48uy ->
+      | Rust_primitives.Integers.MkInt 48 ->
         Core.Result.Result_Ok (AlertDescription_UnknownCa <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 49uy ->
+      | Rust_primitives.Integers.MkInt 49 ->
         Core.Result.Result_Ok (AlertDescription_AccessDenied <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 50uy ->
+      | Rust_primitives.Integers.MkInt 50 ->
         Core.Result.Result_Ok (AlertDescription_DecodeError <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 51uy ->
+      | Rust_primitives.Integers.MkInt 51 ->
         Core.Result.Result_Ok (AlertDescription_DecryptError <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 70uy ->
+      | Rust_primitives.Integers.MkInt 70 ->
         Core.Result.Result_Ok (AlertDescription_ProtocolVersion <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 71uy ->
+      | Rust_primitives.Integers.MkInt 71 ->
         Core.Result.Result_Ok (AlertDescription_InsufficientSecurity <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 80uy ->
+      | Rust_primitives.Integers.MkInt 80 ->
         Core.Result.Result_Ok (AlertDescription_InternalError <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 86uy ->
+      | Rust_primitives.Integers.MkInt 86 ->
         Core.Result.Result_Ok (AlertDescription_InappropriateFallback <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 90uy ->
+      | Rust_primitives.Integers.MkInt 90 ->
         Core.Result.Result_Ok (AlertDescription_UserCanceled <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 109uy ->
+      | Rust_primitives.Integers.MkInt 109 ->
         Core.Result.Result_Ok (AlertDescription_MissingExtension <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 110uy ->
+      | Rust_primitives.Integers.MkInt 110 ->
         Core.Result.Result_Ok (AlertDescription_UnsupportedExtension <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 112uy ->
+      | Rust_primitives.Integers.MkInt 112 ->
         Core.Result.Result_Ok (AlertDescription_UnrecognizedName <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 113uy ->
+      | Rust_primitives.Integers.MkInt 113 ->
         Core.Result.Result_Ok (AlertDescription_BadCertificateStatusResponse <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 115uy ->
+      | Rust_primitives.Integers.MkInt 115 ->
         Core.Result.Result_Ok (AlertDescription_UnknownPskIdentity <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 116uy ->
+      | Rust_primitives.Integers.MkInt 116 ->
         Core.Result.Result_Ok (AlertDescription_CertificateRequired <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | 120uy ->
+      | Rust_primitives.Integers.MkInt 120 ->
         Core.Result.Result_Ok (AlertDescription_NoApplicationProtocol <: t_AlertDescription)
         <:
         Core.Result.t_Result t_AlertDescription u8
-      | _ -> Bertie.Tls13utils.tlserr (Bertie.Tls13utils.parse_failed () <: u8)
+      | _ -> Bertie.Tls13utils.tlserr #t_AlertDescription (Bertie.Tls13utils.parse_failed () <: u8)
   }
-
-val check_psk_shared_key (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_server_psk_shared_key (v__algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_server_supported_version (v__algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_server_name (extension: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_server_key_share (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_server_extension (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result (usize & Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_supported_groups (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val parse_ecdsa_signature (sig: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val build_server_name (name: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (gx: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_pre_shared_key (v__algs: Bertie.Tls13crypto.t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_supported_version (v__algorithms: Bertie.Tls13crypto.t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val signature_algorithms (algs: Bertie.Tls13crypto.t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val supported_groups (algs: Bertie.Tls13crypto.t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val ecdsa_signature (sv: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val pre_shared_key
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (session_ticket: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & usize) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val psk_key_exchange_modes: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
 
 val get_psk_extensions
       (algorithms: Bertie.Tls13crypto.t_Algorithms)
@@ -502,117 +602,13 @@ val get_psk_extensions
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val supported_versions: Prims.unit
-  -> Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-type t_Extensions = {
-  f_sni:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
-  f_key_share:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
-  f_ticket:Core.Option.t_Option Bertie.Tls13utils.t_Bytes;
-  f_binder:Core.Option.t_Option Bertie.Tls13utils.t_Bytes
-}
-
-val impl__Extensions__merge (self e2: t_Extensions)
-    : Prims.Pure (Core.Result.t_Result t_Extensions u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val certificate_verify (algs: Bertie.Tls13crypto.t_Algorithms) (cv: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_handshake_record (p: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure
-      (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_server_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
+/// Build a ClientHello message.
 val client_hello
       (algorithms: Bertie.Tls13crypto.t_Algorithms)
       (client_random kem_pk server_name: Bertie.Tls13utils.t_Bytes)
       (session_ticket: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
     : Prims.Pure
       (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val encrypted_extensions (v__algs: Bertie.Tls13crypto.t_Algorithms)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result (usize & t_Extensions) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val finished (vd: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val get_handshake_record (p: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val handshake_record (p: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val parse_certificate_verify
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (certificate_verify: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val parse_encrypted_extensions
-      (v__algs: Bertie.Tls13crypto.t_Algorithms)
-      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val parse_finished (finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val parse_server_certificate (certificate: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val parse_server_hello
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (server_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_certificate (v__algs: Bertie.Tls13crypto.t_Algorithms) (cert: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_hello (algs: Bertie.Tls13crypto.t_Algorithms) (sr sid gy: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
@@ -625,29 +621,203 @@ val set_client_hello_binder
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+val invalid_compression_list: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Build the server hello message.
+val server_hello (algs: Bertie.Tls13crypto.t_Algorithms) (sr sid gy: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val unsupported_cipher_alert: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val invalid_compression_method_alert: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val encrypted_extensions (e_algs: Bertie.Tls13crypto.t_Algorithms)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val parse_encrypted_extensions
+      (e_algs: Bertie.Tls13crypto.t_Algorithms)
+      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val server_certificate (e_algs: Bertie.Tls13crypto.t_Algorithms) (cert: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val parse_server_certificate (certificate: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ecdsa_signature (sv: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_r_len (rlen: usize)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val parse_ecdsa_signature (sig: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val certificate_verify (algs: Bertie.Tls13crypto.t_Algorithms) (cv: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val parse_certificate_verify
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (certificate_verify: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val finished (vd: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val parse_finished (finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// ```TLS
+/// enum {
+///     invalid(0),
+///     change_cipher_spec(20),
+///     alert(21),
+///     handshake(22),
+///     application_data(23),
+///     (255)
+/// } ContentType;
+/// ```
+type t_ContentType =
+  | ContentType_Invalid : t_ContentType
+  | ContentType_ChangeCipherSpec : t_ContentType
+  | ContentType_Alert : t_ContentType
+  | ContentType_Handshake : t_ContentType
+  | ContentType_ApplicationData : t_ContentType
+
+let anon_const_ContentType_Invalid__anon_const_0: u8 = mk_u8 0
+
+let anon_const_ContentType_ChangeCipherSpec__anon_const_0: u8 = mk_u8 20
+
+let anon_const_ContentType_Alert__anon_const_0: u8 = mk_u8 21
+
+let anon_const_ContentType_Handshake__anon_const_0: u8 = mk_u8 22
+
+let anon_const_ContentType_ApplicationData__anon_const_0: u8 = mk_u8 23
+
+val t_ContentType_cast_to_repr (x: t_ContentType)
+    : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_16:Core.Clone.t_Clone t_ContentType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core.Marker.t_Copy t_ContentType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core.Fmt.t_Debug t_ContentType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core.Marker.t_StructuralPartialEq t_ContentType
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core.Cmp.t_PartialEq t_ContentType t_ContentType
+
+/// Get the [`ContentType`] from the `u8` representation.
+val impl_ContentType__try_from_u8 (t: u8)
+    : Prims.Pure (Core.Result.t_Result t_ContentType u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val handshake_record (p: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val protocol_version_alert: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val application_data_instead_of_handshake: Prims.unit
+  -> Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val check_handshake_record (p: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val get_handshake_record (p: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Incremental Transcript Construction
+/// For simplicity, we store the full transcript, but an internal Digest state would suffice.
 type t_Transcript = {
   f_hash_algorithm:Bertie.Tls13crypto.t_HashAlgorithm;
   f_transcript:Bertie.Tls13formats.Handshake_data.t_HandshakeData
 }
 
-val impl__Transcript__add
+val impl_Transcript__new (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
+    : Prims.Pure t_Transcript Prims.l_True (fun _ -> Prims.l_True)
+
+/// Add the [`HandshakeData`] `msg` to this transcript.
+val impl_Transcript__add
       (self: t_Transcript)
       (msg: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
     : Prims.Pure t_Transcript Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Transcript__new (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
-    : Prims.Pure t_Transcript Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Transcript__transcript_hash (self: t_Transcript)
+/// Get the hash of this transcript
+val impl_Transcript__transcript_hash (self: t_Transcript)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val impl__Transcript__transcript_hash_without_client_hello
+/// Get the hash of this transcript without the client hello
+val impl_Transcript__transcript_hash_without_client_hello
       (self: t_Transcript)
       (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (trunc_len: usize)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val find_key_share (g: Bertie.Tls13utils.t_Bytes) (ch: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_server_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13utils.t_Bytes) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val check_key_shares (algs: Bertie.Tls13crypto.t_Algorithms) (ch: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Check an extension for validity.
+val check_extension (algs: Bertie.Tls13crypto.t_Algorithms) (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result (usize & t_Extensions) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val parse_server_hello
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (server_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
@@ -657,6 +827,7 @@ val check_extensions_slice (algs: Bertie.Tls13crypto.t_Algorithms) (b: t_Slice u
 val check_extensions (algs: Bertie.Tls13crypto.t_Algorithms) (b: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result t_Extensions u8) Prims.l_True (fun _ -> Prims.l_True)
 
+/// Parse the provided `client_hello` with the given `ciphersuite`.
 val parse_client_hello
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
       (client_hello: Bertie.Tls13formats.Handshake_data.t_HandshakeData)

--- a/proofs/fstar/extraction/Bertie.Tls13handshake.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13handshake.fst
@@ -3,28 +3,34 @@ module Bertie.Tls13handshake
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  let open Rand_core in
+  ()
+
 let hash_empty (algorithm: Bertie.Tls13crypto.t_HashAlgorithm) =
-  Bertie.Tls13crypto.impl__HashAlgorithm__hash algorithm
-    (Bertie.Tls13utils.impl__Bytes__new () <: Bertie.Tls13utils.t_Bytes)
+  Bertie.Tls13crypto.impl_HashAlgorithm__hash algorithm
+    (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes)
 
 let hkdf_expand_label
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
       (key label context: Bertie.Tls13utils.t_Bytes)
       (len: usize)
      =
-  if len >=. sz 65536
+  if len >=. mk_usize 65536
   then
     Core.Result.Result_Err Bertie.Tls13utils.v_PAYLOAD_TOO_LONG
     <:
     Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   else
-    let lenb:t_Array u8 (sz 2) =
+    let lenb:t_Array u8 (mk_usize 2) =
       Bertie.Tls13utils.u16_as_be_bytes (Bertie.Tls13utils.v_U16 (cast (len <: usize) <: u16) <: u16
         )
     in
     let tls13_label:Bertie.Tls13utils.t_Bytes =
-      Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__from_slice (Rust_primitives.unsize
-                Bertie.Tls13formats.v_LABEL_TLS13
+      Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__from_slice (Bertie.Tls13formats.v_LABEL_TLS13
               <:
               t_Slice u8)
           <:
@@ -32,40 +38,33 @@ let hkdf_expand_label
         label
     in
     match
-      Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw tls13_label
+      Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw tls13_label
           <:
           t_Slice u8)
+      <:
+      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
     with
-    | Core.Result.Result_Ok hoist107 ->
+    | Core.Result.Result_Ok hoist96 ->
       (match
-          Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl__Bytes__as_raw context
+          Bertie.Tls13utils.encode_length_u8 (Bertie.Tls13utils.impl_Bytes__as_raw context
               <:
               t_Slice u8)
+          <:
+          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
         with
-        | Core.Result.Result_Ok hoist106 ->
+        | Core.Result.Result_Ok hoist95 ->
           let info:Bertie.Tls13utils.t_Bytes =
-            Bertie.Tls13utils.impl__Bytes__prefix (Bertie.Tls13utils.impl__Bytes__concat hoist107
-                  hoist106
+            Bertie.Tls13utils.impl_Bytes__prefix (Bertie.Tls13utils.impl_Bytes__concat hoist96
+                  hoist95
                 <:
                 Bertie.Tls13utils.t_Bytes)
-              (Rust_primitives.unsize lenb <: t_Slice u8)
+              (lenb <: t_Slice u8)
           in
           Bertie.Tls13crypto.hkdf_expand hash_algorithm key info len
         | Core.Result.Result_Err err ->
           Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
     | Core.Result.Result_Err err ->
       Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let derive_finished_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13utils.t_Bytes) =
-  hkdf_expand_label ha
-    k
-    (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_FINISHED
-          <:
-          t_Slice u8)
-      <:
-      Bertie.Tls13utils.t_Bytes)
-    (Bertie.Tls13utils.impl__Bytes__new () <: Bertie.Tls13utils.t_Bytes)
-    (Bertie.Tls13crypto.impl__HashAlgorithm__hmac_tag_len ha <: usize)
 
 let derive_secret
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
@@ -75,75 +74,29 @@ let derive_secret
     key
     label
     transcript_hash
-    (Bertie.Tls13crypto.impl__HashAlgorithm__hash_len hash_algorithm <: usize)
+    (Bertie.Tls13crypto.impl_HashAlgorithm__hash_len hash_algorithm <: usize)
 
 let derive_binder_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13utils.t_Bytes) =
   match
     Bertie.Tls13crypto.hkdf_extract ha
       k
       (Bertie.Tls13crypto.zero_key ha <: Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
   | Core.Result.Result_Ok early_secret ->
-    (match hash_empty ha with
-      | Core.Result.Result_Ok hoist109 ->
+    (match hash_empty ha <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 with
+      | Core.Result.Result_Ok hoist98 ->
         derive_secret ha
           early_secret
-          (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_RES_BINDER
-                <:
-                t_Slice u8)
+          (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_RES_BINDER <: t_Slice u8)
             <:
             Bertie.Tls13utils.t_Bytes)
-          hoist109
+          hoist98
       | Core.Result.Result_Err err ->
         Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let derive_rms
-      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
-      (master_secret tx: Bertie.Tls13utils.t_Bytes)
-     =
-  derive_secret ha
-    master_secret
-    (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_RES_MASTER
-          <:
-          t_Slice u8)
-      <:
-      Bertie.Tls13utils.t_Bytes)
-    tx
-
-let get_rsa_signature
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
-      (cert sk sigval: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-     =
-  match Bertie.Tls13cert.verification_key_from_cert cert with
-  | Core.Result.Result_Ok (cert_scheme, cert_slice) ->
-    (match Bertie.Tls13cert.rsa_public_key cert cert_slice with
-      | Core.Result.Result_Ok pk ->
-        let tmp0, out:(impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8) =
-          Bertie.Tls13crypto.sign_rsa sk
-            pk.Bertie.Tls13crypto.f_modulus
-            pk.Bertie.Tls13crypto.f_exponent
-            cert_scheme
-            sigval
-            rng
-        in
-        let rng:impl_916461611_ = tmp0 in
-        let hax_temp_output:Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 = out in
-        rng, hax_temp_output
-        <:
-        (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      | Core.Result.Result_Err err ->
-        rng, (Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-        <:
-        (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8))
-  | Core.Result.Result_Err err ->
-    rng, (Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-    <:
-    (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
 
 let derive_aead_key_iv
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
@@ -153,28 +106,29 @@ let derive_aead_key_iv
   match
     hkdf_expand_label hash_algorithm
       key
-      (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_KEY <: t_Slice u8
-          )
+      (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_KEY <: t_Slice u8)
         <:
         Bertie.Tls13utils.t_Bytes)
-      (Bertie.Tls13utils.impl__Bytes__new () <: Bertie.Tls13utils.t_Bytes)
-      (Bertie.Tls13crypto.impl__AeadAlgorithm__key_len aead_algorithm <: usize)
+      (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes)
+      (Bertie.Tls13crypto.impl_AeadAlgorithm__key_len aead_algorithm <: usize)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
   | Core.Result.Result_Ok sender_write_key ->
     (match
         hkdf_expand_label hash_algorithm
           key
-          (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_IV
-                <:
-                t_Slice u8)
+          (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_IV <: t_Slice u8)
             <:
             Bertie.Tls13utils.t_Bytes)
-          (Bertie.Tls13utils.impl__Bytes__new () <: Bertie.Tls13utils.t_Bytes)
-          (Bertie.Tls13crypto.impl__AeadAlgorithm__iv_len aead_algorithm <: usize)
+          (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes)
+          (Bertie.Tls13crypto.impl_AeadAlgorithm__iv_len aead_algorithm <: usize)
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
       | Core.Result.Result_Ok sender_write_iv ->
         Core.Result.Result_Ok
-        (Bertie.Tls13crypto.impl__AeadKeyIV__new (Bertie.Tls13crypto.impl__AeadKey__new sender_write_key
+        (Bertie.Tls13crypto.impl_AeadKeyIV__new (Bertie.Tls13crypto.impl_AeadKey__new sender_write_key
                 aead_algorithm
               <:
               Bertie.Tls13crypto.t_AeadKey)
@@ -195,33 +149,36 @@ let derive_0rtt_keys
     Bertie.Tls13crypto.hkdf_extract hash_algorithm
       key
       (Bertie.Tls13crypto.zero_key hash_algorithm <: Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
   | Core.Result.Result_Ok early_secret ->
     (match
         derive_secret hash_algorithm
           early_secret
-          (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_C_E_TRAFFIC
-                <:
-                t_Slice u8)
+          (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_C_E_TRAFFIC <: t_Slice u8)
             <:
             Bertie.Tls13utils.t_Bytes)
           tx
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
       | Core.Result.Result_Ok client_early_traffic_secret ->
         (match
             derive_secret hash_algorithm
               early_secret
-              (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_E_EXP_MASTER
-
-                    <:
-                    t_Slice u8)
+              (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_E_EXP_MASTER <: t_Slice u8)
                 <:
                 Bertie.Tls13utils.t_Bytes)
               tx
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           with
           | Core.Result.Result_Ok early_exporter_master_secret ->
             (match
                 derive_aead_key_iv hash_algorithm aead_algoorithm client_early_traffic_secret
+                <:
+                Core.Result.t_Result Bertie.Tls13crypto.t_AeadKeyIV u8
               with
               | Core.Result.Result_Ok sender_write_key_iv ->
                 Core.Result.Result_Ok
@@ -248,88 +205,14 @@ let derive_0rtt_keys
     <:
     Core.Result.t_Result (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13utils.t_Bytes) u8
 
-let derive_app_keys
-      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
-      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (master_secret tx: Bertie.Tls13utils.t_Bytes)
-     =
-  match
-    derive_secret ha
-      master_secret
-      (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_C_AP_TRAFFIC
-            <:
-            t_Slice u8)
-        <:
-        Bertie.Tls13utils.t_Bytes)
-      tx
-  with
-  | Core.Result.Result_Ok client_application_traffic_secret_0_ ->
-    (match
-        derive_secret ha
-          master_secret
-          (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_S_AP_TRAFFIC
-                <:
-                t_Slice u8)
-            <:
-            Bertie.Tls13utils.t_Bytes)
-          tx
-      with
-      | Core.Result.Result_Ok server_application_traffic_secret_0_ ->
-        (match derive_aead_key_iv ha ae client_application_traffic_secret_0_ with
-          | Core.Result.Result_Ok client_write_key_iv ->
-            (match derive_aead_key_iv ha ae server_application_traffic_secret_0_ with
-              | Core.Result.Result_Ok server_write_key_iv ->
-                (match
-                    derive_secret ha
-                      master_secret
-                      (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_EXP_MASTER
-
-                            <:
-                            t_Slice u8)
-                        <:
-                        Bertie.Tls13utils.t_Bytes)
-                      tx
-                  with
-                  | Core.Result.Result_Ok exporter_master_secret ->
-                    Core.Result.Result_Ok
-                    (client_write_key_iv, server_write_key_iv, exporter_master_secret
-                      <:
-                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-                        Bertie.Tls13utils.t_Bytes))
-                    <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-                        Bertie.Tls13utils.t_Bytes) u8
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err
-                    <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-                        Bertie.Tls13utils.t_Bytes) u8)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result
-                  (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-                    Bertie.Tls13utils.t_Bytes) u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result
-              (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-                Bertie.Tls13utils.t_Bytes) u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result
-          (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-            Bertie.Tls13utils.t_Bytes) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13utils.t_Bytes)
-      u8
+let derive_finished_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13utils.t_Bytes) =
+  hkdf_expand_label ha
+    k
+    (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_FINISHED <: t_Slice u8)
+      <:
+      Bertie.Tls13utils.t_Bytes)
+    (Bertie.Tls13utils.impl_Bytes__new () <: Bertie.Tls13utils.t_Bytes)
+    (Bertie.Tls13crypto.impl_HashAlgorithm__hmac_tag_len ha <: usize)
 
 let derive_hk_ms
       (ha: Bertie.Tls13crypto.t_HashAlgorithm)
@@ -339,83 +222,109 @@ let derive_hk_ms
       (transcript_hash: Bertie.Tls13utils.t_Bytes)
      =
   let psk:Bertie.Tls13utils.t_Bytes =
-    match psko with
-    | Core.Option.Option_Some k -> Core.Clone.f_clone k
+    match psko <: Core.Option.t_Option Bertie.Tls13utils.t_Bytes with
+    | Core.Option.Option_Some k ->
+      Core.Clone.f_clone #Bertie.Tls13utils.t_Bytes #FStar.Tactics.Typeclasses.solve k
     | _ -> Bertie.Tls13crypto.zero_key ha
   in
   match
     Bertie.Tls13crypto.hkdf_extract ha
       psk
       (Bertie.Tls13crypto.zero_key ha <: Bertie.Tls13utils.t_Bytes)
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
   with
   | Core.Result.Result_Ok early_secret ->
-    (match hash_empty ha with
+    (match hash_empty ha <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 with
       | Core.Result.Result_Ok digest_emp ->
         (match
             derive_secret ha
               early_secret
-              (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_DERIVED
-                    <:
-                    t_Slice u8)
+              (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_DERIVED <: t_Slice u8)
                 <:
                 Bertie.Tls13utils.t_Bytes)
               digest_emp
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
           with
           | Core.Result.Result_Ok derived_secret ->
-            (match Bertie.Tls13crypto.hkdf_extract ha shared_secret derived_secret with
+            (match
+                Bertie.Tls13crypto.hkdf_extract ha shared_secret derived_secret
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
               | Core.Result.Result_Ok handshake_secret ->
                 (match
                     derive_secret ha
                       handshake_secret
-                      (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_C_HS_TRAFFIC
-
+                      (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_C_HS_TRAFFIC
                             <:
                             t_Slice u8)
                         <:
                         Bertie.Tls13utils.t_Bytes)
                       transcript_hash
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                   with
                   | Core.Result.Result_Ok client_handshake_traffic_secret ->
                     (match
                         derive_secret ha
                           handshake_secret
-                          (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_S_HS_TRAFFIC
-
+                          (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_S_HS_TRAFFIC
                                 <:
                                 t_Slice u8)
                             <:
                             Bertie.Tls13utils.t_Bytes)
                           transcript_hash
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                       with
                       | Core.Result.Result_Ok server_handshake_traffic_secret ->
-                        (match derive_finished_key ha client_handshake_traffic_secret with
+                        (match
+                            derive_finished_key ha client_handshake_traffic_secret
+                            <:
+                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                          with
                           | Core.Result.Result_Ok client_finished_key ->
-                            (match derive_finished_key ha server_handshake_traffic_secret with
+                            (match
+                                derive_finished_key ha server_handshake_traffic_secret
+                                <:
+                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                              with
                               | Core.Result.Result_Ok server_finished_key ->
-                                (match derive_aead_key_iv ha ae client_handshake_traffic_secret with
+                                (match
+                                    derive_aead_key_iv ha ae client_handshake_traffic_secret
+                                    <:
+                                    Core.Result.t_Result Bertie.Tls13crypto.t_AeadKeyIV u8
+                                  with
                                   | Core.Result.Result_Ok client_write_key_iv ->
                                     (match
                                         derive_aead_key_iv ha ae server_handshake_traffic_secret
+                                        <:
+                                        Core.Result.t_Result Bertie.Tls13crypto.t_AeadKeyIV u8
                                       with
                                       | Core.Result.Result_Ok server_write_key_iv ->
                                         (match
                                             derive_secret ha
                                               handshake_secret
-                                              (Bertie.Tls13utils.bytes (Rust_primitives.unsize Bertie.Tls13formats.v_LABEL_DERIVED
-
+                                              (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_DERIVED
                                                     <:
                                                     t_Slice u8)
                                                 <:
                                                 Bertie.Tls13utils.t_Bytes)
                                               digest_emp
+                                            <:
+                                            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                                           with
-                                          | Core.Result.Result_Ok master_secret___ ->
+                                          | Core.Result.Result_Ok master_secret_ ->
                                             (match
                                                 Bertie.Tls13crypto.hkdf_extract ha
                                                   (Bertie.Tls13crypto.zero_key ha
                                                     <:
                                                     Bertie.Tls13utils.t_Bytes)
-                                                  master_secret___
+                                                  master_secret_
+                                                <:
+                                                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
                                               with
                                               | Core.Result.Result_Ok master_secret ->
                                                 Core.Result.Result_Ok
@@ -537,773 +446,113 @@ let derive_hk_ms
         Bertie.Tls13utils.t_Bytes &
         Bertie.Tls13utils.t_Bytes) u8
 
-let algs_post_client_finished (st: t_ClientPostClientFinished) = st._2
+let derive_app_keys
+      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
+      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
+      (master_secret tx: Bertie.Tls13utils.t_Bytes)
+     =
+  match
+    derive_secret ha
+      master_secret
+      (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_C_AP_TRAFFIC <: t_Slice u8)
+        <:
+        Bertie.Tls13utils.t_Bytes)
+      tx
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok client_application_traffic_secret_0_ ->
+    (match
+        derive_secret ha
+          master_secret
+          (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_S_AP_TRAFFIC <: t_Slice u8)
+            <:
+            Bertie.Tls13utils.t_Bytes)
+          tx
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok server_application_traffic_secret_0_ ->
+        (match
+            derive_aead_key_iv ha ae client_application_traffic_secret_0_
+            <:
+            Core.Result.t_Result Bertie.Tls13crypto.t_AeadKeyIV u8
+          with
+          | Core.Result.Result_Ok client_write_key_iv ->
+            (match
+                derive_aead_key_iv ha ae server_application_traffic_secret_0_
+                <:
+                Core.Result.t_Result Bertie.Tls13crypto.t_AeadKeyIV u8
+              with
+              | Core.Result.Result_Ok server_write_key_iv ->
+                (match
+                    derive_secret ha
+                      master_secret
+                      (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_EXP_MASTER <: t_Slice u8
+                          )
+                        <:
+                        Bertie.Tls13utils.t_Bytes)
+                      tx
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  with
+                  | Core.Result.Result_Ok exporter_master_secret ->
+                    Core.Result.Result_Ok
+                    (client_write_key_iv, server_write_key_iv, exporter_master_secret
+                      <:
+                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                        Bertie.Tls13utils.t_Bytes))
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                        Bertie.Tls13utils.t_Bytes) u8
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                        Bertie.Tls13utils.t_Bytes) u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                    Bertie.Tls13utils.t_Bytes) u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                Bertie.Tls13utils.t_Bytes) u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+            Bertie.Tls13utils.t_Bytes) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13utils.t_Bytes)
+      u8
+
+let derive_rms
+      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
+      (master_secret tx: Bertie.Tls13utils.t_Bytes)
+     =
+  derive_secret ha
+    master_secret
+    (Bertie.Tls13utils.bytes (Bertie.Tls13formats.v_LABEL_RES_MASTER <: t_Slice u8)
+      <:
+      Bertie.Tls13utils.t_Bytes)
+    tx
 
 let algs_post_client_hello (st: t_ClientPostClientHello) = st._1
 
 let algs_post_server_hello (st: t_ClientPostServerHello) = st._2
 
-let get_client_finished (handshake_state: t_ClientPostServerFinished) =
-  let
-  ClientPostServerFinished
-    client_random
-    server_random
-    algorithms
-    master_secret
-    client_finished_key
-    transcript:t_ClientPostServerFinished =
-    handshake_state
-  in
-  match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
-  | Core.Result.Result_Ok transcript_hash ->
-    (match
-        Bertie.Tls13crypto.hmac_tag (Bertie.Tls13crypto.impl__Algorithms__hash algorithms
-            <:
-            Bertie.Tls13crypto.t_HashAlgorithm)
-          client_finished_key
-          transcript_hash
-      with
-      | Core.Result.Result_Ok verify_data ->
-        (match Bertie.Tls13formats.finished verify_data with
-          | Core.Result.Result_Ok client_finished ->
-            let transcript:Bertie.Tls13formats.t_Transcript =
-              Bertie.Tls13formats.impl__Transcript__add transcript client_finished
-            in
-            (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
-              | Core.Result.Result_Ok transcript_hash ->
-                (match
-                    derive_rms (Bertie.Tls13crypto.impl__Algorithms__hash algorithms
-                        <:
-                        Bertie.Tls13crypto.t_HashAlgorithm)
-                      master_secret
-                      transcript_hash
-                  with
-                  | Core.Result.Result_Ok resumption_master_secret ->
-                    Core.Result.Result_Ok
-                    (client_finished,
-                      (ClientPostClientFinished client_random
-                          server_random
-                          algorithms
-                          resumption_master_secret
-                          transcript
-                        <:
-                        t_ClientPostClientFinished)
-                      <:
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        t_ClientPostClientFinished))
-                    <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        t_ClientPostClientFinished) u8
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err
-                    <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        t_ClientPostClientFinished) u8)
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result
-                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished)
-                  u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result
-              (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8
-
-let get_server_signature_no_psk
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
-      (state: t_ServerPostServerHello)
-      (rng: impl_916461611_)
-     =
-  match Bertie.Tls13formats.encrypted_extensions state.f_ciphersuite with
-  | Core.Result.Result_Ok ee ->
-    let transcript:Bertie.Tls13formats.t_Transcript =
-      Bertie.Tls13formats.impl__Transcript__add state.f_transcript ee
-    in
-    (match
-        Bertie.Tls13formats.server_certificate state.f_ciphersuite
-          state.f_server.Bertie.Server.f_cert
-      with
-      | Core.Result.Result_Ok sc ->
-        let transcript:Bertie.Tls13formats.t_Transcript =
-          Bertie.Tls13formats.impl__Transcript__add transcript sc
-        in
-        (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
-          | Core.Result.Result_Ok transcript_hash ->
-            let sigval:Bertie.Tls13utils.t_Bytes =
-              Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__from_slice (Rust_primitives.unsize
-                        Bertie.Tls13formats.v_PREFIX_SERVER_SIGNATURE
-                      <:
-                      t_Slice u8)
-                  <:
-                  Bertie.Tls13utils.t_Bytes)
-                transcript_hash
-            in
-            let rng, hoist164:(impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-            =
-              match Bertie.Tls13crypto.impl__Algorithms__signature state.f_ciphersuite with
-              | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
-                let tmp0, out:(impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                =
-                  Bertie.Tls13crypto.sign (Bertie.Tls13crypto.impl__Algorithms__signature state
-                          .f_ciphersuite
-                      <:
-                      Bertie.Tls13crypto.t_SignatureScheme)
-                    state.f_server.Bertie.Server.f_sk
-                    sigval
-                    rng
-                in
-                let rng:impl_916461611_ = tmp0 in
-                rng, out <: (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-              | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
-                let tmp0, out:(impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                =
-                  get_rsa_signature state.f_server.Bertie.Server.f_cert
-                    state.f_server.Bertie.Server.f_sk
-                    sigval
-                    rng
-                in
-                let rng:impl_916461611_ = tmp0 in
-                rng, out <: (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-              | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
-                rng,
-                (Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
-                  <:
-                  Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-                <:
-                (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-            in
-            (match hoist164 with
-              | Core.Result.Result_Ok sig ->
-                (match Bertie.Tls13formats.certificate_verify state.f_ciphersuite sig with
-                  | Core.Result.Result_Ok scv ->
-                    let transcript:Bertie.Tls13formats.t_Transcript =
-                      Bertie.Tls13formats.impl__Transcript__add transcript scv
-                    in
-                    let hax_temp_output:Core.Result.t_Result
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        t_ServerPostCertificateVerify) u8 =
-                      Core.Result.Result_Ok
-                      (ee,
-                        sc,
-                        scv,
-                        (ServerPostCertificateVerify state.f_client_random
-                            state.f_server_random
-                            state.f_ciphersuite
-                            state.f_master_secret
-                            state.f_cfk
-                            state.f_sfk
-                            transcript
-                          <:
-                          t_ServerPostCertificateVerify)
-                        <:
-                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          t_ServerPostCertificateVerify))
-                      <:
-                      Core.Result.t_Result
-                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          t_ServerPostCertificateVerify) u8
-                    in
-                    rng, hax_temp_output
-                    <:
-                    (impl_916461611_ &
-                      Core.Result.t_Result
-                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          t_ServerPostCertificateVerify) u8)
-                  | Core.Result.Result_Err err ->
-                    rng,
-                    (Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result
-                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          t_ServerPostCertificateVerify) u8)
-                    <:
-                    (impl_916461611_ &
-                      Core.Result.t_Result
-                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                          t_ServerPostCertificateVerify) u8))
-              | Core.Result.Result_Err err ->
-                rng,
-                (Core.Result.Result_Err err
-                  <:
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      t_ServerPostCertificateVerify) u8)
-                <:
-                (impl_916461611_ &
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      t_ServerPostCertificateVerify) u8))
-          | Core.Result.Result_Err err ->
-            rng,
-            (Core.Result.Result_Err err
-              <:
-              Core.Result.t_Result
-                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  t_ServerPostCertificateVerify) u8)
-            <:
-            (impl_916461611_ &
-              Core.Result.t_Result
-                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  t_ServerPostCertificateVerify) u8))
-      | Core.Result.Result_Err err ->
-        rng,
-        (Core.Result.Result_Err err
-          <:
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              t_ServerPostCertificateVerify) u8)
-        <:
-        (impl_916461611_ &
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              t_ServerPostCertificateVerify) u8))
-  | Core.Result.Result_Err err ->
-    rng,
-    (Core.Result.Result_Err err
-      <:
-      Core.Result.t_Result
-        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          t_ServerPostCertificateVerify) u8)
-    <:
-    (impl_916461611_ &
-      Core.Result.t_Result
-        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          t_ServerPostCertificateVerify) u8)
-
-let get_server_signature
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
-      (state: t_ServerPostServerHello)
-      (rng: impl_916461611_)
-     =
-  let rng, hax_temp_output:(impl_916461611_ &
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        t_ServerPostCertificateVerify) u8) =
-    if ~.(Bertie.Tls13crypto.impl__Algorithms__psk_mode state.f_ciphersuite <: bool)
-    then
-      let tmp0, out:(impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            t_ServerPostCertificateVerify) u8) =
-        get_server_signature_no_psk state rng
-      in
-      let rng:impl_916461611_ = tmp0 in
-      rng, out
-      <:
-      (impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            t_ServerPostCertificateVerify) u8)
-    else
-      rng,
-      (Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
-        <:
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            t_ServerPostCertificateVerify) u8)
-      <:
-      (impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            t_ServerPostCertificateVerify) u8)
-  in
-  rng, hax_temp_output
-  <:
-  (impl_916461611_ &
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        t_ServerPostCertificateVerify) u8)
-
-let get_skip_server_signature_no_psk (st: t_ServerPostServerHello) =
-  let
-  { f_client_random = cr ;
-    f_server_random = sr ;
-    f_ciphersuite = algs ;
-    f_server = server ;
-    f_master_secret = ms ;
-    f_cfk = cfk ;
-    f_sfk = sfk ;
-    f_transcript = tx }:t_ServerPostServerHello =
-    st
-  in
-  match Bertie.Tls13formats.encrypted_extensions algs with
-  | Core.Result.Result_Ok ee ->
-    let tx:Bertie.Tls13formats.t_Transcript = Bertie.Tls13formats.impl__Transcript__add tx ee in
-    Core.Result.Result_Ok
-    (ee, (ServerPostCertificateVerify cr sr algs ms cfk sfk tx <: t_ServerPostCertificateVerify)
-      <:
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify))
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
-
-let get_skip_server_signature (st: t_ServerPostServerHello) =
-  let
-  { f_client_random = cr ;
-    f_server_random = sr ;
-    f_ciphersuite = algs ;
-    f_server = server ;
-    f_master_secret = ms ;
-    f_cfk = cfk ;
-    f_sfk = sfk ;
-    f_transcript = tx }:t_ServerPostServerHello =
-    st
-  in
-  if Bertie.Tls13crypto.impl__Algorithms__psk_mode algs
-  then get_skip_server_signature_no_psk st
-  else
-    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
-
-let put_client_finished
-      (cfin: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ServerPostServerFinished)
-     =
-  let ServerPostServerFinished cr sr algs ms cfk tx:t_ServerPostServerFinished = st in
-  match Bertie.Tls13formats.impl__Transcript__transcript_hash tx with
-  | Core.Result.Result_Ok th ->
-    (match Bertie.Tls13formats.parse_finished cfin with
-      | Core.Result.Result_Ok vd ->
-        (match
-            Bertie.Tls13crypto.hmac_verify (Bertie.Tls13crypto.impl__Algorithms__hash algs
-                <:
-                Bertie.Tls13crypto.t_HashAlgorithm)
-              cfk
-              th
-              vd
-          with
-          | Core.Result.Result_Ok _ ->
-            let tx:Bertie.Tls13formats.t_Transcript =
-              Bertie.Tls13formats.impl__Transcript__add tx cfin
-            in
-            (match Bertie.Tls13formats.impl__Transcript__transcript_hash tx with
-              | Core.Result.Result_Ok th ->
-                (match
-                    derive_rms (Bertie.Tls13crypto.impl__Algorithms__hash algs
-                        <:
-                        Bertie.Tls13crypto.t_HashAlgorithm)
-                      ms
-                      th
-                  with
-                  | Core.Result.Result_Ok rms ->
-                    Core.Result.Result_Ok
-                    (ServerPostClientFinished cr sr algs rms tx <: t_ServerPostClientFinished)
-                    <:
-                    Core.Result.t_Result t_ServerPostClientFinished u8
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8
-                )
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8
-
-let put_psk_skip_server_signature
-      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostServerHello)
-     =
-  let
-  ClientPostServerHello
-    client_random
-    server_random
-    algorithms
-    master_secret
-    client_finished_key
-    server_finished_key
-    transcript:t_ClientPostServerHello =
-    handshake_state
-  in
-  if Bertie.Tls13crypto.impl__Algorithms__psk_mode algorithms
-  then
-    match Bertie.Tls13formats.parse_encrypted_extensions algorithms encrypted_extensions with
-    | Core.Result.Result_Ok _ ->
-      let transcript:Bertie.Tls13formats.t_Transcript =
-        Bertie.Tls13formats.impl__Transcript__add transcript encrypted_extensions
-      in
-      Core.Result.Result_Ok
-      (ClientPostCertificateVerify client_random
-          server_random
-          algorithms
-          master_secret
-          client_finished_key
-          server_finished_key
-          transcript
-        <:
-        t_ClientPostCertificateVerify)
-      <:
-      Core.Result.t_Result t_ClientPostCertificateVerify u8
-    | Core.Result.Result_Err err ->
-      Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8
-  else
-    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
-    <:
-    Core.Result.t_Result t_ClientPostCertificateVerify u8
-
-let put_server_signature
-      (encrypted_extensions server_certificate server_certificate_verify:
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostServerHello)
-     =
-  let
-  ClientPostServerHello
-    client_random
-    server_random
-    algorithms
-    master_secret
-    client_finished_key
-    server_finished_key
-    transcript:t_ClientPostServerHello =
-    handshake_state
-  in
-  if ~.(Bertie.Tls13crypto.impl__Algorithms__psk_mode algorithms <: bool)
-  then
-    match Bertie.Tls13formats.parse_encrypted_extensions algorithms encrypted_extensions with
-    | Core.Result.Result_Ok _ ->
-      let transcript:Bertie.Tls13formats.t_Transcript =
-        Bertie.Tls13formats.impl__Transcript__add transcript encrypted_extensions
-      in
-      (match Bertie.Tls13formats.parse_server_certificate server_certificate with
-        | Core.Result.Result_Ok certificate ->
-          let transcript:Bertie.Tls13formats.t_Transcript =
-            Bertie.Tls13formats.impl__Transcript__add transcript server_certificate
-          in
-          (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
-            | Core.Result.Result_Ok transcript_hash_server_certificate ->
-              (match Bertie.Tls13cert.verification_key_from_cert certificate with
-                | Core.Result.Result_Ok spki ->
-                  (match Bertie.Tls13cert.cert_public_key certificate spki with
-                    | Core.Result.Result_Ok cert_pk ->
-                      (match
-                          Bertie.Tls13formats.parse_certificate_verify algorithms
-                            server_certificate_verify
-                        with
-                        | Core.Result.Result_Ok cert_signature ->
-                          let sigval:Bertie.Tls13utils.t_Bytes =
-                            Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__from_slice
-                                  (Rust_primitives.unsize Bertie.Tls13formats.v_PREFIX_SERVER_SIGNATURE
-
-                                    <:
-                                    t_Slice u8)
-                                <:
-                                Bertie.Tls13utils.t_Bytes)
-                              transcript_hash_server_certificate
-                          in
-                          (match
-                              Bertie.Tls13crypto.verify (Bertie.Tls13crypto.impl__Algorithms__signature
-                                    algorithms
-                                  <:
-                                  Bertie.Tls13crypto.t_SignatureScheme)
-                                cert_pk
-                                sigval
-                                cert_signature
-                            with
-                            | Core.Result.Result_Ok _ ->
-                              let transcript:Bertie.Tls13formats.t_Transcript =
-                                Bertie.Tls13formats.impl__Transcript__add transcript
-                                  server_certificate_verify
-                              in
-                              Core.Result.Result_Ok
-                              (ClientPostCertificateVerify client_random
-                                  server_random
-                                  algorithms
-                                  master_secret
-                                  client_finished_key
-                                  server_finished_key
-                                  transcript
-                                <:
-                                t_ClientPostCertificateVerify)
-                              <:
-                              Core.Result.t_Result t_ClientPostCertificateVerify u8
-                            | Core.Result.Result_Err err ->
-                              Core.Result.Result_Err err
-                              <:
-                              Core.Result.t_Result t_ClientPostCertificateVerify u8)
-                        | Core.Result.Result_Err err ->
-                          Core.Result.Result_Err err
-                          <:
-                          Core.Result.t_Result t_ClientPostCertificateVerify u8)
-                    | Core.Result.Result_Err err ->
-                      Core.Result.Result_Err err
-                      <:
-                      Core.Result.t_Result t_ClientPostCertificateVerify u8)
-                | Core.Result.Result_Err err ->
-                  Core.Result.Result_Err err
-                  <:
-                  Core.Result.t_Result t_ClientPostCertificateVerify u8)
-            | Core.Result.Result_Err err ->
-              Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8)
-        | Core.Result.Result_Err err ->
-          Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8)
-    | Core.Result.Result_Err err ->
-      Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8
-  else
-    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
-    <:
-    Core.Result.t_Result t_ClientPostCertificateVerify u8
-
-let server_finish
-      (cf: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ServerPostServerFinished)
-     = put_client_finished cf st
-
-let get_server_hello
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
-      (state: t_ServerPostClientHello)
-      (rng: impl_916461611_)
-     =
-  let server_random:t_Array u8 (sz 32) = Rust_primitives.Hax.repeat 0uy (sz 32) in
-  let tmp0, tmp1:(impl_916461611_ & t_Array u8 (sz 32)) =
-    Rand_core.f_fill_bytes rng server_random
-  in
-  let rng:impl_916461611_ = tmp0 in
-  let server_random:t_Array u8 (sz 32) = tmp1 in
-  let _:Prims.unit = () in
-  let tmp0, out:(impl_916461611_ &
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8) =
-    Bertie.Tls13crypto.kem_encap state.f_ciphersuite.Bertie.Tls13crypto.f_kem state.f_gx rng
-  in
-  let rng:impl_916461611_ = tmp0 in
-  match out with
-  | Core.Result.Result_Ok (shared_secret, gy) ->
-    (match
-        Bertie.Tls13formats.server_hello state.f_ciphersuite
-          (Core.Convert.f_into server_random <: Bertie.Tls13utils.t_Bytes)
-          state.f_session_id
-          gy
-      with
-      | Core.Result.Result_Ok sh ->
-        let transcript:Bertie.Tls13formats.t_Transcript =
-          Bertie.Tls13formats.impl__Transcript__add state.f_transcript sh
-        in
-        (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
-          | Core.Result.Result_Ok transcript_hash ->
-            (match
-                derive_hk_ms state.f_ciphersuite.Bertie.Tls13crypto.f_hash
-                  state.f_ciphersuite.Bertie.Tls13crypto.f_aead
-                  shared_secret
-                  state.f_server.Bertie.Server.f_psk_opt
-                  transcript_hash
-              with
-              | Core.Result.Result_Ok (chk, shk, cfk, sfk, ms) ->
-                let hax_temp_output:Core.Result.t_Result
-                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                    Bertie.Tls13record.t_DuplexCipherStateH &
-                    t_ServerPostServerHello) u8 =
-                  Core.Result.Result_Ok
-                  (sh,
-                    Bertie.Tls13record.impl__DuplexCipherStateH__new shk 0uL chk 0uL,
-                    ({
-                        f_client_random = state.f_client_randomness;
-                        f_server_random = Core.Convert.f_into server_random;
-                        f_ciphersuite = state.f_ciphersuite;
-                        f_server = state.f_server;
-                        f_master_secret = ms;
-                        f_cfk = cfk;
-                        f_sfk = sfk;
-                        f_transcript = transcript
-                      }
-                      <:
-                      t_ServerPostServerHello)
-                    <:
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13record.t_DuplexCipherStateH &
-                      t_ServerPostServerHello))
-                  <:
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13record.t_DuplexCipherStateH &
-                      t_ServerPostServerHello) u8
-                in
-                rng, hax_temp_output
-                <:
-                (impl_916461611_ &
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13record.t_DuplexCipherStateH &
-                      t_ServerPostServerHello) u8)
-              | Core.Result.Result_Err err ->
-                rng,
-                (Core.Result.Result_Err err
-                  <:
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13record.t_DuplexCipherStateH &
-                      t_ServerPostServerHello) u8)
-                <:
-                (impl_916461611_ &
-                  Core.Result.t_Result
-                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                      Bertie.Tls13record.t_DuplexCipherStateH &
-                      t_ServerPostServerHello) u8))
-          | Core.Result.Result_Err err ->
-            rng,
-            (Core.Result.Result_Err err
-              <:
-              Core.Result.t_Result
-                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13record.t_DuplexCipherStateH &
-                  t_ServerPostServerHello) u8)
-            <:
-            (impl_916461611_ &
-              Core.Result.t_Result
-                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                  Bertie.Tls13record.t_DuplexCipherStateH &
-                  t_ServerPostServerHello) u8))
-      | Core.Result.Result_Err err ->
-        rng,
-        (Core.Result.Result_Err err
-          <:
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13record.t_DuplexCipherStateH &
-              t_ServerPostServerHello) u8)
-        <:
-        (impl_916461611_ &
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-              Bertie.Tls13record.t_DuplexCipherStateH &
-              t_ServerPostServerHello) u8))
-  | Core.Result.Result_Err err ->
-    rng,
-    (Core.Result.Result_Err err
-      <:
-      Core.Result.t_Result
-        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13record.t_DuplexCipherStateH &
-          t_ServerPostServerHello) u8)
-    <:
-    (impl_916461611_ &
-      Core.Result.t_Result
-        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-          Bertie.Tls13record.t_DuplexCipherStateH &
-          t_ServerPostServerHello) u8)
-
-let put_server_hello
-      (handshake: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (state: t_ClientPostClientHello)
-     =
-  let ClientPostClientHello client_random ciphersuite sk psk tx:t_ClientPostClientHello = state in
-  match Bertie.Tls13formats.parse_server_hello ciphersuite handshake with
-  | Core.Result.Result_Ok (sr, ct) ->
-    let tx:Bertie.Tls13formats.t_Transcript =
-      Bertie.Tls13formats.impl__Transcript__add tx handshake
-    in
-    (match Bertie.Tls13crypto.kem_decap ciphersuite.Bertie.Tls13crypto.f_kem ct sk with
-      | Core.Result.Result_Ok shared_secret ->
-        (match Bertie.Tls13formats.impl__Transcript__transcript_hash tx with
-          | Core.Result.Result_Ok th ->
-            (match
-                derive_hk_ms ciphersuite.Bertie.Tls13crypto.f_hash
-                  ciphersuite.Bertie.Tls13crypto.f_aead
-                  shared_secret
-                  psk
-                  th
-              with
-              | Core.Result.Result_Ok (chk, shk, cfk, sfk, ms) ->
-                Core.Result.Result_Ok
-                (Bertie.Tls13record.impl__DuplexCipherStateH__new chk 0uL shk 0uL,
-                  (ClientPostServerHello client_random sr ciphersuite ms cfk sfk tx
-                    <:
-                    t_ClientPostServerHello)
-                  <:
-                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello))
-                <:
-                Core.Result.t_Result
-                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8
-              | Core.Result.Result_Err err ->
-                Core.Result.Result_Err err
-                <:
-                Core.Result.t_Result
-                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
-          | Core.Result.Result_Err err ->
-            Core.Result.Result_Err err
-            <:
-            Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello)
-              u8)
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8
-
-let client_set_params
-      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ClientPostClientHello)
-     = put_server_hello payload st
+let algs_post_client_finished (st: t_ClientPostClientFinished) = st._2
 
 let compute_psk_binder_zero_rtt
       (algs0: Bertie.Tls13crypto.t_Algorithms)
@@ -1315,8 +564,8 @@ let compute_psk_binder_zero_rtt
   let
   { Bertie.Tls13crypto.f_hash = ha ;
     Bertie.Tls13crypto.f_aead = ae ;
-    Bertie.Tls13crypto.f_signature = v__sa ;
-    Bertie.Tls13crypto.f_kem = v__ks ;
+    Bertie.Tls13crypto.f_signature = e_sa ;
+    Bertie.Tls13crypto.f_kem = e_ks ;
     Bertie.Tls13crypto.f_psk_mode = psk_mode ;
     Bertie.Tls13crypto.f_zero_rtt = zero_rtt }:Bertie.Tls13crypto.t_Algorithms =
     algs0
@@ -1328,12 +577,18 @@ let compute_psk_binder_zero_rtt
   with
   | true, Core.Option.Option_Some k, _ ->
     (match
-        Bertie.Tls13formats.impl__Transcript__transcript_hash_without_client_hello tx ch trunc_len
+        Bertie.Tls13formats.impl_Transcript__transcript_hash_without_client_hello tx ch trunc_len
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
       | Core.Result.Result_Ok th_trunc ->
-        (match derive_binder_key ha k with
+        (match derive_binder_key ha k <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 with
           | Core.Result.Result_Ok mk ->
-            (match Bertie.Tls13crypto.hmac_tag ha mk th_trunc with
+            (match
+                Bertie.Tls13crypto.hmac_tag ha mk th_trunc
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
               | Core.Result.Result_Ok binder ->
                 (match
                     Bertie.Tls13formats.set_client_hello_binder algs0
@@ -1342,21 +597,32 @@ let compute_psk_binder_zero_rtt
                         Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
                       ch
                       (Core.Option.Option_Some trunc_len <: Core.Option.t_Option usize)
+                    <:
+                    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
                   with
                   | Core.Result.Result_Ok nch ->
                     let tx_ch:Bertie.Tls13formats.t_Transcript =
-                      Bertie.Tls13formats.impl__Transcript__add tx nch
+                      Bertie.Tls13formats.impl_Transcript__add tx nch
                     in
                     if zero_rtt
                     then
-                      match Bertie.Tls13formats.impl__Transcript__transcript_hash tx_ch with
+                      match
+                        Bertie.Tls13formats.impl_Transcript__transcript_hash tx_ch
+                        <:
+                        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                      with
                       | Core.Result.Result_Ok th ->
-                        (match derive_0rtt_keys ha ae k th with
+                        (match
+                            derive_0rtt_keys ha ae k th
+                            <:
+                            Core.Result.t_Result
+                              (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13utils.t_Bytes) u8
+                          with
                           | Core.Result.Result_Ok (aek, key) ->
                             let cipher0:Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0
                             =
                               Core.Option.Option_Some
-                              (Bertie.Tls13record.client_cipher_state0 ae aek 0uL key)
+                              (Bertie.Tls13record.client_cipher_state0 ae aek (mk_u64 0) key)
                               <:
                               Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0
                             in
@@ -1429,8 +695,8 @@ let compute_psk_binder_zero_rtt
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
             Bertie.Tls13formats.t_Transcript) u8)
-  | false, Core.Option.Option_None , 0uy ->
-    let tx_ch:Bertie.Tls13formats.t_Transcript = Bertie.Tls13formats.impl__Transcript__add tx ch in
+  | false, Core.Option.Option_None , Rust_primitives.Integers.MkInt 0 ->
+    let tx_ch:Bertie.Tls13formats.t_Transcript = Bertie.Tls13formats.impl_Transcript__add tx ch in
     Core.Result.Result_Ok
     (ch,
       (Core.Option.Option_None <: Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0),
@@ -1453,45 +719,58 @@ let compute_psk_binder_zero_rtt
         Bertie.Tls13formats.t_Transcript) u8
 
 let build_client_hello
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
       (sn: Bertie.Tls13utils.t_Bytes)
       (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
   let tx:Bertie.Tls13formats.t_Transcript =
-    Bertie.Tls13formats.impl__Transcript__new (Bertie.Tls13crypto.impl__Algorithms__hash ciphersuite
+    Bertie.Tls13formats.impl_Transcript__new (Bertie.Tls13crypto.impl_Algorithms__hash ciphersuite
         <:
         Bertie.Tls13crypto.t_HashAlgorithm)
   in
-  let client_random:t_Array u8 (sz 32) = Rust_primitives.Hax.repeat 0uy (sz 32) in
-  let tmp0, tmp1:(impl_916461611_ & t_Array u8 (sz 32)) =
-    Rand_core.f_fill_bytes rng client_random
+  let client_random:t_Array u8 (mk_usize 32) = Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32) in
+  let tmp0, tmp1:(iimpl_916461611_ & t_Array u8 (mk_usize 32)) =
+    Rand_core.f_fill_bytes #iimpl_916461611_ #FStar.Tactics.Typeclasses.solve rng client_random
   in
-  let rng:impl_916461611_ = tmp0 in
-  let client_random:t_Array u8 (sz 32) = tmp1 in
+  let rng:iimpl_916461611_ = tmp0 in
+  let client_random:t_Array u8 (mk_usize 32) = tmp1 in
   let _:Prims.unit = () in
-  let tmp0, out:(impl_916461611_ &
+  let tmp0, out:(iimpl_916461611_ &
     Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8) =
-    Bertie.Tls13crypto.kem_keygen (Bertie.Tls13crypto.impl__Algorithms__kem ciphersuite
-        <:
-        Bertie.Tls13crypto.t_KemScheme)
+    Bertie.Tls13crypto.kem_keygen #iimpl_916461611_
+      (Bertie.Tls13crypto.impl_Algorithms__kem ciphersuite <: Bertie.Tls13crypto.t_KemScheme)
       rng
   in
-  let rng:impl_916461611_ = tmp0 in
-  match out with
+  let rng:iimpl_916461611_ = tmp0 in
+  match out <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8 with
   | Core.Result.Result_Ok (kem_sk, kem_pk) ->
     (match
         Bertie.Tls13formats.client_hello ciphersuite
-          (Core.Convert.f_into client_random <: Bertie.Tls13utils.t_Bytes)
+          (Core.Convert.f_into #(t_Array u8 (mk_usize 32))
+              #Bertie.Tls13utils.t_Bytes
+              #FStar.Tactics.Typeclasses.solve
+              client_random
+            <:
+            Bertie.Tls13utils.t_Bytes)
           kem_pk
           sn
           tkt
+        <:
+        Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & usize) u8
       with
       | Core.Result.Result_Ok (client_hello, trunc_len) ->
-        (match compute_psk_binder_zero_rtt ciphersuite client_hello trunc_len psk tx with
+        (match
+            compute_psk_binder_zero_rtt ciphersuite client_hello trunc_len psk tx
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+                Bertie.Tls13formats.t_Transcript) u8
+          with
           | Core.Result.Result_Ok (nch, cipher0, tx_ch) ->
             let hax_temp_output:Core.Result.t_Result
               (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -1500,11 +779,11 @@ let build_client_hello
               Core.Result.Result_Ok
               (nch,
                 cipher0,
-                (ClientPostClientHello (Core.Convert.f_into client_random)
-                    ciphersuite
-                    kem_sk
-                    psk
-                    tx_ch
+                (ClientPostClientHello
+                    (Core.Convert.f_into #(t_Array u8 (mk_usize 32))
+                        #Bertie.Tls13utils.t_Bytes
+                        #FStar.Tactics.Typeclasses.solve
+                        client_random) ciphersuite kem_sk psk tx_ch
                   <:
                   t_ClientPostClientHello)
                 <:
@@ -1519,7 +798,7 @@ let build_client_hello
             in
             rng, hax_temp_output
             <:
-            (impl_916461611_ &
+            (iimpl_916461611_ &
               Core.Result.t_Result
                 (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                   Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
@@ -1533,7 +812,7 @@ let build_client_hello
                   Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
                   t_ClientPostClientHello) u8)
             <:
-            (impl_916461611_ &
+            (iimpl_916461611_ &
               Core.Result.t_Result
                 (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                   Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
@@ -1547,7 +826,7 @@ let build_client_hello
               Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
               t_ClientPostClientHello) u8)
         <:
-        (impl_916461611_ &
+        (iimpl_916461611_ &
           Core.Result.t_Result
             (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
@@ -1561,117 +840,249 @@ let build_client_hello
           Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
           t_ClientPostClientHello) u8)
     <:
-    (impl_916461611_ &
+    (iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
           t_ClientPostClientHello) u8)
 
-let client_init
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (sn: Bertie.Tls13utils.t_Bytes)
-      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
+let put_server_hello
+      (handshake: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (state: t_ClientPostClientHello)
      =
-  let tmp0, out:(impl_916461611_ &
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-        t_ClientPostClientHello) u8) =
-    build_client_hello algs sn tkt psk rng
-  in
-  let rng:impl_916461611_ = tmp0 in
-  let hax_temp_output:Core.Result.t_Result
-    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-      Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-      t_ClientPostClientHello) u8 =
-    out
-  in
-  rng, hax_temp_output
-  <:
-  (impl_916461611_ &
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-        Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-        t_ClientPostClientHello) u8)
-
-let get_server_finished (st: t_ServerPostCertificateVerify) =
-  let ServerPostCertificateVerify cr sr algs ms cfk sfk tx:t_ServerPostCertificateVerify = st in
-  let
-  { Bertie.Tls13crypto.f_hash = ha ;
-    Bertie.Tls13crypto.f_aead = ae ;
-    Bertie.Tls13crypto.f_signature = v__sa ;
-    Bertie.Tls13crypto.f_kem = v__gn ;
-    Bertie.Tls13crypto.f_psk_mode = v__psk_mode ;
-    Bertie.Tls13crypto.f_zero_rtt = v__zero_rtt }:Bertie.Tls13crypto.t_Algorithms =
-    algs
-  in
-  match Bertie.Tls13formats.impl__Transcript__transcript_hash tx with
-  | Core.Result.Result_Ok th_scv ->
-    (match Bertie.Tls13crypto.hmac_tag ha sfk th_scv with
-      | Core.Result.Result_Ok vd ->
-        (match Bertie.Tls13formats.finished vd with
-          | Core.Result.Result_Ok sfin ->
-            let tx:Bertie.Tls13formats.t_Transcript =
-              Bertie.Tls13formats.impl__Transcript__add tx sfin
-            in
-            (match Bertie.Tls13formats.impl__Transcript__transcript_hash tx with
-              | Core.Result.Result_Ok th_sfin ->
-                (match derive_app_keys ha ae ms th_sfin with
-                  | Core.Result.Result_Ok (cak, sak, exp) ->
-                    let cipher1:Bertie.Tls13record.t_DuplexCipherState1 =
-                      Bertie.Tls13record.duplex_cipher_state1 ae sak 0uL cak 0uL exp
-                    in
-                    Core.Result.Result_Ok
-                    (sfin,
-                      cipher1,
-                      (ServerPostServerFinished cr sr algs ms cfk tx <: t_ServerPostServerFinished)
-                      <:
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        Bertie.Tls13record.t_DuplexCipherState1 &
-                        t_ServerPostServerFinished))
+  let ClientPostClientHello client_random ciphersuite sk psk tx:t_ClientPostClientHello = state in
+  match
+    Bertie.Tls13formats.parse_server_hello ciphersuite handshake
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8
+  with
+  | Core.Result.Result_Ok (sr, ct) ->
+    let tx:Bertie.Tls13formats.t_Transcript =
+      Bertie.Tls13formats.impl_Transcript__add tx handshake
+    in
+    (match
+        Bertie.Tls13crypto.kem_decap ciphersuite.Bertie.Tls13crypto.f_kem ct sk
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok shared_secret ->
+        (match
+            Bertie.Tls13formats.impl_Transcript__transcript_hash tx
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok th ->
+            (match
+                derive_hk_ms ciphersuite.Bertie.Tls13crypto.f_hash
+                  ciphersuite.Bertie.Tls13crypto.f_aead
+                  shared_secret
+                  psk
+                  th
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                    Bertie.Tls13utils.t_Bytes &
+                    Bertie.Tls13utils.t_Bytes &
+                    Bertie.Tls13utils.t_Bytes) u8
+              with
+              | Core.Result.Result_Ok (chk, shk, cfk, sfk, ms) ->
+                Core.Result.Result_Ok
+                (Bertie.Tls13record.impl_DuplexCipherStateH__new chk (mk_u64 0) shk (mk_u64 0),
+                  (ClientPostServerHello client_random sr ciphersuite ms cfk sfk tx
                     <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        Bertie.Tls13record.t_DuplexCipherState1 &
-                        t_ServerPostServerFinished) u8
-                  | Core.Result.Result_Err err ->
-                    Core.Result.Result_Err err
-                    <:
-                    Core.Result.t_Result
-                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                        Bertie.Tls13record.t_DuplexCipherState1 &
-                        t_ServerPostServerFinished) u8)
+                    t_ClientPostServerHello)
+                  <:
+                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello))
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8
               | Core.Result.Result_Err err ->
                 Core.Result.Result_Err err
                 <:
                 Core.Result.t_Result
-                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                    Bertie.Tls13record.t_DuplexCipherState1 &
-                    t_ServerPostServerFinished) u8)
+                  (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
           | Core.Result.Result_Err err ->
             Core.Result.Result_Err err
             <:
-            Core.Result.t_Result
-              (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-                Bertie.Tls13record.t_DuplexCipherState1 &
-                t_ServerPostServerFinished) u8)
+            Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello)
+              u8)
       | Core.Result.Result_Err err ->
         Core.Result.Result_Err err
         <:
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13record.t_DuplexCipherState1 &
-            t_ServerPostServerFinished) u8)
+        Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err
     <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & Bertie.Tls13record.t_DuplexCipherState1 &
-        t_ServerPostServerFinished) u8
+    Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8
+
+let put_server_signature
+      (encrypted_extensions server_certificate server_certificate_verify:
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostServerHello)
+     =
+  let
+  ClientPostServerHello
+    client_random
+    server_random
+    algorithms
+    master_secret
+    client_finished_key
+    server_finished_key
+    transcript:t_ClientPostServerHello =
+    handshake_state
+  in
+  if ~.(Bertie.Tls13crypto.impl_Algorithms__psk_mode algorithms <: bool)
+  then
+    match
+      Bertie.Tls13formats.parse_encrypted_extensions algorithms encrypted_extensions
+      <:
+      Core.Result.t_Result Prims.unit u8
+    with
+    | Core.Result.Result_Ok _ ->
+      let transcript:Bertie.Tls13formats.t_Transcript =
+        Bertie.Tls13formats.impl_Transcript__add transcript encrypted_extensions
+      in
+      (match
+          Bertie.Tls13formats.parse_server_certificate server_certificate
+          <:
+          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+        with
+        | Core.Result.Result_Ok certificate ->
+          let transcript:Bertie.Tls13formats.t_Transcript =
+            Bertie.Tls13formats.impl_Transcript__add transcript server_certificate
+          in
+          (match
+              Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+              <:
+              Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+            with
+            | Core.Result.Result_Ok transcript_hash_server_certificate ->
+              (match
+                  Bertie.Tls13cert.verification_key_from_cert certificate
+                  <:
+                  Core.Result.t_Result
+                    (Bertie.Tls13crypto.t_SignatureScheme & Bertie.Tls13cert.t_CertificateKey) u8
+                with
+                | Core.Result.Result_Ok spki ->
+                  (match
+                      Bertie.Tls13cert.cert_public_key certificate spki
+                      <:
+                      Core.Result.t_Result Bertie.Tls13crypto.t_PublicVerificationKey u8
+                    with
+                    | Core.Result.Result_Ok cert_pk ->
+                      (match
+                          Bertie.Tls13formats.parse_certificate_verify algorithms
+                            server_certificate_verify
+                          <:
+                          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                        with
+                        | Core.Result.Result_Ok cert_signature ->
+                          let sigval:Bertie.Tls13utils.t_Bytes =
+                            Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__from_slice
+                                  (Bertie.Tls13formats.v_PREFIX_SERVER_SIGNATURE <: t_Slice u8)
+                                <:
+                                Bertie.Tls13utils.t_Bytes)
+                              transcript_hash_server_certificate
+                          in
+                          (match
+                              Bertie.Tls13crypto.verify (Bertie.Tls13crypto.impl_Algorithms__signature
+                                    algorithms
+                                  <:
+                                  Bertie.Tls13crypto.t_SignatureScheme)
+                                cert_pk
+                                sigval
+                                cert_signature
+                              <:
+                              Core.Result.t_Result Prims.unit u8
+                            with
+                            | Core.Result.Result_Ok _ ->
+                              let transcript:Bertie.Tls13formats.t_Transcript =
+                                Bertie.Tls13formats.impl_Transcript__add transcript
+                                  server_certificate_verify
+                              in
+                              Core.Result.Result_Ok
+                              (ClientPostCertificateVerify client_random
+                                  server_random
+                                  algorithms
+                                  master_secret
+                                  client_finished_key
+                                  server_finished_key
+                                  transcript
+                                <:
+                                t_ClientPostCertificateVerify)
+                              <:
+                              Core.Result.t_Result t_ClientPostCertificateVerify u8
+                            | Core.Result.Result_Err err ->
+                              Core.Result.Result_Err err
+                              <:
+                              Core.Result.t_Result t_ClientPostCertificateVerify u8)
+                        | Core.Result.Result_Err err ->
+                          Core.Result.Result_Err err
+                          <:
+                          Core.Result.t_Result t_ClientPostCertificateVerify u8)
+                    | Core.Result.Result_Err err ->
+                      Core.Result.Result_Err err
+                      <:
+                      Core.Result.t_Result t_ClientPostCertificateVerify u8)
+                | Core.Result.Result_Err err ->
+                  Core.Result.Result_Err err
+                  <:
+                  Core.Result.t_Result t_ClientPostCertificateVerify u8)
+            | Core.Result.Result_Err err ->
+              Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8)
+        | Core.Result.Result_Err err ->
+          Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8)
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8
+  else
+    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
+    <:
+    Core.Result.t_Result t_ClientPostCertificateVerify u8
+
+let put_psk_skip_server_signature
+      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostServerHello)
+     =
+  let
+  ClientPostServerHello
+    client_random
+    server_random
+    algorithms
+    master_secret
+    client_finished_key
+    server_finished_key
+    transcript:t_ClientPostServerHello =
+    handshake_state
+  in
+  if Bertie.Tls13crypto.impl_Algorithms__psk_mode algorithms
+  then
+    match
+      Bertie.Tls13formats.parse_encrypted_extensions algorithms encrypted_extensions
+      <:
+      Core.Result.t_Result Prims.unit u8
+    with
+    | Core.Result.Result_Ok _ ->
+      let transcript:Bertie.Tls13formats.t_Transcript =
+        Bertie.Tls13formats.impl_Transcript__add transcript encrypted_extensions
+      in
+      Core.Result.Result_Ok
+      (ClientPostCertificateVerify client_random
+          server_random
+          algorithms
+          master_secret
+          client_finished_key
+          server_finished_key
+          transcript
+        <:
+        t_ClientPostCertificateVerify)
+      <:
+      Core.Result.t_Result t_ClientPostCertificateVerify u8
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err <: Core.Result.t_Result t_ClientPostCertificateVerify u8
+  else
+    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
+    <:
+    Core.Result.t_Result t_ClientPostCertificateVerify u8
 
 let put_server_finished
       (server_finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
@@ -1697,23 +1108,43 @@ let put_server_finished
     Bertie.Tls13crypto.f_zero_rtt = zero_rtt }:Bertie.Tls13crypto.t_Algorithms =
     algorithms
   in
-  match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
+  match
+    Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
   | Core.Result.Result_Ok transcript_hash ->
-    (match Bertie.Tls13formats.parse_finished server_finished with
+    (match
+        Bertie.Tls13formats.parse_finished server_finished
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
       | Core.Result.Result_Ok verify_data ->
         (match
             Bertie.Tls13crypto.hmac_verify hash server_finished_key transcript_hash verify_data
+            <:
+            Core.Result.t_Result Prims.unit u8
           with
           | Core.Result.Result_Ok _ ->
             let transcript:Bertie.Tls13formats.t_Transcript =
-              Bertie.Tls13formats.impl__Transcript__add transcript server_finished
+              Bertie.Tls13formats.impl_Transcript__add transcript server_finished
             in
-            (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
+            (match
+                Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
               | Core.Result.Result_Ok transcript_hash_server_finished ->
-                (match derive_app_keys hash aead master_secret transcript_hash_server_finished with
+                (match
+                    derive_app_keys hash aead master_secret transcript_hash_server_finished
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                        Bertie.Tls13utils.t_Bytes) u8
+                  with
                   | Core.Result.Result_Ok (cak, sak, exp) ->
                     let cipher1:Bertie.Tls13record.t_DuplexCipherState1 =
-                      Bertie.Tls13record.duplex_cipher_state1 aead cak 0uL sak 0uL exp
+                      Bertie.Tls13record.duplex_cipher_state1 aead cak (mk_u64 0) sak (mk_u64 0) exp
                     in
                     Core.Result.Result_Ok
                     (cipher1,
@@ -1755,17 +1186,159 @@ let put_server_finished
     <:
     Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherState1 & t_ClientPostServerFinished) u8
 
+let get_client_finished (handshake_state: t_ClientPostServerFinished) =
+  let
+  ClientPostServerFinished
+    client_random
+    server_random
+    algorithms
+    master_secret
+    client_finished_key
+    transcript:t_ClientPostServerFinished =
+    handshake_state
+  in
+  match
+    Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok transcript_hash ->
+    (match
+        Bertie.Tls13crypto.hmac_tag (Bertie.Tls13crypto.impl_Algorithms__hash algorithms
+            <:
+            Bertie.Tls13crypto.t_HashAlgorithm)
+          client_finished_key
+          transcript_hash
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok verify_data ->
+        (match
+            Bertie.Tls13formats.finished verify_data
+            <:
+            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+          with
+          | Core.Result.Result_Ok client_finished ->
+            let transcript:Bertie.Tls13formats.t_Transcript =
+              Bertie.Tls13formats.impl_Transcript__add transcript client_finished
+            in
+            (match
+                Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok transcript_hash ->
+                (match
+                    derive_rms (Bertie.Tls13crypto.impl_Algorithms__hash algorithms
+                        <:
+                        Bertie.Tls13crypto.t_HashAlgorithm)
+                      master_secret
+                      transcript_hash
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  with
+                  | Core.Result.Result_Ok resumption_master_secret ->
+                    Core.Result.Result_Ok
+                    (client_finished,
+                      (ClientPostClientFinished client_random
+                          server_random
+                          algorithms
+                          resumption_master_secret
+                          transcript
+                        <:
+                        t_ClientPostClientFinished)
+                      <:
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        t_ClientPostClientFinished))
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        t_ClientPostClientFinished) u8
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        t_ClientPostClientFinished) u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished)
+                  u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished) u8
+
+let client_init
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (sn: Bertie.Tls13utils.t_Bytes)
+      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+     =
+  let tmp0, out:(iimpl_916461611_ &
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+        t_ClientPostClientHello) u8) =
+    build_client_hello #iimpl_916461611_ algs sn tkt psk rng
+  in
+  let rng:iimpl_916461611_ = tmp0 in
+  let hax_temp_output:Core.Result.t_Result
+    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+      Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+      t_ClientPostClientHello) u8 =
+    out
+  in
+  rng, hax_temp_output
+  <:
+  (iimpl_916461611_ &
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+        t_ClientPostClientHello) u8)
+
+let client_set_params
+      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ClientPostClientHello)
+     = put_server_hello payload st
+
 let client_finish
       (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (handshake_state: t_ClientPostServerHello)
      =
   match
-    Bertie.Tls13crypto.impl__Algorithms__psk_mode (algs_post_server_hello handshake_state
+    Bertie.Tls13crypto.impl_Algorithms__psk_mode (algs_post_server_hello handshake_state
         <:
         Bertie.Tls13crypto.t_Algorithms)
+    <:
+    bool
   with
   | false ->
-    (match Bertie.Tls13formats.Handshake_data.impl__HandshakeData__to_four payload with
+    (match
+        Bertie.Tls13formats.Handshake_data.impl_HandshakeData__to_four payload
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData) u8
+      with
       | Core.Result.Result_Ok
         (encrypted_extensions, server_certificate, server_certificate_verify, server_finished) ->
         (match
@@ -1773,11 +1346,24 @@ let client_finish
               server_certificate
               server_certificate_verify
               handshake_state
+            <:
+            Core.Result.t_Result t_ClientPostCertificateVerify u8
           with
           | Core.Result.Result_Ok client_state_certificate_verify ->
-            (match put_server_finished server_finished client_state_certificate_verify with
+            (match
+                put_server_finished server_finished client_state_certificate_verify
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13record.t_DuplexCipherState1 & t_ClientPostServerFinished) u8
+              with
               | Core.Result.Result_Ok (cipher, client_state_server_finished) ->
-                (match get_client_finished client_state_server_finished with
+                (match
+                    get_client_finished client_state_server_finished
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        t_ClientPostClientFinished) u8
+                  with
                   | Core.Result.Result_Ok (client_finished, client_state) ->
                     Core.Result.Result_Ok
                     (client_finished, cipher, client_state
@@ -1819,13 +1405,34 @@ let client_finish
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ClientPostClientFinished) u8)
   | true ->
-    match Bertie.Tls13formats.Handshake_data.impl__HandshakeData__to_two payload with
+    match
+      Bertie.Tls13formats.Handshake_data.impl_HandshakeData__to_two payload
+      <:
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData) u8
+    with
     | Core.Result.Result_Ok (encrypted_extensions, server_finished) ->
-      (match put_psk_skip_server_signature encrypted_extensions handshake_state with
+      (match
+          put_psk_skip_server_signature encrypted_extensions handshake_state
+          <:
+          Core.Result.t_Result t_ClientPostCertificateVerify u8
+        with
         | Core.Result.Result_Ok client_state_certificate_verify ->
-          (match put_server_finished server_finished client_state_certificate_verify with
+          (match
+              put_server_finished server_finished client_state_certificate_verify
+              <:
+              Core.Result.t_Result
+                (Bertie.Tls13record.t_DuplexCipherState1 & t_ClientPostServerFinished) u8
+            with
             | Core.Result.Result_Ok (cipher, client_state_server_finished) ->
-              (match get_client_finished client_state_server_finished with
+              (match
+                  get_client_finished client_state_server_finished
+                  <:
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ClientPostClientFinished
+                    ) u8
+                with
                 | Core.Result.Result_Ok (client_finished, client_state) ->
                   Core.Result.Result_Ok
                   (client_finished, cipher, client_state
@@ -1879,10 +1486,16 @@ let process_psk_binder_zero_rtt
       Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
   with
   | true, Core.Option.Option_Some k, Core.Option.Option_Some binder ->
-    (match derive_binder_key ciphersuite.Bertie.Tls13crypto.f_hash k with
+    (match
+        derive_binder_key ciphersuite.Bertie.Tls13crypto.f_hash k
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
       | Core.Result.Result_Ok mk ->
         (match
             Bertie.Tls13crypto.hmac_verify ciphersuite.Bertie.Tls13crypto.f_hash mk th_trunc binder
+            <:
+            Core.Result.t_Result Prims.unit u8
           with
           | Core.Result.Result_Ok _ ->
             if ciphersuite.Bertie.Tls13crypto.f_zero_rtt
@@ -1892,11 +1505,13 @@ let process_psk_binder_zero_rtt
                   ciphersuite.Bertie.Tls13crypto.f_aead
                   k
                   th
+                <:
+                Core.Result.t_Result (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13utils.t_Bytes) u8
               with
               | Core.Result.Result_Ok (key_iv, early_exporter_ms) ->
                 let cipher0:Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 =
                   Core.Option.Option_Some
-                  (Bertie.Tls13record.server_cipher_state0 key_iv 0uL early_exporter_ms)
+                  (Bertie.Tls13record.server_cipher_state0 key_iv (mk_u64 0) early_exporter_ms)
                   <:
                   Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0
                 in
@@ -1939,24 +1554,42 @@ let put_client_hello
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
      =
-  match Bertie.Tls13formats.parse_client_hello ciphersuite ch with
+  match
+    Bertie.Tls13formats.parse_client_hello ciphersuite ch
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes &
+        Bertie.Tls13utils.t_Bytes &
+        Core.Option.t_Option Bertie.Tls13utils.t_Bytes &
+        Core.Option.t_Option Bertie.Tls13utils.t_Bytes &
+        usize) u8
+  with
   | Core.Result.Result_Ok (client_randomness, session_id, sni, gx, tkto, bindero, trunc_len) ->
     let tx:Bertie.Tls13formats.t_Transcript =
-      Bertie.Tls13formats.impl__Transcript__new (Bertie.Tls13crypto.impl__Algorithms__hash ciphersuite
-
+      Bertie.Tls13formats.impl_Transcript__new (Bertie.Tls13crypto.impl_Algorithms__hash ciphersuite
           <:
           Bertie.Tls13crypto.t_HashAlgorithm)
     in
     (match
-        Bertie.Tls13formats.impl__Transcript__transcript_hash_without_client_hello tx ch trunc_len
+        Bertie.Tls13formats.impl_Transcript__transcript_hash_without_client_hello tx ch trunc_len
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
       with
       | Core.Result.Result_Ok th_trunc ->
         let transcript:Bertie.Tls13formats.t_Transcript =
-          Bertie.Tls13formats.impl__Transcript__add tx ch
+          Bertie.Tls13formats.impl_Transcript__add tx ch
         in
-        (match Bertie.Tls13formats.impl__Transcript__transcript_hash transcript with
+        (match
+            Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
           | Core.Result.Result_Ok th ->
-            (match Bertie.Server.lookup_db ciphersuite db sni tkto with
+            (match
+                Bertie.Server.lookup_db ciphersuite db sni tkto
+                <:
+                Core.Result.t_Result Bertie.Server.t_ServerInfo u8
+              with
               | Core.Result.Result_Ok server ->
                 (match
                     process_psk_binder_zero_rtt ciphersuite
@@ -1964,6 +1597,9 @@ let put_client_hello
                       th
                       server.Bertie.Server.f_psk_opt
                       bindero
+                    <:
+                    Core.Result.t_Result
+                      (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0) u8
                   with
                   | Core.Result.Result_Ok cipher0 ->
                     Core.Result.Result_Ok
@@ -2015,43 +1651,749 @@ let put_client_hello
     Core.Result.t_Result
       (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 & t_ServerPostClientHello) u8
 
+let get_server_hello
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
+      (state: t_ServerPostClientHello)
+      (rng: iimpl_916461611_)
+     =
+  let server_random:t_Array u8 (mk_usize 32) = Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32) in
+  let tmp0, tmp1:(iimpl_916461611_ & t_Array u8 (mk_usize 32)) =
+    Rand_core.f_fill_bytes #iimpl_916461611_ #FStar.Tactics.Typeclasses.solve rng server_random
+  in
+  let rng:iimpl_916461611_ = tmp0 in
+  let server_random:t_Array u8 (mk_usize 32) = tmp1 in
+  let _:Prims.unit = () in
+  let tmp0, out:(iimpl_916461611_ &
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8) =
+    Bertie.Tls13crypto.kem_encap #iimpl_916461611_
+      state.f_ciphersuite.Bertie.Tls13crypto.f_kem
+      state.f_gx
+      rng
+  in
+  let rng:iimpl_916461611_ = tmp0 in
+  match out <: Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & Bertie.Tls13utils.t_Bytes) u8 with
+  | Core.Result.Result_Ok (shared_secret, gy) ->
+    (match
+        Bertie.Tls13formats.server_hello state.f_ciphersuite
+          (Core.Convert.f_into #(t_Array u8 (mk_usize 32))
+              #Bertie.Tls13utils.t_Bytes
+              #FStar.Tactics.Typeclasses.solve
+              server_random
+            <:
+            Bertie.Tls13utils.t_Bytes)
+          state.f_session_id
+          gy
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+      with
+      | Core.Result.Result_Ok sh ->
+        let transcript:Bertie.Tls13formats.t_Transcript =
+          Bertie.Tls13formats.impl_Transcript__add state.f_transcript sh
+        in
+        (match
+            Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok transcript_hash ->
+            (match
+                derive_hk_ms state.f_ciphersuite.Bertie.Tls13crypto.f_hash
+                  state.f_ciphersuite.Bertie.Tls13crypto.f_aead
+                  shared_secret
+                  state.f_server.Bertie.Server.f_psk_opt
+                  transcript_hash
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                    Bertie.Tls13utils.t_Bytes &
+                    Bertie.Tls13utils.t_Bytes &
+                    Bertie.Tls13utils.t_Bytes) u8
+              with
+              | Core.Result.Result_Ok (chk, shk, cfk, sfk, ms) ->
+                let hax_temp_output:Core.Result.t_Result
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                    Bertie.Tls13record.t_DuplexCipherStateH &
+                    t_ServerPostServerHello) u8 =
+                  Core.Result.Result_Ok
+                  (sh,
+                    Bertie.Tls13record.impl_DuplexCipherStateH__new shk (mk_u64 0) chk (mk_u64 0),
+                    ({
+                        f_client_random = state.f_client_randomness;
+                        f_server_random
+                        =
+                        Core.Convert.f_into #(t_Array u8 (mk_usize 32))
+                          #Bertie.Tls13utils.t_Bytes
+                          #FStar.Tactics.Typeclasses.solve
+                          server_random;
+                        f_ciphersuite = state.f_ciphersuite;
+                        f_server = state.f_server;
+                        f_master_secret = ms;
+                        f_cfk = cfk;
+                        f_sfk = sfk;
+                        f_transcript = transcript
+                      }
+                      <:
+                      t_ServerPostServerHello)
+                    <:
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13record.t_DuplexCipherStateH &
+                      t_ServerPostServerHello))
+                  <:
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13record.t_DuplexCipherStateH &
+                      t_ServerPostServerHello) u8
+                in
+                rng, hax_temp_output
+                <:
+                (iimpl_916461611_ &
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13record.t_DuplexCipherStateH &
+                      t_ServerPostServerHello) u8)
+              | Core.Result.Result_Err err ->
+                rng,
+                (Core.Result.Result_Err err
+                  <:
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13record.t_DuplexCipherStateH &
+                      t_ServerPostServerHello) u8)
+                <:
+                (iimpl_916461611_ &
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13record.t_DuplexCipherStateH &
+                      t_ServerPostServerHello) u8))
+          | Core.Result.Result_Err err ->
+            rng,
+            (Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result
+                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13record.t_DuplexCipherStateH &
+                  t_ServerPostServerHello) u8)
+            <:
+            (iimpl_916461611_ &
+              Core.Result.t_Result
+                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13record.t_DuplexCipherStateH &
+                  t_ServerPostServerHello) u8))
+      | Core.Result.Result_Err err ->
+        rng,
+        (Core.Result.Result_Err err
+          <:
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13record.t_DuplexCipherStateH &
+              t_ServerPostServerHello) u8)
+        <:
+        (iimpl_916461611_ &
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13record.t_DuplexCipherStateH &
+              t_ServerPostServerHello) u8))
+  | Core.Result.Result_Err err ->
+    rng,
+    (Core.Result.Result_Err err
+      <:
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13record.t_DuplexCipherStateH &
+          t_ServerPostServerHello) u8)
+    <:
+    (iimpl_916461611_ &
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13record.t_DuplexCipherStateH &
+          t_ServerPostServerHello) u8)
+
+let get_rsa_signature
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
+      (cert sk sigval: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+     =
+  match
+    Bertie.Tls13cert.verification_key_from_cert cert
+    <:
+    Core.Result.t_Result (Bertie.Tls13crypto.t_SignatureScheme & Bertie.Tls13cert.t_CertificateKey)
+      u8
+  with
+  | Core.Result.Result_Ok (cert_scheme, cert_slice) ->
+    (match
+        Bertie.Tls13cert.rsa_public_key cert cert_slice
+        <:
+        Core.Result.t_Result Bertie.Tls13crypto.t_RsaVerificationKey u8
+      with
+      | Core.Result.Result_Ok pk ->
+        let tmp0, out:(iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8) =
+          Bertie.Tls13crypto.sign_rsa #iimpl_916461611_
+            sk
+            pk.Bertie.Tls13crypto.f_modulus
+            pk.Bertie.Tls13crypto.f_exponent
+            cert_scheme
+            sigval
+            rng
+        in
+        let rng:iimpl_916461611_ = tmp0 in
+        let hax_temp_output:Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 = out in
+        rng, hax_temp_output
+        <:
+        (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      | Core.Result.Result_Err err ->
+        rng, (Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+        <:
+        (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8))
+  | Core.Result.Result_Err err ->
+    rng, (Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+    <:
+    (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+
+let get_server_signature_no_psk
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
+      (state: t_ServerPostServerHello)
+      (rng: iimpl_916461611_)
+     =
+  match
+    Bertie.Tls13formats.encrypted_extensions state.f_ciphersuite
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
+  | Core.Result.Result_Ok ee ->
+    let transcript:Bertie.Tls13formats.t_Transcript =
+      Bertie.Tls13formats.impl_Transcript__add state.f_transcript ee
+    in
+    (match
+        Bertie.Tls13formats.server_certificate state.f_ciphersuite
+          state.f_server.Bertie.Server.f_cert
+        <:
+        Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+      with
+      | Core.Result.Result_Ok sc ->
+        let transcript:Bertie.Tls13formats.t_Transcript =
+          Bertie.Tls13formats.impl_Transcript__add transcript sc
+        in
+        (match
+            Bertie.Tls13formats.impl_Transcript__transcript_hash transcript
+            <:
+            Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+          with
+          | Core.Result.Result_Ok transcript_hash ->
+            let sigval:Bertie.Tls13utils.t_Bytes =
+              Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__from_slice (Bertie.Tls13formats.v_PREFIX_SERVER_SIGNATURE
+                      <:
+                      t_Slice u8)
+                  <:
+                  Bertie.Tls13utils.t_Bytes)
+                transcript_hash
+            in
+            let rng, hoist101:(iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+            =
+              match
+                Bertie.Tls13crypto.impl_Algorithms__signature state.f_ciphersuite
+                <:
+                Bertie.Tls13crypto.t_SignatureScheme
+              with
+              | Bertie.Tls13crypto.SignatureScheme_EcdsaSecp256r1Sha256  ->
+                let tmp0, out:(iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                =
+                  Bertie.Tls13crypto.sign #iimpl_916461611_
+                    (Bertie.Tls13crypto.impl_Algorithms__signature state.f_ciphersuite
+                      <:
+                      Bertie.Tls13crypto.t_SignatureScheme)
+                    state.f_server.Bertie.Server.f_sk
+                    sigval
+                    rng
+                in
+                let rng:iimpl_916461611_ = tmp0 in
+                rng, out <: (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+              | Bertie.Tls13crypto.SignatureScheme_RsaPssRsaSha256  ->
+                let tmp0, out:(iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                =
+                  get_rsa_signature #iimpl_916461611_
+                    state.f_server.Bertie.Server.f_cert
+                    state.f_server.Bertie.Server.f_sk
+                    sigval
+                    rng
+                in
+                let rng:iimpl_916461611_ = tmp0 in
+                rng, out <: (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+              | Bertie.Tls13crypto.SignatureScheme_ED25519  ->
+                rng,
+                (Core.Result.Result_Err Bertie.Tls13utils.v_UNSUPPORTED_ALGORITHM
+                  <:
+                  Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+                <:
+                (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+            in
+            (match hoist101 <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8 with
+              | Core.Result.Result_Ok sig ->
+                (match
+                    Bertie.Tls13formats.certificate_verify state.f_ciphersuite sig
+                    <:
+                    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+                  with
+                  | Core.Result.Result_Ok scv ->
+                    let transcript:Bertie.Tls13formats.t_Transcript =
+                      Bertie.Tls13formats.impl_Transcript__add transcript scv
+                    in
+                    let hax_temp_output:Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        t_ServerPostCertificateVerify) u8 =
+                      Core.Result.Result_Ok
+                      (ee,
+                        sc,
+                        scv,
+                        (ServerPostCertificateVerify state.f_client_random
+                            state.f_server_random
+                            state.f_ciphersuite
+                            state.f_master_secret
+                            state.f_cfk
+                            state.f_sfk
+                            transcript
+                          <:
+                          t_ServerPostCertificateVerify)
+                        <:
+                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          t_ServerPostCertificateVerify))
+                      <:
+                      Core.Result.t_Result
+                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          t_ServerPostCertificateVerify) u8
+                    in
+                    rng, hax_temp_output
+                    <:
+                    (iimpl_916461611_ &
+                      Core.Result.t_Result
+                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          t_ServerPostCertificateVerify) u8)
+                  | Core.Result.Result_Err err ->
+                    rng,
+                    (Core.Result.Result_Err err
+                      <:
+                      Core.Result.t_Result
+                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          t_ServerPostCertificateVerify) u8)
+                    <:
+                    (iimpl_916461611_ &
+                      Core.Result.t_Result
+                        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                          t_ServerPostCertificateVerify) u8))
+              | Core.Result.Result_Err err ->
+                rng,
+                (Core.Result.Result_Err err
+                  <:
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      t_ServerPostCertificateVerify) u8)
+                <:
+                (iimpl_916461611_ &
+                  Core.Result.t_Result
+                    (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                      t_ServerPostCertificateVerify) u8))
+          | Core.Result.Result_Err err ->
+            rng,
+            (Core.Result.Result_Err err
+              <:
+              Core.Result.t_Result
+                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  t_ServerPostCertificateVerify) u8)
+            <:
+            (iimpl_916461611_ &
+              Core.Result.t_Result
+                (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                  t_ServerPostCertificateVerify) u8))
+      | Core.Result.Result_Err err ->
+        rng,
+        (Core.Result.Result_Err err
+          <:
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              t_ServerPostCertificateVerify) u8)
+        <:
+        (iimpl_916461611_ &
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+              t_ServerPostCertificateVerify) u8))
+  | Core.Result.Result_Err err ->
+    rng,
+    (Core.Result.Result_Err err
+      <:
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          t_ServerPostCertificateVerify) u8)
+    <:
+    (iimpl_916461611_ &
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+          t_ServerPostCertificateVerify) u8)
+
+let get_server_signature
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
+      (state: t_ServerPostServerHello)
+      (rng: iimpl_916461611_)
+     =
+  let rng, hax_temp_output:(iimpl_916461611_ &
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        t_ServerPostCertificateVerify) u8) =
+    if ~.(Bertie.Tls13crypto.impl_Algorithms__psk_mode state.f_ciphersuite <: bool)
+    then
+      let tmp0, out:(iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            t_ServerPostCertificateVerify) u8) =
+        get_server_signature_no_psk #iimpl_916461611_ state rng
+      in
+      let rng:iimpl_916461611_ = tmp0 in
+      rng, out
+      <:
+      (iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            t_ServerPostCertificateVerify) u8)
+    else
+      rng,
+      (Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            t_ServerPostCertificateVerify) u8)
+      <:
+      (iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            t_ServerPostCertificateVerify) u8)
+  in
+  rng, hax_temp_output
+  <:
+  (iimpl_916461611_ &
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+        t_ServerPostCertificateVerify) u8)
+
+let get_skip_server_signature_no_psk (st: t_ServerPostServerHello) =
+  let
+  { f_client_random = cr ;
+    f_server_random = sr ;
+    f_ciphersuite = algs ;
+    f_server = server ;
+    f_master_secret = ms ;
+    f_cfk = cfk ;
+    f_sfk = sfk ;
+    f_transcript = tx }:t_ServerPostServerHello =
+    st
+  in
+  match
+    Bertie.Tls13formats.encrypted_extensions algs
+    <:
+    Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+  with
+  | Core.Result.Result_Ok ee ->
+    let tx:Bertie.Tls13formats.t_Transcript = Bertie.Tls13formats.impl_Transcript__add tx ee in
+    Core.Result.Result_Ok
+    (ee, (ServerPostCertificateVerify cr sr algs ms cfk sfk tx <: t_ServerPostCertificateVerify)
+      <:
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify))
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
+
+let get_skip_server_signature (st: t_ServerPostServerHello) =
+  let
+  { f_client_random = cr ;
+    f_server_random = sr ;
+    f_ciphersuite = algs ;
+    f_server = server ;
+    f_master_secret = ms ;
+    f_cfk = cfk ;
+    f_sfk = sfk ;
+    f_transcript = tx }:t_ServerPostServerHello =
+    st
+  in
+  if Bertie.Tls13crypto.impl_Algorithms__psk_mode algs
+  then get_skip_server_signature_no_psk st
+  else
+    Core.Result.Result_Err Bertie.Tls13utils.v_PSK_MODE_MISMATCH
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify) u8
+
+let get_server_finished (st: t_ServerPostCertificateVerify) =
+  let ServerPostCertificateVerify cr sr algs ms cfk sfk tx:t_ServerPostCertificateVerify = st in
+  let
+  { Bertie.Tls13crypto.f_hash = ha ;
+    Bertie.Tls13crypto.f_aead = ae ;
+    Bertie.Tls13crypto.f_signature = e_sa ;
+    Bertie.Tls13crypto.f_kem = e_gn ;
+    Bertie.Tls13crypto.f_psk_mode = e_psk_mode ;
+    Bertie.Tls13crypto.f_zero_rtt = e_zero_rtt }:Bertie.Tls13crypto.t_Algorithms =
+    algs
+  in
+  match
+    Bertie.Tls13formats.impl_Transcript__transcript_hash tx
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok th_scv ->
+    (match
+        Bertie.Tls13crypto.hmac_tag ha sfk th_scv
+        <:
+        Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok vd ->
+        (match
+            Bertie.Tls13formats.finished vd
+            <:
+            Core.Result.t_Result Bertie.Tls13formats.Handshake_data.t_HandshakeData u8
+          with
+          | Core.Result.Result_Ok sfin ->
+            let tx:Bertie.Tls13formats.t_Transcript =
+              Bertie.Tls13formats.impl_Transcript__add tx sfin
+            in
+            (match
+                Bertie.Tls13formats.impl_Transcript__transcript_hash tx
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok th_sfin ->
+                (match
+                    derive_app_keys ha ae ms th_sfin
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+                        Bertie.Tls13utils.t_Bytes) u8
+                  with
+                  | Core.Result.Result_Ok (cak, sak, exp) ->
+                    let cipher1:Bertie.Tls13record.t_DuplexCipherState1 =
+                      Bertie.Tls13record.duplex_cipher_state1 ae sak (mk_u64 0) cak (mk_u64 0) exp
+                    in
+                    Core.Result.Result_Ok
+                    (sfin,
+                      cipher1,
+                      (ServerPostServerFinished cr sr algs ms cfk tx <: t_ServerPostServerFinished)
+                      <:
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        Bertie.Tls13record.t_DuplexCipherState1 &
+                        t_ServerPostServerFinished))
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        Bertie.Tls13record.t_DuplexCipherState1 &
+                        t_ServerPostServerFinished) u8
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err
+                    <:
+                    Core.Result.t_Result
+                      (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                        Bertie.Tls13record.t_DuplexCipherState1 &
+                        t_ServerPostServerFinished) u8)
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                    Bertie.Tls13record.t_DuplexCipherState1 &
+                    t_ServerPostServerFinished) u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                Bertie.Tls13record.t_DuplexCipherState1 &
+                t_ServerPostServerFinished) u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherState1 &
+            t_ServerPostServerFinished) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result
+      (Bertie.Tls13formats.Handshake_data.t_HandshakeData & Bertie.Tls13record.t_DuplexCipherState1 &
+        t_ServerPostServerFinished) u8
+
+let put_client_finished
+      (cfin: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ServerPostServerFinished)
+     =
+  let ServerPostServerFinished cr sr algs ms cfk tx:t_ServerPostServerFinished = st in
+  match
+    Bertie.Tls13formats.impl_Transcript__transcript_hash tx
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok th ->
+    (match
+        Bertie.Tls13formats.parse_finished cfin <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+      with
+      | Core.Result.Result_Ok vd ->
+        (match
+            Bertie.Tls13crypto.hmac_verify (Bertie.Tls13crypto.impl_Algorithms__hash algs
+                <:
+                Bertie.Tls13crypto.t_HashAlgorithm)
+              cfk
+              th
+              vd
+            <:
+            Core.Result.t_Result Prims.unit u8
+          with
+          | Core.Result.Result_Ok _ ->
+            let tx:Bertie.Tls13formats.t_Transcript =
+              Bertie.Tls13formats.impl_Transcript__add tx cfin
+            in
+            (match
+                Bertie.Tls13formats.impl_Transcript__transcript_hash tx
+                <:
+                Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+              with
+              | Core.Result.Result_Ok th ->
+                (match
+                    derive_rms (Bertie.Tls13crypto.impl_Algorithms__hash algs
+                        <:
+                        Bertie.Tls13crypto.t_HashAlgorithm)
+                      ms
+                      th
+                    <:
+                    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+                  with
+                  | Core.Result.Result_Ok rms ->
+                    Core.Result.Result_Ok
+                    (ServerPostClientFinished cr sr algs rms tx <: t_ServerPostClientFinished)
+                    <:
+                    Core.Result.t_Result t_ServerPostClientFinished u8
+                  | Core.Result.Result_Err err ->
+                    Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8
+                )
+              | Core.Result.Result_Err err ->
+                Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
+          | Core.Result.Result_Err err ->
+            Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err <: Core.Result.t_Result t_ServerPostClientFinished u8
+
 let server_init_no_psk
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
-  match put_client_hello algs ch db with
+  match
+    put_client_hello algs ch db
+    <:
+    Core.Result.t_Result
+      (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 & t_ServerPostClientHello) u8
+  with
   | Core.Result.Result_Ok (cipher0, st) ->
-    let tmp0, out:(impl_916461611_ &
+    let tmp0, out:(iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Bertie.Tls13record.t_DuplexCipherStateH &
           t_ServerPostServerHello) u8) =
-      get_server_hello st rng
+      get_server_hello #iimpl_916461611_ st rng
     in
-    let rng:impl_916461611_ = tmp0 in
-    (match out with
+    let rng:iimpl_916461611_ = tmp0 in
+    (match
+        out
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherStateH &
+            t_ServerPostServerHello) u8
+      with
       | Core.Result.Result_Ok (sh, cipher_hs, st) ->
-        let tmp0, out:(impl_916461611_ &
+        let tmp0, out:(iimpl_916461611_ &
           Core.Result.t_Result
             (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               t_ServerPostCertificateVerify) u8) =
-          get_server_signature st rng
+          get_server_signature #iimpl_916461611_ st rng
         in
-        let rng:impl_916461611_ = tmp0 in
-        (match out with
+        let rng:iimpl_916461611_ = tmp0 in
+        (match
+            out
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                t_ServerPostCertificateVerify) u8
+          with
           | Core.Result.Result_Ok (ee, sc, scv, st) ->
-            (match get_server_finished st with
+            (match
+                get_server_finished st
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                    Bertie.Tls13record.t_DuplexCipherState1 &
+                    t_ServerPostServerFinished) u8
+              with
               | Core.Result.Result_Ok (sfin, cipher1, st) ->
                 let flight:Bertie.Tls13formats.Handshake_data.t_HandshakeData =
-                  Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat (Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat
-                        (Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat ee sc
+                  Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat (Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat
+                        (Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat ee sc
                           <:
                           Bertie.Tls13formats.Handshake_data.t_HandshakeData)
                         scv
@@ -2086,7 +2428,7 @@ let server_init_no_psk
                 in
                 rng, hax_temp_output
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                       Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2106,7 +2448,7 @@ let server_init_no_psk
                       Bertie.Tls13record.t_DuplexCipherState1 &
                       t_ServerPostServerFinished) u8)
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                       Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2126,7 +2468,7 @@ let server_init_no_psk
                   Bertie.Tls13record.t_DuplexCipherState1 &
                   t_ServerPostServerFinished) u8)
             <:
-            (impl_916461611_ &
+            (iimpl_916461611_ &
               Core.Result.t_Result
                 (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                   Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2146,7 +2488,7 @@ let server_init_no_psk
               Bertie.Tls13record.t_DuplexCipherState1 &
               t_ServerPostServerFinished) u8)
         <:
-        (impl_916461611_ &
+        (iimpl_916461611_ &
           Core.Result.t_Result
             (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2166,7 +2508,7 @@ let server_init_no_psk
           Bertie.Tls13record.t_DuplexCipherState1 &
           t_ServerPostServerFinished) u8)
     <:
-    (impl_916461611_ &
+    (iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2176,32 +2518,57 @@ let server_init_no_psk
           t_ServerPostServerFinished) u8)
 
 let server_init_psk
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
-  match put_client_hello algs ch db with
+  match
+    put_client_hello algs ch db
+    <:
+    Core.Result.t_Result
+      (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 & t_ServerPostClientHello) u8
+  with
   | Core.Result.Result_Ok (cipher0, st) ->
-    let tmp0, out:(impl_916461611_ &
+    let tmp0, out:(iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Bertie.Tls13record.t_DuplexCipherStateH &
           t_ServerPostServerHello) u8) =
-      get_server_hello st rng
+      get_server_hello #iimpl_916461611_ st rng
     in
-    let rng:impl_916461611_ = tmp0 in
-    (match out with
+    let rng:iimpl_916461611_ = tmp0 in
+    (match
+        out
+        <:
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherStateH &
+            t_ServerPostServerHello) u8
+      with
       | Core.Result.Result_Ok (sh, cipher_hs, st) ->
-        (match get_skip_server_signature st with
+        (match
+            get_skip_server_signature st
+            <:
+            Core.Result.t_Result
+              (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_ServerPostCertificateVerify)
+              u8
+          with
           | Core.Result.Result_Ok (ee, st) ->
-            (match get_server_finished st with
+            (match
+                get_server_finished st
+                <:
+                Core.Result.t_Result
+                  (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+                    Bertie.Tls13record.t_DuplexCipherState1 &
+                    t_ServerPostServerFinished) u8
+              with
               | Core.Result.Result_Ok (sfin, cipher1, st) ->
                 let flight:Bertie.Tls13formats.Handshake_data.t_HandshakeData =
-                  Bertie.Tls13formats.Handshake_data.impl__HandshakeData__concat ee sfin
+                  Bertie.Tls13formats.Handshake_data.impl_HandshakeData__concat ee sfin
                 in
                 let hax_temp_output:Core.Result.t_Result
                   (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2230,7 +2597,7 @@ let server_init_psk
                 in
                 rng, hax_temp_output
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                       Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2250,7 +2617,7 @@ let server_init_psk
                       Bertie.Tls13record.t_DuplexCipherState1 &
                       t_ServerPostServerFinished) u8)
                 <:
-                (impl_916461611_ &
+                (iimpl_916461611_ &
                   Core.Result.t_Result
                     (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                       Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2270,7 +2637,7 @@ let server_init_psk
                   Bertie.Tls13record.t_DuplexCipherState1 &
                   t_ServerPostServerFinished) u8)
             <:
-            (impl_916461611_ &
+            (iimpl_916461611_ &
               Core.Result.t_Result
                 (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
                   Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2290,7 +2657,7 @@ let server_init_psk
               Bertie.Tls13record.t_DuplexCipherState1 &
               t_ServerPostServerFinished) u8)
         <:
-        (impl_916461611_ &
+        (iimpl_916461611_ &
           Core.Result.t_Result
             (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
               Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2310,7 +2677,7 @@ let server_init_psk
           Bertie.Tls13record.t_DuplexCipherState1 &
           t_ServerPostServerFinished) u8)
     <:
-    (impl_916461611_ &
+    (iimpl_916461611_ &
       Core.Result.t_Result
         (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
           Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2320,15 +2687,15 @@ let server_init_psk
           t_ServerPostServerFinished) u8)
 
 let server_init
-      (#impl_916461611_: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng impl_916461611_)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore impl_916461611_)
+      (#iimpl_916461611_: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng iimpl_916461611_)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Rand_core.t_RngCore iimpl_916461611_)
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
      =
-  let rng, hax_temp_output:(impl_916461611_ &
+  let rng, hax_temp_output:(iimpl_916461611_ &
     Core.Result.t_Result
       (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
         Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2336,9 +2703,9 @@ let server_init
         Bertie.Tls13record.t_DuplexCipherStateH &
         Bertie.Tls13record.t_DuplexCipherState1 &
         t_ServerPostServerFinished) u8) =
-    match Bertie.Tls13crypto.impl__Algorithms__psk_mode algs with
+    match Bertie.Tls13crypto.impl_Algorithms__psk_mode algs <: bool with
     | false ->
-      let tmp0, out:(impl_916461611_ &
+      let tmp0, out:(iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2346,12 +2713,12 @@ let server_init
             Bertie.Tls13record.t_DuplexCipherStateH &
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ServerPostServerFinished) u8) =
-        server_init_no_psk algs ch db rng
+        server_init_no_psk #iimpl_916461611_ algs ch db rng
       in
-      let rng:impl_916461611_ = tmp0 in
+      let rng:iimpl_916461611_ = tmp0 in
       rng, out
       <:
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2360,7 +2727,7 @@ let server_init
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ServerPostServerFinished) u8)
     | true ->
-      let tmp0, out:(impl_916461611_ &
+      let tmp0, out:(iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2368,12 +2735,12 @@ let server_init
             Bertie.Tls13record.t_DuplexCipherStateH &
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ServerPostServerFinished) u8) =
-        server_init_psk algs ch db rng
+        server_init_psk #iimpl_916461611_ algs ch db rng
       in
-      let rng:impl_916461611_ = tmp0 in
+      let rng:iimpl_916461611_ = tmp0 in
       rng, out
       <:
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2384,7 +2751,7 @@ let server_init
   in
   rng, hax_temp_output
   <:
-  (impl_916461611_ &
+  (iimpl_916461611_ &
     Core.Result.t_Result
       (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
         Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -2392,3 +2759,8 @@ let server_init
         Bertie.Tls13record.t_DuplexCipherStateH &
         Bertie.Tls13record.t_DuplexCipherState1 &
         t_ServerPostServerFinished) u8)
+
+let server_finish
+      (cf: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ServerPostServerFinished)
+     = put_client_finished cf st

--- a/proofs/fstar/extraction/Bertie.Tls13handshake.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13handshake.fsti
@@ -3,20 +3,24 @@ module Bertie.Tls13handshake
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13utils in
+  let open Rand_core in
+  ()
+
+/// Get the hash of an empty byte slice.
 val hash_empty (algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// HKDF expand with a `label`.
 val hkdf_expand_label
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
       (key label context: Bertie.Tls13utils.t_Bytes)
       (len: usize)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val derive_finished_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13utils.t_Bytes)
     : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
@@ -33,23 +37,7 @@ val derive_binder_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13u
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val derive_rms
-      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
-      (master_secret tx: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val get_rsa_signature
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (cert sk sigval: Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure (impl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
+/// Derive an AEAD key and iv.
 val derive_aead_key_iv
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
       (aead_algorithm: Bertie.Tls13crypto.t_AeadAlgorithm)
@@ -58,6 +46,7 @@ val derive_aead_key_iv
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+/// Derive 0-RTT AEAD keys.
 val derive_0rtt_keys
       (hash_algorithm: Bertie.Tls13crypto.t_HashAlgorithm)
       (aead_algoorithm: Bertie.Tls13crypto.t_AeadAlgorithm)
@@ -67,15 +56,12 @@ val derive_0rtt_keys
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val derive_app_keys
-      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
-      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (master_secret tx: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure
-      (Core.Result.t_Result
-          (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
-            Bertie.Tls13utils.t_Bytes) u8) Prims.l_True (fun _ -> Prims.l_True)
+val derive_finished_key (ha: Bertie.Tls13crypto.t_HashAlgorithm) (k: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
+/// Derive the handshake keys and master secret.
 val derive_hk_ms
       (ha: Bertie.Tls13crypto.t_HashAlgorithm)
       (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
@@ -89,25 +75,22 @@ val derive_hk_ms
             Bertie.Tls13utils.t_Bytes &
             Bertie.Tls13utils.t_Bytes) u8) Prims.l_True (fun _ -> Prims.l_True)
 
-type t_ClientPostCertificateVerify =
-  | ClientPostCertificateVerify :
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13crypto.t_Algorithms ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13formats.t_Transcript
-    -> t_ClientPostCertificateVerify
+/// Derive the application keys and master secret.
+val derive_app_keys
+      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
+      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
+      (master_secret tx: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result
+          (Bertie.Tls13crypto.t_AeadKeyIV & Bertie.Tls13crypto.t_AeadKeyIV &
+            Bertie.Tls13utils.t_Bytes) u8) Prims.l_True (fun _ -> Prims.l_True)
 
-type t_ClientPostClientFinished =
-  | ClientPostClientFinished :
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13crypto.t_Algorithms ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13formats.t_Transcript
-    -> t_ClientPostClientFinished
+val derive_rms
+      (ha: Bertie.Tls13crypto.t_HashAlgorithm)
+      (master_secret tx: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
 
 type t_ClientPostClientHello =
   | ClientPostClientHello :
@@ -117,16 +100,6 @@ type t_ClientPostClientHello =
       Core.Option.t_Option Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13formats.t_Transcript
     -> t_ClientPostClientHello
-
-type t_ClientPostServerFinished =
-  | ClientPostServerFinished :
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13crypto.t_Algorithms ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13formats.t_Transcript
-    -> t_ClientPostServerFinished
 
 type t_ClientPostServerHello =
   | ClientPostServerHello :
@@ -139,8 +112,8 @@ type t_ClientPostServerHello =
       Bertie.Tls13formats.t_Transcript
     -> t_ClientPostServerHello
 
-type t_ServerPostCertificateVerify =
-  | ServerPostCertificateVerify :
+type t_ClientPostCertificateVerify =
+  | ClientPostCertificateVerify :
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13crypto.t_Algorithms ->
@@ -148,17 +121,37 @@ type t_ServerPostCertificateVerify =
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13formats.t_Transcript
-    -> t_ServerPostCertificateVerify
+    -> t_ClientPostCertificateVerify
 
-type t_ServerPostClientFinished =
-  | ServerPostClientFinished :
+type t_ClientPostServerFinished =
+  | ClientPostServerFinished :
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13crypto.t_Algorithms ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13formats.t_Transcript
+    -> t_ClientPostServerFinished
+
+type t_ClientPostClientFinished =
+  | ClientPostClientFinished :
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13crypto.t_Algorithms ->
       Bertie.Tls13utils.t_Bytes ->
       Bertie.Tls13formats.t_Transcript
-    -> t_ServerPostClientFinished
+    -> t_ClientPostClientFinished
 
+val algs_post_client_hello (st: t_ClientPostClientHello)
+    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+
+val algs_post_server_hello (st: t_ClientPostServerHello)
+    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+
+val algs_post_client_finished (st: t_ClientPostClientFinished)
+    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+
+/// Server state after processing the client hello.
 type t_ServerPostClientHello = {
   f_client_randomness:Bertie.Tls13utils.t_Bytes;
   f_ciphersuite:Bertie.Tls13crypto.t_Algorithms;
@@ -168,16 +161,7 @@ type t_ServerPostClientHello = {
   f_transcript:Bertie.Tls13formats.t_Transcript
 }
 
-type t_ServerPostServerFinished =
-  | ServerPostServerFinished :
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13crypto.t_Algorithms ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13utils.t_Bytes ->
-      Bertie.Tls13formats.t_Transcript
-    -> t_ServerPostServerFinished
-
+/// Server state after generating the server hello.
 type t_ServerPostServerHello = {
   f_client_random:Bertie.Tls13utils.t_Bytes;
   f_server_random:Bertie.Tls13utils.t_Bytes;
@@ -189,14 +173,92 @@ type t_ServerPostServerHello = {
   f_transcript:Bertie.Tls13formats.t_Transcript
 }
 
-val algs_post_client_finished (st: t_ClientPostClientFinished)
-    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+type t_ServerPostCertificateVerify =
+  | ServerPostCertificateVerify :
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13crypto.t_Algorithms ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13formats.t_Transcript
+    -> t_ServerPostCertificateVerify
 
-val algs_post_client_hello (st: t_ClientPostClientHello)
-    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+type t_ServerPostServerFinished =
+  | ServerPostServerFinished :
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13crypto.t_Algorithms ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13formats.t_Transcript
+    -> t_ServerPostServerFinished
 
-val algs_post_server_hello (st: t_ClientPostServerHello)
-    : Prims.Pure Bertie.Tls13crypto.t_Algorithms Prims.l_True (fun _ -> Prims.l_True)
+type t_ServerPostClientFinished =
+  | ServerPostClientFinished :
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13crypto.t_Algorithms ->
+      Bertie.Tls13utils.t_Bytes ->
+      Bertie.Tls13formats.t_Transcript
+    -> t_ServerPostClientFinished
+
+val compute_psk_binder_zero_rtt
+      (algs0: Bertie.Tls13crypto.t_Algorithms)
+      (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (trunc_len: usize)
+      (psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (tx: Bertie.Tls13formats.t_Transcript)
+    : Prims.Pure
+      (Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+            Bertie.Tls13formats.t_Transcript) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val build_client_hello
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
+      (sn: Bertie.Tls13utils.t_Bytes)
+      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+    : Prims.Pure
+      (iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+            t_ClientPostClientHello) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val put_server_hello
+      (handshake: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (state: t_ClientPostClientHello)
+    : Prims.Pure
+      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val put_server_signature
+      (encrypted_extensions server_certificate server_certificate_verify:
+          Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostServerHello)
+    : Prims.Pure (Core.Result.t_Result t_ClientPostCertificateVerify u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val put_psk_skip_server_signature
+      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostServerHello)
+    : Prims.Pure (Core.Result.t_Result t_ClientPostCertificateVerify u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val put_server_finished
+      (server_finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostCertificateVerify)
+    : Prims.Pure
+      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherState1 & t_ClientPostServerFinished)
+          u8) Prims.l_True (fun _ -> Prims.l_True)
 
 val get_client_finished (handshake_state: t_ClientPostServerFinished)
     : Prims.Pure
@@ -205,14 +267,89 @@ val get_client_finished (handshake_state: t_ClientPostServerFinished)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val get_server_signature_no_psk
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (state: t_ServerPostServerHello)
-      (rng: impl_916461611_)
+val client_init
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (algs: Bertie.Tls13crypto.t_Algorithms)
+      (sn: Bertie.Tls13utils.t_Bytes)
+      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (impl_916461611_ &
+      (iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
+            t_ClientPostClientHello) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Update the client state after generating the client hello message.
+val client_set_params
+      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ClientPostClientHello)
+    : Prims.Pure
+      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val client_finish
+      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (handshake_state: t_ClientPostServerHello)
+    : Prims.Pure
+      (Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherState1 &
+            t_ClientPostClientFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Process the PSK binder for 0-RTT
+val process_psk_binder_zero_rtt
+      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
+      (th_trunc th: Bertie.Tls13utils.t_Bytes)
+      (psko bindero: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val put_client_hello
+      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
+      (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (db: Bertie.Server.t_ServerDB)
+    : Prims.Pure
+      (Core.Result.t_Result
+          (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 & t_ServerPostClientHello)
+          u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val get_server_hello
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (state: t_ServerPostClientHello)
+      (rng: iimpl_916461611_)
+    : Prims.Pure
+      (iimpl_916461611_ &
+        Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
+            Bertie.Tls13record.t_DuplexCipherStateH &
+            t_ServerPostServerHello) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val get_rsa_signature
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (cert sk sigval: Bertie.Tls13utils.t_Bytes)
+      (rng: iimpl_916461611_)
+    : Prims.Pure (iimpl_916461611_ & Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val get_server_signature_no_psk
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
+      (state: t_ServerPostServerHello)
+      (rng: iimpl_916461611_)
+    : Prims.Pure
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -220,13 +357,13 @@ val get_server_signature_no_psk
             t_ServerPostCertificateVerify) u8) Prims.l_True (fun _ -> Prims.l_True)
 
 val get_server_signature
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
       (state: t_ServerPostServerHello)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -247,106 +384,6 @@ val get_skip_server_signature (st: t_ServerPostServerHello)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val put_client_finished
-      (cfin: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ServerPostServerFinished)
-    : Prims.Pure (Core.Result.t_Result t_ServerPostClientFinished u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val put_psk_skip_server_signature
-      (encrypted_extensions: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostServerHello)
-    : Prims.Pure (Core.Result.t_Result t_ClientPostCertificateVerify u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val put_server_signature
-      (encrypted_extensions server_certificate server_certificate_verify:
-          Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostServerHello)
-    : Prims.Pure (Core.Result.t_Result t_ClientPostCertificateVerify u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_finish
-      (cf: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ServerPostServerFinished)
-    : Prims.Pure (Core.Result.t_Result t_ServerPostClientFinished u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val get_server_hello
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (state: t_ServerPostClientHello)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13record.t_DuplexCipherStateH &
-            t_ServerPostServerHello) u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val put_server_hello
-      (handshake: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (state: t_ClientPostClientHello)
-    : Prims.Pure
-      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val client_set_params
-      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (st: t_ClientPostClientHello)
-    : Prims.Pure
-      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherStateH & t_ClientPostServerHello) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val compute_psk_binder_zero_rtt
-      (algs0: Bertie.Tls13crypto.t_Algorithms)
-      (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (trunc_len: usize)
-      (psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (tx: Bertie.Tls13formats.t_Transcript)
-    : Prims.Pure
-      (Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-            Bertie.Tls13formats.t_Transcript) u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val build_client_hello
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (sn: Bertie.Tls13utils.t_Bytes)
-      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-            t_ClientPostClientHello) u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val client_init
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
-      (algs: Bertie.Tls13crypto.t_Algorithms)
-      (sn: Bertie.Tls13utils.t_Bytes)
-      (tkt psk: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-      (rng: impl_916461611_)
-    : Prims.Pure
-      (impl_916461611_ &
-        Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Core.Option.t_Option Bertie.Tls13record.t_ClientCipherState0 &
-            t_ClientPostClientHello) u8) Prims.l_True (fun _ -> Prims.l_True)
-
 val get_server_finished (st: t_ServerPostCertificateVerify)
     : Prims.Pure
       (Core.Result.t_Result
@@ -354,50 +391,23 @@ val get_server_finished (st: t_ServerPostCertificateVerify)
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ServerPostServerFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val put_server_finished
-      (server_finished: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostCertificateVerify)
-    : Prims.Pure
-      (Core.Result.t_Result (Bertie.Tls13record.t_DuplexCipherState1 & t_ClientPostServerFinished)
-          u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val client_finish
-      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (handshake_state: t_ClientPostServerHello)
-    : Prims.Pure
-      (Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
-            Bertie.Tls13record.t_DuplexCipherState1 &
-            t_ClientPostClientFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val process_psk_binder_zero_rtt
-      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (th_trunc th: Bertie.Tls13utils.t_Bytes)
-      (psko bindero: Core.Option.t_Option Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure
-      (Core.Result.t_Result (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0) u8)
+val put_client_finished
+      (cfin: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ServerPostServerFinished)
+    : Prims.Pure (Core.Result.t_Result t_ServerPostClientFinished u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val put_client_hello
-      (ciphersuite: Bertie.Tls13crypto.t_Algorithms)
-      (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (db: Bertie.Server.t_ServerDB)
-    : Prims.Pure
-      (Core.Result.t_Result
-          (Core.Option.t_Option Bertie.Tls13record.t_ServerCipherState0 & t_ServerPostClientHello)
-          u8) Prims.l_True (fun _ -> Prims.l_True)
-
 val server_init_no_psk
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -407,15 +417,15 @@ val server_init_no_psk
             t_ServerPostServerFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
 
 val server_init_psk
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -425,15 +435,15 @@ val server_init_psk
             t_ServerPostServerFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
 
 val server_init
-      (#impl_916461611_: Type)
-      {| i1: Rand_core.t_CryptoRng impl_916461611_ |}
-      {| i2: Rand_core.t_RngCore impl_916461611_ |}
+      (#iimpl_916461611_: Type0)
+      {| i1: Rand_core.t_CryptoRng iimpl_916461611_ |}
+      {| i2: Rand_core.t_RngCore iimpl_916461611_ |}
       (algs: Bertie.Tls13crypto.t_Algorithms)
       (ch: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
       (db: Bertie.Server.t_ServerDB)
-      (rng: impl_916461611_)
+      (rng: iimpl_916461611_)
     : Prims.Pure
-      (impl_916461611_ &
+      (iimpl_916461611_ &
         Core.Result.t_Result
           (Bertie.Tls13formats.Handshake_data.t_HandshakeData &
             Bertie.Tls13formats.Handshake_data.t_HandshakeData &
@@ -441,3 +451,10 @@ val server_init
             Bertie.Tls13record.t_DuplexCipherStateH &
             Bertie.Tls13record.t_DuplexCipherState1 &
             t_ServerPostServerFinished) u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val server_finish
+      (cf: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (st: t_ServerPostServerFinished)
+    : Prims.Pure (Core.Result.t_Result t_ServerPostClientFinished u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Bertie.Tls13record.fst
+++ b/proofs/fstar/extraction/Bertie.Tls13record.fst
@@ -3,24 +3,71 @@ module Bertie.Tls13record
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13formats in
+  let open Bertie.Tls13formats.Handshake_data in
+  let open Bertie.Tls13utils in
+  ()
+
+let client_cipher_state0
+      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
+      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c: u64)
+      (k: Bertie.Tls13utils.t_Bytes)
+     = ClientCipherState0 ae kiv c k <: t_ClientCipherState0
+
+let server_cipher_state0
+      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (counter: u64)
+      (early_exporter_ms: Bertie.Tls13utils.t_Bytes)
+     =
+  { f_key_iv = key_iv; f_counter = counter; f_early_exporter_ms = early_exporter_ms }
+  <:
+  t_ServerCipherState0
+
+let impl_DuplexCipherStateH__new
+      (sender_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (sender_counter: u64)
+      (receiver_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (receiver_counter: u64)
+     =
+  {
+    f_sender_key_iv = sender_key_iv;
+    f_sender_counter = sender_counter;
+    f_receiver_key_iv = receiver_key_iv;
+    f_receiver_counter = receiver_counter
+  }
+  <:
+  t_DuplexCipherStateH
+
+let duplex_cipher_state1
+      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
+      (kiv1: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c1: u64)
+      (kiv2: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c2: u64)
+      (k: Bertie.Tls13utils.t_Bytes)
+     = DuplexCipherState1 ae kiv1 c1 kiv2 c2 k <: t_DuplexCipherState1
+
 let derive_iv_ctr (iv: Bertie.Tls13utils.t_Bytes) (n: u64) =
   let (counter: Bertie.Tls13utils.t_Bytes):Bertie.Tls13utils.t_Bytes =
-    Core.Convert.f_into (Core.Num.impl__u64__to_be_bytes n <: t_Array u8 (sz 8))
+    Core.Convert.f_into #(t_Array u8 (mk_usize 8))
+      #Bertie.Tls13utils.t_Bytes
+      #FStar.Tactics.Typeclasses.solve
+      (Core.Num.impl_u64__to_be_bytes n <: t_Array u8 (mk_usize 8))
   in
   let iv_ctr:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.impl__Bytes__zeroes (Bertie.Tls13utils.impl__Bytes__len iv <: usize)
+    Bertie.Tls13utils.impl_Bytes__zeroes (Bertie.Tls13utils.impl_Bytes__len iv <: usize)
   in
   let iv_ctr:Bertie.Tls13utils.t_Bytes =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end
-              =
-              (Bertie.Tls13utils.impl__Bytes__len iv <: usize) -! sz 8 <: usize
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      ((Bertie.Tls13utils.impl_Bytes__len iv <: usize) -! mk_usize 8 <: usize)
+      (fun iv_ctr temp_1_ ->
+          let iv_ctr:Bertie.Tls13utils.t_Bytes = iv_ctr in
+          let _:usize = temp_1_ in
+          true)
       iv_ctr
       (fun iv_ctr i ->
           let iv_ctr:Bertie.Tls13utils.t_Bytes = iv_ctr in
@@ -28,22 +75,21 @@ let derive_iv_ctr (iv: Bertie.Tls13utils.t_Bytes) (n: u64) =
           Rust_primitives.Hax.update_at iv_ctr i (iv.[ i ] <: u8) <: Bertie.Tls13utils.t_Bytes)
   in
   let iv_ctr:Bertie.Tls13utils.t_Bytes =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 8
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      (mk_usize 8)
+      (fun iv_ctr temp_1_ ->
+          let iv_ctr:Bertie.Tls13utils.t_Bytes = iv_ctr in
+          let _:usize = temp_1_ in
+          true)
       iv_ctr
       (fun iv_ctr i ->
           let iv_ctr:Bertie.Tls13utils.t_Bytes = iv_ctr in
           let i:usize = i in
           Rust_primitives.Hax.update_at iv_ctr
-            ((i +! (Bertie.Tls13utils.impl__Bytes__len iv <: usize) <: usize) -! sz 8 <: usize)
-            ((iv.[ (i +! (Bertie.Tls13utils.impl__Bytes__len iv <: usize) <: usize) -! sz 8 <: usize
-                ]
+            ((i +! (Bertie.Tls13utils.impl_Bytes__len iv <: usize) <: usize) -! mk_usize 8 <: usize)
+            ((iv.[ (i +! (Bertie.Tls13utils.impl_Bytes__len iv <: usize) <: usize) -! mk_usize 8
+                  <:
+                  usize ]
                 <:
                 u8) ^.
               (counter.[ i ] <: u8)
@@ -54,10 +100,141 @@ let derive_iv_ctr (iv: Bertie.Tls13utils.t_Bytes) (n: u64) =
   in
   iv_ctr
 
+let encrypt_record_payload
+      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (n: u64)
+      (ct: Bertie.Tls13formats.t_ContentType)
+      (payload: Bertie.Tls13utils.t_Bytes)
+      (pad: usize)
+     =
+  let iv_ctr:Bertie.Tls13utils.t_Bytes = derive_iv_ctr key_iv.Bertie.Tls13crypto.f_iv n in
+  let inner_plaintext:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13utils.impl_Bytes__concat (Bertie.Tls13utils.impl_Bytes__concat payload
+          (Bertie.Tls13utils.bytes1 (Bertie.Tls13formats.t_ContentType_cast_to_repr ct <: u8)
+            <:
+            Bertie.Tls13utils.t_Bytes)
+        <:
+        Bertie.Tls13utils.t_Bytes)
+      (Bertie.Tls13utils.impl_Bytes__zeroes pad <: Bertie.Tls13utils.t_Bytes)
+  in
+  let clen:usize = (Bertie.Tls13utils.impl_Bytes__len inner_plaintext <: usize) +! mk_usize 16 in
+  if clen <=. mk_usize 65536
+  then
+    let clenb:t_Array u8 (mk_usize 2) =
+      Core.Num.impl_u16__to_be_bytes (cast (clen <: usize) <: u16)
+    in
+    let ad:Bertie.Tls13utils.t_Bytes =
+      Core.Convert.f_into #(t_Array u8 (mk_usize 5))
+        #Bertie.Tls13utils.t_Bytes
+        #FStar.Tactics.Typeclasses.solve
+        (let list =
+            [mk_u8 23; mk_u8 3; mk_u8 3; clenb.[ mk_usize 0 ] <: u8; clenb.[ mk_usize 1 ] <: u8]
+          in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 5);
+          Rust_primitives.Hax.array_of_list 5 list)
+    in
+    match
+      Bertie.Tls13crypto.aead_encrypt key_iv.Bertie.Tls13crypto.f_key iv_ctr inner_plaintext ad
+      <:
+      Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+    with
+    | Core.Result.Result_Ok cip ->
+      let v_rec:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl_Bytes__concat ad cip in
+      Core.Result.Result_Ok v_rec <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+    | Core.Result.Result_Err err ->
+      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  else
+    Core.Result.Result_Err Bertie.Tls13utils.v_PAYLOAD_TOO_LONG
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+
+let encrypt_zerortt (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_ClientCipherState0) =
+  let ClientCipherState0 ae kiv n exp:t_ClientCipherState0 = st in
+  match
+    encrypt_record_payload kiv
+      n
+      (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
+      (Bertie.Tls13utils.impl_AppData__into_raw payload <: Bertie.Tls13utils.t_Bytes)
+      pad
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok v_rec ->
+    Core.Result.Result_Ok
+    (v_rec, (ClientCipherState0 ae kiv (n +! mk_u64 1) exp <: t_ClientCipherState0)
+      <:
+      (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0))
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8
+
+let encrypt_handshake
+      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (pad: usize)
+      (state: t_DuplexCipherStateH)
+     =
+  let payload:Bertie.Tls13utils.t_Bytes =
+    Bertie.Tls13formats.Handshake_data.impl_HandshakeData__to_bytes payload
+  in
+  match
+    encrypt_record_payload state.f_sender_key_iv
+      state.f_sender_counter
+      (Bertie.Tls13formats.ContentType_Handshake <: Bertie.Tls13formats.t_ContentType)
+      payload
+      pad
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok v_rec ->
+    let state:t_DuplexCipherStateH =
+      { state with f_sender_counter = state.f_sender_counter +! mk_u64 1 } <: t_DuplexCipherStateH
+    in
+    Core.Result.Result_Ok (v_rec, state <: (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH))
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8
+
+let encrypt_data (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_DuplexCipherState1) =
+  let DuplexCipherState1 ae kiv n x y exp:t_DuplexCipherState1 = st in
+  match
+    encrypt_record_payload kiv
+      n
+      (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
+      (Bertie.Tls13utils.impl_AppData__into_raw payload <: Bertie.Tls13utils.t_Bytes)
+      pad
+    <:
+    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+  with
+  | Core.Result.Result_Ok v_rec ->
+    Core.Result.Result_Ok
+    (v_rec, (DuplexCipherState1 ae kiv (n +! mk_u64 1) x y exp <: t_DuplexCipherState1)
+      <:
+      (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1))
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
+
 let rec padlen (b: Bertie.Tls13utils.t_Bytes) (n: usize) =
-  if n >. sz 0 && (Bertie.Tls13utils.f_declassify (b.[ n -! sz 1 <: usize ] <: u8) <: u8) =. 0uy
-  then sz 1 +! (padlen b (n -! sz 1 <: usize) <: usize)
-  else sz 0
+  if
+    n >. mk_usize 0 &&
+    (Bertie.Tls13utils.f_declassify #u8
+        #u8
+        #FStar.Tactics.Typeclasses.solve
+        (b.[ n -! mk_usize 1 <: usize ] <: u8)
+      <:
+      u8) =.
+    mk_u8 0
+  then mk_usize 1 +! (padlen b (n -! mk_usize 1 <: usize) <: usize)
+  else mk_usize 0
 
 let decrypt_record_payload
       (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
@@ -65,59 +242,76 @@ let decrypt_record_payload
       (ciphertext: Bertie.Tls13utils.t_Bytes)
      =
   let iv_ctr:Bertie.Tls13utils.t_Bytes = derive_iv_ctr kiv.Bertie.Tls13crypto.f_iv n in
-  let clen:usize = (Bertie.Tls13utils.impl__Bytes__len ciphertext <: usize) -! sz 5 in
-  if clen <=. sz 65536 && clen >. sz 16
+  let clen:usize = (Bertie.Tls13utils.impl_Bytes__len ciphertext <: usize) -! mk_usize 5 in
+  if clen <=. mk_usize 65536 && clen >. mk_usize 16
   then
-    let clen_bytes:t_Array u8 (sz 2) =
-      Core.Num.impl__u16__to_be_bytes (cast (clen <: usize) <: u16)
+    let clen_bytes:t_Array u8 (mk_usize 2) =
+      Core.Num.impl_u16__to_be_bytes (cast (clen <: usize) <: u16)
     in
     let ad:Bertie.Tls13utils.t_Bytes =
-      Core.Convert.f_into (let list =
-            [23uy; 3uy; 3uy; clen_bytes.[ sz 0 ] <: u8; clen_bytes.[ sz 1 ] <: u8]
+      Core.Convert.f_into #(t_Array u8 (mk_usize 5))
+        #Bertie.Tls13utils.t_Bytes
+        #FStar.Tactics.Typeclasses.solve
+        (let list =
+            [
+              mk_u8 23;
+              mk_u8 3;
+              mk_u8 3;
+              clen_bytes.[ mk_usize 0 ] <: u8;
+              clen_bytes.[ mk_usize 1 ] <: u8
+            ]
           in
           FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 5);
           Rust_primitives.Hax.array_of_list 5 list)
     in
     match
       Bertie.Tls13utils.check_eq ad
-        (Bertie.Tls13utils.impl__Bytes__slice_range ciphertext
-            ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 5 }
+        (Bertie.Tls13utils.impl_Bytes__slice_range ciphertext
+            ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = mk_usize 5 }
               <:
               Core.Ops.Range.t_Range usize)
           <:
           Bertie.Tls13utils.t_Bytes)
+      <:
+      Core.Result.t_Result Prims.unit u8
     with
     | Core.Result.Result_Ok _ ->
       let cip:Bertie.Tls13utils.t_Bytes =
-        Bertie.Tls13utils.impl__Bytes__slice_range ciphertext
+        Bertie.Tls13utils.impl_Bytes__slice_range ciphertext
           ({
-              Core.Ops.Range.f_start = sz 5;
-              Core.Ops.Range.f_end = Bertie.Tls13utils.impl__Bytes__len ciphertext <: usize
+              Core.Ops.Range.f_start = mk_usize 5;
+              Core.Ops.Range.f_end = Bertie.Tls13utils.impl_Bytes__len ciphertext <: usize
             }
             <:
             Core.Ops.Range.t_Range usize)
       in
-      (match Bertie.Tls13crypto.aead_decrypt kiv.Bertie.Tls13crypto.f_key iv_ctr cip ad with
+      (match
+          Bertie.Tls13crypto.aead_decrypt kiv.Bertie.Tls13crypto.f_key iv_ctr cip ad
+          <:
+          Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
+        with
         | Core.Result.Result_Ok plain ->
           let payload_len:usize =
-            ((Bertie.Tls13utils.impl__Bytes__len plain <: usize) -!
-              (padlen plain (Bertie.Tls13utils.impl__Bytes__len plain <: usize) <: usize)
+            ((Bertie.Tls13utils.impl_Bytes__len plain <: usize) -!
+              (padlen plain (Bertie.Tls13utils.impl_Bytes__len plain <: usize) <: usize)
               <:
               usize) -!
-            sz 1
+            mk_usize 1
           in
           (match
-              Bertie.Tls13formats.impl__ContentType__try_from_u8 (Bertie.Tls13utils.f_declassify (plain.[
-                        payload_len ]
-                      <:
-                      u8)
+              Bertie.Tls13formats.impl_ContentType__try_from_u8 (Bertie.Tls13utils.f_declassify #u8
+                    #u8
+                    #FStar.Tactics.Typeclasses.solve
+                    (plain.[ payload_len ] <: u8)
                   <:
                   u8)
+              <:
+              Core.Result.t_Result Bertie.Tls13formats.t_ContentType u8
             with
             | Core.Result.Result_Ok ct ->
               let payload:Bertie.Tls13utils.t_Bytes =
-                Bertie.Tls13utils.impl__Bytes__slice_range plain
-                  ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = payload_len }
+                Bertie.Tls13utils.impl_Bytes__slice_range plain
+                  ({ Core.Ops.Range.f_start = mk_usize 0; Core.Ops.Range.f_end = payload_len }
                     <:
                     Core.Ops.Range.t_Range usize)
               in
@@ -144,168 +338,27 @@ let decrypt_record_payload
     <:
     Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8
 
-let encrypt_record_payload
-      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (n: u64)
-      (ct: Bertie.Tls13formats.t_ContentType)
-      (payload: Bertie.Tls13utils.t_Bytes)
-      (pad: usize)
-     =
-  let iv_ctr:Bertie.Tls13utils.t_Bytes = derive_iv_ctr key_iv.Bertie.Tls13crypto.f_iv n in
-  let inner_plaintext:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13utils.impl__Bytes__concat (Bertie.Tls13utils.impl__Bytes__concat payload
-          (Bertie.Tls13utils.bytes1 (Bertie.Tls13formats.t_ContentType_cast_to_repr ct <: u8)
-            <:
-            Bertie.Tls13utils.t_Bytes)
-        <:
-        Bertie.Tls13utils.t_Bytes)
-      (Bertie.Tls13utils.impl__Bytes__zeroes pad <: Bertie.Tls13utils.t_Bytes)
-  in
-  let clen:usize = (Bertie.Tls13utils.impl__Bytes__len inner_plaintext <: usize) +! sz 16 in
-  if clen <=. sz 65536
-  then
-    let clenb:t_Array u8 (sz 2) = Core.Num.impl__u16__to_be_bytes (cast (clen <: usize) <: u16) in
-    let ad:Bertie.Tls13utils.t_Bytes =
-      Core.Convert.f_into (let list =
-            [23uy; 3uy; 3uy; clenb.[ sz 0 ] <: u8; clenb.[ sz 1 ] <: u8]
-          in
-          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 5);
-          Rust_primitives.Hax.array_of_list 5 list)
-    in
-    match
-      Bertie.Tls13crypto.aead_encrypt key_iv.Bertie.Tls13crypto.f_key iv_ctr inner_plaintext ad
-    with
-    | Core.Result.Result_Ok cip ->
-      let v_rec:Bertie.Tls13utils.t_Bytes = Bertie.Tls13utils.impl__Bytes__concat ad cip in
-      Core.Result.Result_Ok v_rec <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-    | Core.Result.Result_Err err ->
-      Core.Result.Result_Err err <: Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-  else
-    Core.Result.Result_Err Bertie.Tls13utils.v_PAYLOAD_TOO_LONG
-    <:
-    Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8
-
-let impl__DuplexCipherStateH__new
-      (sender_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (sender_counter: u64)
-      (receiver_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (receiver_counter: u64)
-     =
-  {
-    f_sender_key_iv = sender_key_iv;
-    f_sender_counter = sender_counter;
-    f_receiver_key_iv = receiver_key_iv;
-    f_receiver_counter = receiver_counter
-  }
-  <:
-  t_DuplexCipherStateH
-
-let client_cipher_state0
-      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c: u64)
-      (k: Bertie.Tls13utils.t_Bytes)
-     = ClientCipherState0 ae kiv c k <: t_ClientCipherState0
-
-let decrypt_data (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1) =
-  let DuplexCipherState1 ae x y kiv n exp:t_DuplexCipherState1 = st in
-  match decrypt_record_payload kiv n ciphertext with
-  | Core.Result.Result_Ok (ct, payload) ->
-    (match
-        Bertie.Tls13utils.check (ct =.
-            (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
-            <:
-            bool)
-      with
-      | Core.Result.Result_Ok _ ->
-        Core.Result.Result_Ok
-        (Bertie.Tls13utils.impl__AppData__new payload,
-          (DuplexCipherState1 ae x y kiv (n +! 1uL) exp <: t_DuplexCipherState1)
-          <:
-          (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1))
-        <:
-        Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8
-      | Core.Result.Result_Err err ->
-        Core.Result.Result_Err err
-        <:
-        Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8
-
-let decrypt_data_or_hs (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1) =
-  let DuplexCipherState1 ae x y kiv n exp:t_DuplexCipherState1 = st in
-  match decrypt_record_payload kiv n ciphertext with
-  | Core.Result.Result_Ok (ct, payload) ->
-    Core.Result.Result_Ok
-    (ct, payload, (DuplexCipherState1 ae x y kiv (n +! 1uL) exp <: t_DuplexCipherState1)
-      <:
-      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1))
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result
-      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
-
-let decrypt_handshake (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_DuplexCipherStateH) =
-  match decrypt_record_payload state.f_receiver_key_iv state.f_receiver_counter ciphertext with
-  | Core.Result.Result_Ok (ct, payload) ->
-    if ct =. (Bertie.Tls13formats.ContentType_Alert <: Bertie.Tls13formats.t_ContentType)
-    then
-      Core.Result.Result_Err Bertie.Tls13utils.v_GOT_HANDSHAKE_FAILURE_ALERT
-      <:
-      Core.Result.t_Result
-        (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8
-    else
-      (match
-          Bertie.Tls13utils.check (ct =.
-              (Bertie.Tls13formats.ContentType_Handshake <: Bertie.Tls13formats.t_ContentType)
-              <:
-              bool)
-        with
-        | Core.Result.Result_Ok _ ->
-          let state:t_DuplexCipherStateH =
-            { state with f_receiver_counter = state.f_receiver_counter +! 1uL }
-            <:
-            t_DuplexCipherStateH
-          in
-          Core.Result.Result_Ok
-          (Core.Convert.f_from payload, state
-            <:
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH))
-          <:
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8
-        | Core.Result.Result_Err err ->
-          Core.Result.Result_Err err
-          <:
-          Core.Result.t_Result
-            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8)
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH)
-      u8
-
 let decrypt_zerortt (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_ServerCipherState0) =
-  match decrypt_record_payload state.f_key_iv state.f_counter ciphertext with
+  match
+    decrypt_record_payload state.f_key_iv state.f_counter ciphertext
+    <:
+    Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8
+  with
   | Core.Result.Result_Ok (ct, payload) ->
     (match
         Bertie.Tls13utils.check (ct =.
             (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
             <:
             bool)
+        <:
+        Core.Result.t_Result Prims.unit u8
       with
       | Core.Result.Result_Ok _ ->
         Core.Result.Result_Ok
-        (Bertie.Tls13utils.impl__AppData__new payload,
+        (Bertie.Tls13utils.impl_AppData__new payload,
           ({
               f_key_iv = state.f_key_iv;
-              f_counter = state.f_counter +! 1uL;
+              f_counter = state.f_counter +! mk_u64 1;
               f_early_exporter_ms = state.f_early_exporter_ms
             }
             <:
@@ -323,89 +376,106 @@ let decrypt_zerortt (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_ServerCiph
     <:
     Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_ServerCipherState0) u8
 
-let duplex_cipher_state1
-      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (kiv1: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c1: u64)
-      (kiv2: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c2: u64)
-      (k: Bertie.Tls13utils.t_Bytes)
-     = DuplexCipherState1 ae kiv1 c1 kiv2 c2 k <: t_DuplexCipherState1
-
-let encrypt_data (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_DuplexCipherState1) =
-  let DuplexCipherState1 ae kiv n x y exp:t_DuplexCipherState1 = st in
+let decrypt_handshake (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_DuplexCipherStateH) =
   match
-    encrypt_record_payload kiv
-      n
-      (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
-      (Bertie.Tls13utils.impl__AppData__into_raw payload <: Bertie.Tls13utils.t_Bytes)
-      pad
+    decrypt_record_payload state.f_receiver_key_iv state.f_receiver_counter ciphertext
+    <:
+    Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8
   with
-  | Core.Result.Result_Ok v_rec ->
-    Core.Result.Result_Ok
-    (v_rec, (DuplexCipherState1 ae kiv (n +! 1uL) x y exp <: t_DuplexCipherState1)
+  | Core.Result.Result_Ok (ct, payload) ->
+    if ct =. (Bertie.Tls13formats.ContentType_Alert <: Bertie.Tls13formats.t_ContentType)
+    then
+      Core.Result.Result_Err Bertie.Tls13utils.v_GOT_HANDSHAKE_FAILURE_ALERT
       <:
-      (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1))
-    <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
+      Core.Result.t_Result
+        (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8
+    else
+      (match
+          Bertie.Tls13utils.check (ct =.
+              (Bertie.Tls13formats.ContentType_Handshake <: Bertie.Tls13formats.t_ContentType)
+              <:
+              bool)
+          <:
+          Core.Result.t_Result Prims.unit u8
+        with
+        | Core.Result.Result_Ok _ ->
+          let state:t_DuplexCipherStateH =
+            { state with f_receiver_counter = state.f_receiver_counter +! mk_u64 1 }
+            <:
+            t_DuplexCipherStateH
+          in
+          Core.Result.Result_Ok
+          (Core.Convert.f_from #Bertie.Tls13formats.Handshake_data.t_HandshakeData
+              #Bertie.Tls13utils.t_Bytes
+              #FStar.Tactics.Typeclasses.solve
+              payload,
+            state
+            <:
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH))
+          <:
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8
+        | Core.Result.Result_Err err ->
+          Core.Result.Result_Err err
+          <:
+          Core.Result.t_Result
+            (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8)
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err
     <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
+    Core.Result.t_Result (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH)
+      u8
 
-let encrypt_handshake
-      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (pad: usize)
-      (state: t_DuplexCipherStateH)
-     =
-  let payload:Bertie.Tls13utils.t_Bytes =
-    Bertie.Tls13formats.Handshake_data.impl__HandshakeData__to_bytes payload
-  in
+let decrypt_data_or_hs (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1) =
+  let DuplexCipherState1 ae x y kiv n exp:t_DuplexCipherState1 = st in
   match
-    encrypt_record_payload state.f_sender_key_iv
-      state.f_sender_counter
-      (Bertie.Tls13formats.ContentType_Handshake <: Bertie.Tls13formats.t_ContentType)
-      payload
-      pad
-  with
-  | Core.Result.Result_Ok v_rec ->
-    let state:t_DuplexCipherStateH =
-      { state with f_sender_counter = state.f_sender_counter +! 1uL } <: t_DuplexCipherStateH
-    in
-    Core.Result.Result_Ok (v_rec, state <: (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH))
+    decrypt_record_payload kiv n ciphertext
     <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8
-  | Core.Result.Result_Err err ->
-    Core.Result.Result_Err err
-    <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8
-
-let encrypt_zerortt (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_ClientCipherState0) =
-  let ClientCipherState0 ae kiv n exp:t_ClientCipherState0 = st in
-  match
-    encrypt_record_payload kiv
-      n
-      (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
-      (Bertie.Tls13utils.impl__AppData__into_raw payload <: Bertie.Tls13utils.t_Bytes)
-      pad
+    Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8
   with
-  | Core.Result.Result_Ok v_rec ->
+  | Core.Result.Result_Ok (ct, payload) ->
     Core.Result.Result_Ok
-    (v_rec, (ClientCipherState0 ae kiv (n +! 1uL) exp <: t_ClientCipherState0)
+    (ct, payload, (DuplexCipherState1 ae x y kiv (n +! mk_u64 1) exp <: t_DuplexCipherState1)
       <:
-      (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0))
+      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1))
     <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8
+    Core.Result.t_Result
+      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
   | Core.Result.Result_Err err ->
     Core.Result.Result_Err err
     <:
-    Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8
+    Core.Result.t_Result
+      (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8
 
-let server_cipher_state0
-      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (counter: u64)
-      (early_exporter_ms: Bertie.Tls13utils.t_Bytes)
-     =
-  { f_key_iv = key_iv; f_counter = counter; f_early_exporter_ms = early_exporter_ms }
-  <:
-  t_ServerCipherState0
+let decrypt_data (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1) =
+  let DuplexCipherState1 ae x y kiv n exp:t_DuplexCipherState1 = st in
+  match
+    decrypt_record_payload kiv n ciphertext
+    <:
+    Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8
+  with
+  | Core.Result.Result_Ok (ct, payload) ->
+    (match
+        Bertie.Tls13utils.check (ct =.
+            (Bertie.Tls13formats.ContentType_ApplicationData <: Bertie.Tls13formats.t_ContentType)
+            <:
+            bool)
+        <:
+        Core.Result.t_Result Prims.unit u8
+      with
+      | Core.Result.Result_Ok _ ->
+        Core.Result.Result_Ok
+        (Bertie.Tls13utils.impl_AppData__new payload,
+          (DuplexCipherState1 ae x y kiv (n +! mk_u64 1) exp <: t_DuplexCipherState1)
+          <:
+          (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1))
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8
+      | Core.Result.Result_Err err ->
+        Core.Result.Result_Err err
+        <:
+        Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8)
+  | Core.Result.Result_Err err ->
+    Core.Result.Result_Err err
+    <:
+    Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8

--- a/proofs/fstar/extraction/Bertie.Tls13record.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13record.fsti
@@ -3,30 +3,13 @@ module Bertie.Tls13record
 open Core
 open FStar.Mul
 
-val derive_iv_ctr (iv: Bertie.Tls13utils.t_Bytes) (n: u64)
-    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val padlen (b: Bertie.Tls13utils.t_Bytes) (n: usize)
-    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
-
-val decrypt_record_payload
-      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (n: u64)
-      (ciphertext: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure
-      (Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val encrypt_record_payload
-      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (n: u64)
-      (ct: Bertie.Tls13formats.t_ContentType)
-      (payload: Bertie.Tls13utils.t_Bytes)
-      (pad: usize)
-    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Bertie.Tls13formats in
+  let open Bertie.Tls13formats.Handshake_data in
+  let open Bertie.Tls13utils in
+  ()
 
 type t_ClientCipherState0 =
   | ClientCipherState0 :
@@ -35,6 +18,44 @@ type t_ClientCipherState0 =
       u64 ->
       Bertie.Tls13utils.t_Bytes
     -> t_ClientCipherState0
+
+/// Build the initial client cipher state.
+val client_cipher_state0
+      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
+      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c: u64)
+      (k: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure t_ClientCipherState0 Prims.l_True (fun _ -> Prims.l_True)
+
+/// The AEAD state of the server with the key, iv, and counter.
+type t_ServerCipherState0 = {
+  f_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
+  f_counter:u64;
+  f_early_exporter_ms:Bertie.Tls13utils.t_Bytes
+}
+
+/// Create the initial cipher state for the server.
+val server_cipher_state0
+      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (counter: u64)
+      (early_exporter_ms: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure t_ServerCipherState0 Prims.l_True (fun _ -> Prims.l_True)
+
+/// Duplex cipher state with hello keys.
+type t_DuplexCipherStateH = {
+  f_sender_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
+  f_sender_counter:u64;
+  f_receiver_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
+  f_receiver_counter:u64
+}
+
+/// Create a new state
+val impl_DuplexCipherStateH__new
+      (sender_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (sender_counter: u64)
+      (receiver_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (receiver_counter: u64)
+    : Prims.Pure t_DuplexCipherStateH Prims.l_True (fun _ -> Prims.l_True)
 
 type t_DuplexCipherState1 =
   | DuplexCipherState1 :
@@ -46,35 +67,79 @@ type t_DuplexCipherState1 =
       Bertie.Tls13utils.t_Bytes
     -> t_DuplexCipherState1
 
-type t_DuplexCipherStateH = {
-  f_sender_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
-  f_sender_counter:u64;
-  f_receiver_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
-  f_receiver_counter:u64
-}
-
-val impl__DuplexCipherStateH__new
-      (sender_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (sender_counter: u64)
-      (receiver_key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (receiver_counter: u64)
-    : Prims.Pure t_DuplexCipherStateH Prims.l_True (fun _ -> Prims.l_True)
-
-type t_ServerCipherState0 = {
-  f_key_iv:Bertie.Tls13crypto.t_AeadKeyIV;
-  f_counter:u64;
-  f_early_exporter_ms:Bertie.Tls13utils.t_Bytes
-}
-
-val client_cipher_state0
+/// Create the next cipher state.
+val duplex_cipher_state1
       (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c: u64)
+      (kiv1: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c1: u64)
+      (kiv2: Bertie.Tls13crypto.t_AeadKeyIV)
+      (c2: u64)
       (k: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure t_ClientCipherState0 Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure t_DuplexCipherState1 Prims.l_True (fun _ -> Prims.l_True)
 
-val decrypt_data (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8)
+/// Derive the AEAD IV with counter `n`
+val derive_iv_ctr (iv: Bertie.Tls13utils.t_Bytes) (n: u64)
+    : Prims.Pure Bertie.Tls13utils.t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Encrypt the record `payload` with the given `key_iv`.
+val encrypt_record_payload
+      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (n: u64)
+      (ct: Bertie.Tls13formats.t_ContentType)
+      (payload: Bertie.Tls13utils.t_Bytes)
+      (pad: usize)
+    : Prims.Pure (Core.Result.t_Result Bertie.Tls13utils.t_Bytes u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Encrypt 0-RTT `payload`.
+/// TODO: Implement 0-RTT
+val encrypt_zerortt (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_ClientCipherState0)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Encrypt the `payload` [`HandshakeData`].
+/// Returns the ciphertext, new [`DuplexCipherStateH`] if successful, or a
+/// [`TLSError`] otherwise.
+val encrypt_handshake
+      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
+      (pad: usize)
+      (state: t_DuplexCipherStateH)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val encrypt_data (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_DuplexCipherState1)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val padlen (b: Bertie.Tls13utils.t_Bytes) (n: usize)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// AEAD decrypt the record `ciphertext`
+val decrypt_record_payload
+      (kiv: Bertie.Tls13crypto.t_AeadKeyIV)
+      (n: u64)
+      (ciphertext: Bertie.Tls13utils.t_Bytes)
+    : Prims.Pure
+      (Core.Result.t_Result (Bertie.Tls13formats.t_ContentType & Bertie.Tls13utils.t_Bytes) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Decrypt 0-RTT `ciphertext`.
+/// TODO: Implement 0-RTT
+val decrypt_zerortt (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_ServerCipherState0)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_ServerCipherState0) u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Decrypt a handshake message.
+val decrypt_handshake (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_DuplexCipherStateH)
+    : Prims.Pure
+      (Core.Result.t_Result
+          (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
@@ -85,47 +150,7 @@ val decrypt_data_or_hs (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCiph
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-val decrypt_handshake (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_DuplexCipherStateH)
-    : Prims.Pure
-      (Core.Result.t_Result
-          (Bertie.Tls13formats.Handshake_data.t_HandshakeData & t_DuplexCipherStateH) u8)
+val decrypt_data (ciphertext: Bertie.Tls13utils.t_Bytes) (st: t_DuplexCipherState1)
+    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_DuplexCipherState1) u8)
       Prims.l_True
       (fun _ -> Prims.l_True)
-
-val decrypt_zerortt (ciphertext: Bertie.Tls13utils.t_Bytes) (state: t_ServerCipherState0)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_AppData & t_ServerCipherState0) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val duplex_cipher_state1
-      (ae: Bertie.Tls13crypto.t_AeadAlgorithm)
-      (kiv1: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c1: u64)
-      (kiv2: Bertie.Tls13crypto.t_AeadKeyIV)
-      (c2: u64)
-      (k: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure t_DuplexCipherState1 Prims.l_True (fun _ -> Prims.l_True)
-
-val encrypt_data (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_DuplexCipherState1)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherState1) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val encrypt_handshake
-      (payload: Bertie.Tls13formats.Handshake_data.t_HandshakeData)
-      (pad: usize)
-      (state: t_DuplexCipherStateH)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_DuplexCipherStateH) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val encrypt_zerortt (payload: Bertie.Tls13utils.t_AppData) (pad: usize) (st: t_ClientCipherState0)
-    : Prims.Pure (Core.Result.t_Result (Bertie.Tls13utils.t_Bytes & t_ClientCipherState0) u8)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val server_cipher_state0
-      (key_iv: Bertie.Tls13crypto.t_AeadKeyIV)
-      (counter: u64)
-      (early_exporter_ms: Bertie.Tls13utils.t_Bytes)
-    : Prims.Pure t_ServerCipherState0 Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Bertie.Tls13utils.fsti
+++ b/proofs/fstar/extraction/Bertie.Tls13utils.fsti
@@ -3,201 +3,144 @@ module Bertie.Tls13utils
 open Core
 open FStar.Mul
 
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Rand.Distr.Distribution in
+  let open Rand.Distr.Integer in
+  ()
+
 type t_Error = | Error_UnknownCiphersuite : Alloc.String.t_String -> t_Error
 
-unfold
-let t_TLSError = u8
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core.Fmt.t_Debug t_Error
 
-unfold
-let t_U16 = u16
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core.Clone.t_Clone t_Error
 
-unfold
-let t_U32 = u32
+let v_UNSUPPORTED_ALGORITHM: u8 = mk_u8 1
 
-unfold
-let t_U8 = u8
+let v_CRYPTO_ERROR: u8 = mk_u8 2
 
-let v_APPLICATION_DATA_INSTEAD_OF_HANDSHAKE: u8 = 138uy
+let v_INSUFFICIENT_ENTROPY: u8 = mk_u8 3
 
-let v_CRYPTO_ERROR: u8 = 2uy
+let v_INCORRECT_ARRAY_LENGTH: u8 = mk_u8 4
 
-let v_DECODE_ERROR: u8 = 142uy
+let v_INCORRECT_STATE: u8 = mk_u8 128
 
-let v_GOT_HANDSHAKE_FAILURE_ALERT: u8 = 141uy
+let v_ZERO_RTT_DISABLED: u8 = mk_u8 129
 
-let v_INCORRECT_ARRAY_LENGTH: u8 = 4uy
+let v_PAYLOAD_TOO_LONG: u8 = mk_u8 130
 
-let v_INCORRECT_STATE: u8 = 128uy
+let v_PSK_MODE_MISMATCH: u8 = mk_u8 131
 
-let v_INSUFFICIENT_DATA: u8 = 134uy
+let v_NEGOTIATION_MISMATCH: u8 = mk_u8 132
 
-let v_INSUFFICIENT_ENTROPY: u8 = 3uy
-
-let v_INVALID_COMPRESSION_LIST: u8 = 136uy
-
-let v_INVALID_SIGNATURE: u8 = 140uy
-
-let v_MISSING_KEY_SHARE: u8 = 139uy
-
-let v_NEGOTIATION_MISMATCH: u8 = 132uy
-
-let v_PARSE_FAILED: u8 = 133uy
-
-let v_PAYLOAD_TOO_LONG: u8 = 130uy
-
-let v_PROTOCOL_VERSION_ALERT: u8 = 137uy
-
-let v_PSK_MODE_MISMATCH: u8 = 131uy
-
-val v_U16 (x: u16) : Prims.Pure u16 Prims.l_True (fun _ -> Prims.l_True)
-
-val v_U32 (x: u32) : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
-
-val v_U8 (x: u8) : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
-
-let v_UNSUPPORTED: u8 = 135uy
-
-let v_UNSUPPORTED_ALGORITHM: u8 = 1uy
-
-let v_ZERO_RTT_DISABLED: u8 = 129uy
+let v_PARSE_FAILED: u8 = mk_u8 133
 
 val parse_failed: Prims.unit -> Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
 
-class t_Declassify (v_Self: Type) (v_T: Type) = {
-  f_declassify_pre:v_Self -> bool;
-  f_declassify_post:v_Self -> v_T -> bool;
+let v_INSUFFICIENT_DATA: u8 = mk_u8 134
+
+let v_UNSUPPORTED: u8 = mk_u8 135
+
+let v_INVALID_COMPRESSION_LIST: u8 = mk_u8 136
+
+let v_PROTOCOL_VERSION_ALERT: u8 = mk_u8 137
+
+let v_APPLICATION_DATA_INSTEAD_OF_HANDSHAKE: u8 = mk_u8 138
+
+let v_MISSING_KEY_SHARE: u8 = mk_u8 139
+
+let v_INVALID_SIGNATURE: u8 = mk_u8 140
+
+let v_GOT_HANDSHAKE_FAILURE_ALERT: u8 = mk_u8 141
+
+let v_DECODE_ERROR: u8 = mk_u8 142
+
+val error_string (c: u8) : Prims.Pure Alloc.String.t_String Prims.l_True (fun _ -> Prims.l_True)
+
+val tlserr (#v_T: Type0) (err: u8)
+    : Prims.Pure (Core.Result.t_Result v_T u8) Prims.l_True (fun _ -> Prims.l_True)
+
+class t_Declassify (v_Self: Type0) (v_T: Type0) = {
+  f_declassify_pre:v_Self -> Type0;
+  f_declassify_post:v_Self -> v_T -> Type0;
   f_declassify:x0: v_Self
     -> Prims.Pure v_T (f_declassify_pre x0) (fun result -> f_declassify_post x0 result)
 }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl: t_Declassify u8 u8 =
-  {
-    f_declassify_pre = (fun (self: u8) -> true);
-    f_declassify_post = (fun (self: u8) (out: u8) -> true);
-    f_declassify = fun (self: u8) -> self
-  }
+val impl:t_Declassify u8 u8
+
+val v_U8 (x: u8) : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
+
+val v_U16 (x: u16) : Prims.Pure u16 Prims.l_True (fun _ -> Prims.l_True)
+
+val v_U32 (x: u32) : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_1: t_Declassify u32 u32 =
-  {
-    f_declassify_pre = (fun (self: u32) -> true);
-    f_declassify_post = (fun (self: u32) (out: u32) -> true);
-    f_declassify = fun (self: u32) -> self
-  }
+val impl_1:t_Declassify u32 u32
 
-val eq1 (b1 b2: u8) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val u32_from_be_bytes (v_val: t_Array u8 (sz 4))
-    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
-
-val u16_as_be_bytes (v_val: u16)
-    : Prims.Pure (t_Array u8 (sz 2)) Prims.l_True (fun _ -> Prims.l_True)
-
-val u32_as_be_bytes (v_val: u32)
-    : Prims.Pure (t_Array u8 (sz 4)) Prims.l_True (fun _ -> Prims.l_True)
-
-val check (b: bool)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_eq1 (b1 b2: u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val length_u16_encoded_slice (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val length_u16_encoded (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val length_u24_encoded (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val length_u8_encoded (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_length_encoding_u16_slice (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_length_encoding_u24 (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_length_encoding_u8_slice (bytes: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val eq_slice (b1 b2: t_Slice u8) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val check_eq_slice (b1 b2: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_eq_with_slice (b1 b2: t_Slice u8) (start v_end: usize)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val check_mem (b1 b2: t_Slice u8)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val error_string (c: u8) : Prims.Pure Alloc.String.t_String Prims.l_True (fun _ -> Prims.l_True)
-
-val tlserr (#v_T: Type) (err: u8)
-    : Prims.Pure (Core.Result.t_Result v_T u8) Prims.l_True (fun _ -> Prims.l_True)
-
+/// Bytes used in Bertie.
 type t_Bytes = | Bytes : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> t_Bytes
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_2: Core.Convert.t_From t_Bytes (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-  {
-    f_from_pre = (fun (x: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) -> true);
-    f_from_post = (fun (x: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) (out: t_Bytes) -> true);
-    f_from = fun (x: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) -> Bytes x <: t_Bytes
-  }
+val impl_19:Core.Clone.t_Clone t_Bytes
 
-val impl__Bytes__as_raw (self: t_Bytes)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core.Marker.t_StructuralPartialEq t_Bytes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core.Cmp.t_PartialEq t_Bytes t_Bytes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_22:Core.Fmt.t_Debug t_Bytes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_23:Core.Default.t_Default t_Bytes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_2:Core.Convert.t_From t_Bytes (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+
+/// Declassify these bytes and return a copy of [`u8`].
+val impl_Bytes__declassify (self: t_Bytes)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Convert the bytes into raw bytes
+val impl_Bytes__into_raw (self: t_Bytes)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get a reference to the raw bytes.
+val impl_Bytes__as_raw (self: t_Bytes)
     : Prims.Pure (t_Slice u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__declassify (self: t_Bytes)
-    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__into_raw (self: t_Bytes)
-    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__declassify_array (v_C: usize) (self: t_Bytes)
+val impl_Bytes__declassify_array (v_C: usize) (self: t_Bytes)
     : Prims.Pure (Core.Result.t_Result (t_Array u8 v_C) u8) Prims.l_True (fun _ -> Prims.l_True)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_5: Core.Convert.t_From t_Bytes (t_Slice u8) =
-  {
-    f_from_pre = (fun (x: t_Slice u8) -> true);
-    f_from_post = (fun (x: t_Slice u8) (out: t_Bytes) -> true);
-    f_from
-    =
-    fun (x: t_Slice u8) ->
-      Core.Convert.f_into (Alloc.Slice.impl__to_vec x <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-  }
+val impl_5:Core.Convert.t_From t_Bytes (t_Slice u8)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_6 (v_C: usize) : Core.Convert.t_From t_Bytes (t_Array u8 v_C) =
-  {
-    f_from_pre = (fun (x: t_Array u8 v_C) -> true);
-    f_from_post = (fun (x: t_Array u8 v_C) (out: t_Bytes) -> true);
-    f_from
-    =
-    fun (x: t_Array u8 v_C) ->
-      Core.Convert.f_into (Alloc.Slice.impl__to_vec (Rust_primitives.unsize x <: t_Slice u8)
-          <:
-          Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-  }
+val impl_6 (v_C: usize) : Core.Convert.t_From t_Bytes (t_Array u8 v_C)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_7 (v_C: usize) : Core.Convert.t_From t_Bytes (t_Array u8 v_C) =
-  {
-    f_from_pre = (fun (x: t_Array u8 v_C) -> true);
-    f_from_post = (fun (x: t_Array u8 v_C) (out: t_Bytes) -> true);
-    f_from
-    =
-    fun (x: t_Array u8 v_C) ->
-      Core.Convert.f_into (Alloc.Slice.impl__to_vec (Rust_primitives.unsize x <: t_Slice u8)
-          <:
-          Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-  }
+val impl_7 (v_C: usize) : Core.Convert.t_From t_Bytes (t_Array u8 v_C)
+
+val u16_as_be_bytes (v_val: u16)
+    : Prims.Pure (t_Array u8 (mk_usize 2)) Prims.l_True (fun _ -> Prims.l_True)
+
+val u32_as_be_bytes (v_val: u32)
+    : Prims.Pure (t_Array u8 (mk_usize 4)) Prims.l_True (fun _ -> Prims.l_True)
+
+val u32_from_be_bytes (v_val: t_Array u8 (mk_usize 4))
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+val bytes (x: t_Slice u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+val bytes1 (x: u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+val bytes2 (x y: u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_8: Core.Ops.Index.t_Index t_Bytes usize =
@@ -217,117 +160,211 @@ let impl_9: Core.Ops.Index.t_Index t_Bytes (Core.Ops.Range.t_Range usize) =
     f_index = fun (self: t_Bytes) (x: Core.Ops.Range.t_Range usize) -> self._0.[ x ]
   }
 
-val impl__Bytes__append (self x: t_Bytes) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Create new [`Bytes`].
+val impl_Bytes__new: Prims.unit -> Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__concat (self other: t_Bytes)
+/// Create new [`Bytes`].
+val impl_Bytes__new_alloc (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Generate `len` bytes of `0`.
+val impl_Bytes__zeroes (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+
+/// Get the length of these [`Bytes`].
+val impl_Bytes__len (self: t_Bytes) : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+/// Add a prefix to these bytes and return it.
+val impl_Bytes__prefix (self: t_Bytes) (prefix: t_Slice u8)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__concat_array (v_N: usize) (self: t_Bytes) (other: t_Array u8 v_N)
+/// Push `x` into these [`Bytes`].
+val impl_Bytes__push (self: t_Bytes) (x: u8)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__extend_from_slice (self x: t_Bytes)
+/// Extend `self` with the slice `x`.
+val impl_Bytes__extend_from_slice (self x: t_Bytes)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__from_hex (s: string) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Extend `self` with the bytes `x`.
+val impl_Bytes__append (self x: t_Bytes) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__from_slice (s: t_Slice u8)
-    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Generate a new [`Bytes`] struct from slice `s`.
+val impl_Bytes__from_slice (s: t_Slice u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__len (self: t_Bytes) : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+/// Read a hex string into [`Bytes`].
+val impl_Bytes__from_hex (s: string) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__prefix (self: t_Bytes) (prefix: t_Slice u8)
-    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__new: Prims.unit -> Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__new_alloc (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__push (self: t_Bytes) (x: u8)
-    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__Bytes__raw_slice (self: t_Bytes) (range: Core.Ops.Range.t_Range usize)
+/// Get a slice of the given `range`.
+val impl_Bytes__raw_slice (self: t_Bytes) (range: Core.Ops.Range.t_Range usize)
     : Prims.Pure (t_Slice u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__slice (self: t_Bytes) (start len: usize)
+/// Get a new copy of the given `range` as [`Bytes`].
+val impl_Bytes__slice_range (self: t_Bytes) (range: Core.Ops.Range.t_Range usize)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__slice_range (self: t_Bytes) (range: Core.Ops.Range.t_Range usize)
+/// Get a new copy of the given range `[start..start+len]` as [`Bytes`].
+val impl_Bytes__slice (self: t_Bytes) (start len: usize)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__update_slice (self: t_Bytes) (start: usize) (other: t_Bytes) (beg len: usize)
+/// Concatenate `other` with these bytes and return a copy as [`Bytes`].
+val impl_Bytes__concat (self other: t_Bytes)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__Bytes__zeroes (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Concatenate `other` with these bytes and return a copy as [`Bytes`].
+val impl_Bytes__concat_array (v_N: usize) (self: t_Bytes) (other: t_Array u8 v_N)
+    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val bytes (x: t_Slice u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Update the slice `self[start..start+len] = other[beg..beg+len]` and return
+/// a copy as [`Bytes`].
+val impl_Bytes__update_slice (self: t_Bytes) (start: usize) (other: t_Bytes) (beg len: usize)
+    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val bytes1 (x: u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Convert the bool `b` into a Result.
+val check (b: bool)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val bytes2 (x y: u8) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Test if [Bytes] `b1` and `b2` have the same value.
+val eq1 (b1 b2: u8) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
+/// Parser function to check if [Bytes] `b1` and `b2` have the same value,
+/// returning a [TLSError] otherwise.
+val check_eq1 (b1 b2: u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if [U8] slices `b1` and `b2` are of the same
+/// length and agree on all positions.
+val eq_slice (b1 b2: t_Slice u8) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if [Bytes] slices `b1` and `b2` are of the same
+/// length and agree on all positions.
+val eq (b1 b2: t_Bytes) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+/// Parse function to check if two slices `b1` and `b2` are of the same
+/// length and agree on all positions, returning a [TLSError] otherwise.
+val check_eq_slice (b1 b2: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Parse function to check if two slices `b1` and `b2` are of the same
+/// length and agree on all positions, returning a [TLSError] otherwise.
+val check_eq_with_slice (b1 b2: t_Slice u8) (start v_end: usize)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Parse function to check if [Bytes] slices `b1` and `b2` are of the same
+/// length and agree on all positions, returning a [TLSError] otherwise.
 val check_eq (b1 b2: t_Bytes)
     : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val check_length_encoding_u16 (bytes: t_Bytes)
+/// Compare the two provided byte slices.
+/// Returns `Ok(())` when they are equal, and a [`TLSError`] otherwise.
+val check_mem (b1 b2: t_Slice u8)
     : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val check_length_encoding_u8 (bytes: t_Bytes)
-    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val encode_length_u16 (bytes: t_Bytes)
-    : Prims.Pure (Core.Result.t_Result t_Bytes u8) Prims.l_True (fun _ -> Prims.l_True)
-
-val encode_length_u24 (bytes: t_Bytes)
-    : Prims.Pure (Core.Result.t_Result t_Bytes u8) Prims.l_True (fun _ -> Prims.l_True)
-
+/// Attempt to TLS encode the `bytes` with [`u8`] length.
+/// On success, return a new [Bytes] slice such that its first byte encodes the
+/// length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in one byte.
 val encode_length_u8 (bytes: t_Slice u8)
     : Prims.Pure (Core.Result.t_Result t_Bytes u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val eq (b1 b2: t_Bytes) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+/// Attempt to TLS encode the `bytes` with [`u16`] length.
+/// On success, return a new [Bytes] slice such that its first two bytes encode the
+/// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in two bytes.
+val encode_length_u16 (bytes: t_Bytes)
+    : Prims.Pure (Core.Result.t_Result t_Bytes u8) Prims.l_True (fun _ -> Prims.l_True)
 
-val random_bytes (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
+/// Attempt to TLS encode the `bytes` with [`u24`] length.
+/// On success, return a new [Bytes] slice such that its first three bytes encode the
+/// big-endian length of `bytes` and the remainder equals `bytes`. Return a [TLSError] if
+/// the length of `bytes` exceeds what can be encoded in three bytes.
+val encode_length_u24 (bytes: t_Bytes)
+    : Prims.Pure (Core.Result.t_Result t_Bytes u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes[1..]` is at least as long as the length encoded by
+/// `bytes[0]` in big-endian order.
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is
+/// empty or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+val length_u8_encoded (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes[2..]` is at least as long as the length encoded by `bytes[0..2]`
+/// in big-endian order.
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 2
+/// bytes long or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+val length_u16_encoded_slice (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes[2..]` is at least as long as the length encoded by `bytes[0..2]`
+/// in big-endian order.
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 2
+/// bytes long or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+val length_u16_encoded (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes[3..]` is at least as long as the length encoded by `bytes[0..3]`
+/// in big-endian order.
+/// On success, return the encoded length. Return a [TLSError] if `bytes` is less than 3
+/// bytes long or if the encoded length exceeds the length of the remainder of
+/// `bytes`.
+val length_u24_encoded (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result usize u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val check_length_encoding_u8_slice (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes` contains exactly the TLS `u8` length encoded content.
+/// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
+/// more bytes in the `bytes`.
+val check_length_encoding_u8 (bytes: t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val check_length_encoding_u16_slice (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes` contains exactly as many bytes of content as encoded by its
+/// first two bytes.
+/// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
+/// more bytes in the `bytes`.
+val check_length_encoding_u16 (bytes: t_Bytes)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Check if `bytes` contains exactly as many bytes of content as encoded by its
+/// first three bytes.
+/// Returns `Ok(())` if there are no bytes left, and a [`TLSError`] if there are
+/// more bytes in the `bytes`.
+val check_length_encoding_u24 (bytes: t_Slice u8)
+    : Prims.Pure (Core.Result.t_Result Prims.unit u8) Prims.l_True (fun _ -> Prims.l_True)
 
 type t_AppData = | AppData : t_Bytes -> t_AppData
 
-val impl__AppData__as_raw (self: t_AppData)
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_24:Core.Marker.t_StructuralPartialEq t_AppData
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_25:Core.Cmp.t_PartialEq t_AppData t_AppData
+
+/// Create new application data from raw bytes.
+val impl_AppData__new (b: t_Bytes) : Prims.Pure t_AppData Prims.l_True (fun _ -> Prims.l_True)
+
+/// Convert this application data into raw bytes
+val impl_AppData__into_raw (self: t_AppData)
     : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
-val impl__AppData__into_raw (self: t_AppData)
-    : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
-
-val impl__AppData__new (b: t_Bytes) : Prims.Pure t_AppData Prims.l_True (fun _ -> Prims.l_True)
+/// Get a reference to the raw bytes.
+val impl_AppData__as_raw (self: t_AppData) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_12: Core.Convert.t_From t_AppData (t_Slice u8) =
-  {
-    f_from_pre = (fun (value: t_Slice u8) -> true);
-    f_from_post = (fun (value: t_Slice u8) (out: t_AppData) -> true);
-    f_from = fun (value: t_Slice u8) -> AppData (Core.Convert.f_into value) <: t_AppData
-  }
+val impl_13:Core.Convert.t_From t_AppData (t_Slice u8)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_13 (v_N: usize) : Core.Convert.t_From t_AppData (t_Array u8 v_N) =
-  {
-    f_from_pre = (fun (value: t_Array u8 v_N) -> true);
-    f_from_post = (fun (value: t_Array u8 v_N) (out: t_AppData) -> true);
-    f_from = fun (value: t_Array u8 v_N) -> AppData (Core.Convert.f_into value) <: t_AppData
-  }
+val impl_14 (v_N: usize) : Core.Convert.t_From t_AppData (t_Array u8 v_N)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_14: Core.Convert.t_From t_AppData (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-  {
-    f_from_pre = (fun (value: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) -> true);
-    f_from_post = (fun (value: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) (out: t_AppData) -> true);
-    f_from
-    =
-    fun (value: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) ->
-      AppData (Core.Convert.f_into value) <: t_AppData
-  }
+val impl_15:Core.Convert.t_From t_AppData (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_15: Core.Convert.t_From t_AppData t_Bytes =
-  {
-    f_from_pre = (fun (value: t_Bytes) -> true);
-    f_from_post = (fun (value: t_Bytes) (out: t_AppData) -> true);
-    f_from = fun (value: t_Bytes) -> AppData value <: t_AppData
-  }
+val impl_16:Core.Convert.t_From t_AppData t_Bytes
+
+val random_bytes (len: usize) : Prims.Pure t_Bytes Prims.l_True (fun _ -> Prims.l_True)

--- a/simple_https_client/Cargo.toml
+++ b/simple_https_client/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/tls13client.rs"
 anyhow = "1"
 bertie = { path = "../", features = ["test_utils"] }
 hex = "0.4.3"
-rand = "0.8.0"
+rand = "0.9"
 record = { path = "../record" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/simple_https_client/src/tls13client.rs
+++ b/simple_https_client/src/tls13client.rs
@@ -7,7 +7,6 @@ use bertie::{
     tls13crypto::{Algorithms, SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519},
     tls13utils::*,
 };
-use rand::thread_rng;
 use record::AppError;
 use tracing::{error, event, Level};
 
@@ -66,7 +65,7 @@ fn main() -> anyhow::Result<()> {
     event!(Level::DEBUG, "  {ciphersuite:#?}");
 
     // Initiate HTTPS connection to host:port.
-    let mut stream = BertieStream::client(&host, port, ciphersuite, &mut thread_rng())
+    let mut stream = BertieStream::client(&host, port, ciphersuite, &mut rand::rng())
         .expect("Error connecting to server");
 
     // Send HTTP GET

--- a/simple_https_server/Cargo.toml
+++ b/simple_https_server/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/tls13server.rs"
 [dependencies]
 anyhow = "1"
 bertie = { path = "../" }
-rand = "0.8.0"
+rand = "0.9"
 record = { path = "../record" }
 tracing-subscriber = "0.3"
 clap = { version = "4.4.8", features = ["derive"] }

--- a/simple_https_server/src/tls13server.rs
+++ b/simple_https_server/src/tls13server.rs
@@ -10,7 +10,6 @@ use bertie::{
 };
 
 use clap::Parser;
-use rand::thread_rng;
 
 #[derive(Parser)]
 struct Cli {
@@ -77,7 +76,7 @@ pub fn main() -> anyhow::Result<()> {
         println!("New connection established!");
         match BertieStream::server(&host, port, stream, ciphersuite, &cli.cert, &cli.key) {
             Ok(mut server) => {
-                server.connect(&mut thread_rng()).unwrap();
+                server.connect(&mut rand::rng()).unwrap();
                 server
                     .write(b"Hello, this is the Bertie TLS 1.3 server.\n")
                     .unwrap();

--- a/src/stream/client.rs
+++ b/src/stream/client.rs
@@ -235,7 +235,7 @@ impl BertieStream<ClientState<TcpStream>> {
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::{self, rng};
 
     use crate::tls13crypto::SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519;
 
@@ -250,7 +250,7 @@ mod tests {
             host,
             port,
             SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519,
-            &mut thread_rng(),
+            &mut rng(),
         )
         .expect("Error connecting to server");
 

--- a/src/stream/client.rs
+++ b/src/stream/client.rs
@@ -2,7 +2,7 @@
 //!
 //! TLS streaming client API.
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use std::{
     eprintln,
     io::{Read, Write},
@@ -99,7 +99,7 @@ impl BertieStream<ClientState<TcpStream>> {
         host: &str,
         port: u16,
         ciphersuite: Algorithms,
-        rng: &mut (impl RngCore + CryptoRng),
+        rng: &mut impl CryptoRng,
     ) -> Result<Self, BertieError> {
         let mut stream = Self::open(host, port, ciphersuite)?;
         stream.ciphersuite = ciphersuite;
@@ -121,7 +121,7 @@ impl BertieStream<ClientState<TcpStream>> {
     /// Open the connection.
     ///
     /// This will fail if the connection wasn't set up correctly.
-    pub fn start(&mut self, rng: &mut (impl RngCore + CryptoRng)) -> Result<(), BertieError> {
+    pub fn start(&mut self, rng: &mut impl CryptoRng) -> Result<(), BertieError> {
         // Initialize TLS 1.3 client.
         if self.state.cstate.is_some() {
             return Err(BertieError::InvalidState);

--- a/src/stream/server.rs
+++ b/src/stream/server.rs
@@ -8,7 +8,7 @@ use std::{
     vec::Vec,
 };
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::{
     server::ServerDB,
@@ -183,7 +183,7 @@ impl BertieStream<ServerState<TcpStream>> {
 
     /// Connect the incoming TLS stream.
     /// This function blocks until it was able to read the TLS client hello.
-    pub fn connect(&mut self, rng: &mut (impl RngCore + CryptoRng)) -> Result<(), BertieError> {
+    pub fn connect(&mut self, rng: &mut impl CryptoRng) -> Result<(), BertieError> {
         let client_hello = read_record(&mut self.state.read_buffer, &mut self.state.stream)?;
 
         match Server::accept(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -27,11 +27,6 @@ impl RngCore for TestRng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         dest.copy_from_slice(self.bytes.drain(0..dest.len()).as_ref());
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        dest.copy_from_slice(self.bytes.drain(0..dest.len()).as_ref());
-        Ok(())
-    }
 }
 
 impl CryptoRng for TestRng {}

--- a/src/tls13api.rs
+++ b/src/tls13api.rs
@@ -7,7 +7,7 @@
 //!           We will add a more usable API on top in future. But the verifiable
 //!           core of the protocol starts here.
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::{
     server::ServerDB,
@@ -67,7 +67,7 @@ impl Client {
         server_name: &Bytes,
         session_ticket: Option<Bytes>,
         psk: Option<Key>,
-        rng: &mut (impl CryptoRng + RngCore),
+        rng: &mut impl CryptoRng,
     ) -> Result<(Bytes, Self), TLSError> {
         let (client_hello, cipherstate0, client_state) =
             client_init(ciphersuite, server_name, session_ticket, psk, rng)?;
@@ -198,7 +198,7 @@ impl Server {
         ciphersuite: Algorithms,
         db: ServerDB,
         client_hello: &Bytes,
-        rng: &mut (impl CryptoRng + RngCore),
+        rng: &mut impl CryptoRng,
     ) -> Result<(Bytes, Bytes, Self), TLSError> {
         let mut ch_rec = client_hello.clone();
         ch_rec[2] = U8(0x03);

--- a/src/tls13cert.rs
+++ b/src/tls13cert.rs
@@ -16,7 +16,7 @@
 //!     BitString // 0x03
 //! }
 #[cfg(feature = "hax-pv")]
-use hax_lib_macros::{pv_constructor, pv_handwritten};
+use hax_lib::{pv_constructor, pv_handwritten};
 
 #[cfg(not(feature = "secret_integers"))]
 use crate::tls13utils::Declassify;

--- a/src/tls13crypto.rs
+++ b/src/tls13crypto.rs
@@ -15,7 +15,7 @@ use libcrux_rsa::{
 };
 use libcrux_sha2::Algorithm as Sha2Algorithm;
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::std::{fmt::Display, format, vec::Vec};
 
@@ -328,7 +328,7 @@ pub(crate) fn sign_rsa(
     pk_exponent: &Bytes,
     cert_scheme: SignatureScheme,
     input: &Bytes,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<Bytes, TLSError> {
     // salt must be same length as digest output length
     let mut salt = [0u8; 32];
@@ -357,7 +357,7 @@ pub(crate) fn sign_rsa(
     sign_varlen(
         RsaDigestAlgorithm::Sha2_256,
         &sk,
-        &msg,
+        msg,
         &salt,
         &mut signature,
     )
@@ -512,7 +512,7 @@ impl KemScheme {
 #[cfg_attr(feature = "hax-pv", pv_handwritten)]
 pub(crate) fn kem_keygen(
     alg: KemScheme,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<(KemSk, KemPk), TLSError> {
     let res = libcrux_kem::key_gen(alg.libcrux_kem_algorithm()?, rng);
     match res {
@@ -557,7 +557,7 @@ fn into_raw(alg: KemScheme, point: Bytes) -> Bytes {
 pub(crate) fn kem_encap(
     alg: KemScheme,
     pk: &Bytes,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<(Bytes, Bytes), TLSError> {
     // event!(Level::DEBUG, "KEM Encaps with {alg:?}");
     // event!(Level::TRACE, "  pk:  {}", pk.as_hex());

--- a/src/tls13crypto.rs
+++ b/src/tls13crypto.rs
@@ -1,17 +1,27 @@
+use std::vec;
+
 #[cfg(feature = "hax-pv")]
-use hax_lib_macros::{pv_constructor, pv_handwritten};
-use libcrux::{
-    signature::rsa_pss::{RsaPssKeySize, RsaPssPrivateKey, RsaPssPublicKey},
-    *,
-};
+use hax_lib::{pv_constructor, pv_handwritten};
+
+use libcrux_chacha20poly1305::{decrypt_detached, encrypt_detached};
+use libcrux_ecdsa::DigestAlgorithm as EcDsaDigestAlgorithm;
+use libcrux_ed25519;
+use libcrux_hkdf::{expand, extract, Algorithm as HkdfAlgorithm};
+use libcrux_hmac::{hmac, Algorithm as HmacAlgorithm};
 use libcrux_kem::{Ct, PrivateKey, PublicKey};
+use libcrux_rsa::{
+    sign_varlen, verify_varlen, DigestAlgorithm as RsaDigestAlgorithm, VarLenPrivateKey,
+    VarLenPublicKey,
+};
+use libcrux_sha2::Algorithm as Sha2Algorithm;
+
 use rand::{CryptoRng, RngCore};
 
 use crate::std::{fmt::Display, format, vec::Vec};
 
 use crate::tls13utils::{
     check_mem, eq, length_u16_encoded, tlserr, Bytes, Error, TLSError, CRYPTO_ERROR,
-    INVALID_SIGNATURE, U8, UNSUPPORTED_ALGORITHM,
+    INCORRECT_ARRAY_LENGTH, INVALID_SIGNATURE, U8, UNSUPPORTED_ALGORITHM,
 };
 
 pub(crate) type Random = Bytes;
@@ -42,30 +52,13 @@ impl AeadKeyIV {
 /// An AEAD key.
 pub(crate) struct AeadKey {
     bytes: Bytes,
-    alg: AeadAlgorithm,
+    _alg: AeadAlgorithm,
 }
 
 impl AeadKey {
     /// Create a new AEAD key from the raw bytes and the algorithm.
-    pub(crate) fn new(bytes: Bytes, alg: AeadAlgorithm) -> Self {
-        Self { bytes, alg }
-    }
-
-    /// Convert a raw AEAD key into a usable libcrux key.
-    ///
-    /// This copies the key.
-    fn as_libcrux_key(&self) -> Result<aead::Key, TLSError> {
-        match self.alg {
-            AeadAlgorithm::Chacha20Poly1305 => Ok(aead::Key::Chacha20Poly1305(aead::Chacha20Key(
-                self.bytes.declassify_array()?,
-            ))),
-            AeadAlgorithm::Aes128Gcm => Ok(aead::Key::Aes128(aead::Aes128Key(
-                self.bytes.declassify_array()?,
-            ))),
-            AeadAlgorithm::Aes256Gcm => Ok(aead::Key::Aes256(aead::Aes256Key(
-                self.bytes.declassify_array()?,
-            ))),
-        }
+    pub(crate) fn new(bytes: Bytes, _alg: AeadAlgorithm) -> Self {
+        Self { bytes, _alg }
     }
 
     /// Get the raw bytes of the key.
@@ -99,11 +92,11 @@ pub enum HashAlgorithm {
 
 impl HashAlgorithm {
     /// Get the libcrux hash algorithm
-    fn libcrux_algorithm(&self) -> Result<digest::Algorithm, TLSError> {
+    fn libcrux_algorithm(&self) -> Result<Sha2Algorithm, TLSError> {
         match self {
-            HashAlgorithm::SHA256 => Ok(digest::Algorithm::Sha256),
-            HashAlgorithm::SHA384 => Ok(digest::Algorithm::Sha384),
-            HashAlgorithm::SHA512 => Ok(digest::Algorithm::Sha512),
+            HashAlgorithm::SHA256 => Ok(Sha2Algorithm::Sha256),
+            HashAlgorithm::SHA384 => Ok(Sha2Algorithm::Sha384),
+            HashAlgorithm::SHA512 => Ok(Sha2Algorithm::Sha512),
         }
     }
 
@@ -112,24 +105,29 @@ impl HashAlgorithm {
     /// Returns the digest or an [`TLSError`].
     #[cfg_attr(feature = "hax-pv", pv_constructor)]
     pub(crate) fn hash(&self, data: &Bytes) -> Result<Bytes, TLSError> {
-        Ok(digest::hash(self.libcrux_algorithm()?, &data.declassify()).into())
+        let hasher = self.libcrux_algorithm()?;
+
+        let mut digest = vec![0u8; hasher.hash_len()];
+        hasher.hash(&data.declassify(), &mut digest);
+
+        Ok(digest.into())
     }
 
     /// Get the size of the hash digest.
     pub(crate) fn hash_len(&self) -> usize {
         match self {
-            HashAlgorithm::SHA256 => digest::digest_size(digest::Algorithm::Sha256),
-            HashAlgorithm::SHA384 => digest::digest_size(digest::Algorithm::Sha384),
-            HashAlgorithm::SHA512 => digest::digest_size(digest::Algorithm::Sha512),
+            HashAlgorithm::SHA256 => Sha2Algorithm::Sha256.hash_len(),
+            HashAlgorithm::SHA384 => Sha2Algorithm::Sha384.hash_len(),
+            HashAlgorithm::SHA512 => Sha2Algorithm::Sha512.hash_len(),
         }
     }
 
     /// Get the libcrux hmac algorithm.
-    fn hmac_algorithm(&self) -> Result<hmac::Algorithm, TLSError> {
+    fn hmac_algorithm(&self) -> Result<HmacAlgorithm, TLSError> {
         match self {
-            HashAlgorithm::SHA256 => Ok(hmac::Algorithm::Sha256),
-            HashAlgorithm::SHA384 => Ok(hmac::Algorithm::Sha384),
-            HashAlgorithm::SHA512 => Ok(hmac::Algorithm::Sha512),
+            HashAlgorithm::SHA256 => Ok(HmacAlgorithm::Sha256),
+            HashAlgorithm::SHA384 => Ok(HmacAlgorithm::Sha384),
+            HashAlgorithm::SHA512 => Ok(HmacAlgorithm::Sha512),
         }
     }
 
@@ -144,7 +142,7 @@ impl HashAlgorithm {
 /// Returns the tag [`Hmac`] or a [`TLSError`].
 #[cfg_attr(feature = "hax-pv", pv_constructor)]
 pub(crate) fn hmac_tag(alg: &HashAlgorithm, mk: &MacKey, input: &Bytes) -> Result<Hmac, TLSError> {
-    Ok(hmac::hmac(
+    Ok(hmac(
         alg.hmac_algorithm()?,
         &mk.declassify(),
         &input.declassify(),
@@ -176,11 +174,11 @@ pub(crate) fn zero_key(alg: &HashAlgorithm) -> Bytes {
 }
 
 /// Get the libcrux HKDF algorithm.
-fn hkdf_algorithm(alg: &HashAlgorithm) -> Result<hkdf::Algorithm, TLSError> {
+fn hkdf_algorithm(alg: &HashAlgorithm) -> Result<HkdfAlgorithm, TLSError> {
     match alg {
-        HashAlgorithm::SHA256 => Ok(hkdf::Algorithm::Sha256),
-        HashAlgorithm::SHA384 => Ok(hkdf::Algorithm::Sha384),
-        HashAlgorithm::SHA512 => Ok(hkdf::Algorithm::Sha512),
+        HashAlgorithm::SHA256 => Ok(HkdfAlgorithm::Sha256),
+        HashAlgorithm::SHA384 => Ok(HkdfAlgorithm::Sha384),
+        HashAlgorithm::SHA512 => Ok(HkdfAlgorithm::Sha512),
     }
 }
 
@@ -193,7 +191,7 @@ pub(crate) fn hkdf_extract(
     ikm: &Bytes,
     salt: &Bytes,
 ) -> Result<Bytes, TLSError> {
-    hkdf::extract(hkdf_algorithm(alg)?, salt.declassify(), ikm.declassify())
+    extract(hkdf_algorithm(alg)?, salt.declassify(), ikm.declassify())
         .map(|bytes| bytes.into())
         .map_err(|_| CRYPTO_ERROR)
 }
@@ -208,7 +206,7 @@ pub(crate) fn hkdf_expand(
     info: &Bytes,
     len: usize,
 ) -> Result<Bytes, TLSError> {
-    match hkdf::expand(
+    match expand(
         hkdf_algorithm(alg)?,
         prk.declassify(),
         info.declassify(),
@@ -254,15 +252,27 @@ pub(crate) fn aead_encrypt(
     plain: &Bytes,
     aad: &Bytes,
 ) -> Result<Bytes, TLSError> {
-    let res = aead::encrypt_detached(
-        &k.as_libcrux_key()?,
-        plain.declassify(),
-        aead::Iv(iv.declassify_array()?),
-        aad.declassify(),
+    // We only support Chacha20Poly1305 right now.
+    let key = k
+        .bytes
+        .as_raw()
+        .try_into()
+        .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
+
+    let mut ctxt = vec![0u8; plain.len()];
+    let mut tag = [0u8; libcrux_chacha20poly1305::TAG_LEN];
+    let result = encrypt_detached(
+        &key,
+        &plain.declassify(),
+        &mut ctxt,
+        &mut tag,
+        &aad.declassify(),
+        &iv.declassify_array()?,
     );
-    match res {
-        Ok((tag, cip)) => {
-            let cipby: Bytes = cip.into();
+
+    match result {
+        Ok(_) => {
+            let cipby: Bytes = ctxt.into();
             let tagby: Bytes = tag.as_ref().into();
             Ok(cipby.concat(tagby))
         }
@@ -280,16 +290,25 @@ pub(crate) fn aead_decrypt(
     // event!(Level::DEBUG, "AEAD decrypt with {:?}", k.alg);
 
     let tag = cip.slice(cip.len() - 16, 16);
-    let cip = cip.slice(0, cip.len() - 16);
+    let ctxt = cip.slice(0, cip.len() - 16);
     let tag: [u8; 16] = tag.declassify_array()?;
-    let plain = aead::decrypt_detached(
-        &k.as_libcrux_key()?,
-        cip.declassify(),
-        aead::Iv(iv.declassify_array()?),
-        aad.declassify(),
-        &aead::Tag::from(tag),
+    let key = k
+        .bytes
+        .as_raw()
+        .try_into()
+        .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
+    let mut ptxt = vec![0u8; ctxt.len()];
+
+    let result = decrypt_detached(
+        &key,
+        &mut ptxt,
+        &ctxt.declassify(),
+        &tag,
+        &aad.declassify(),
+        &iv.declassify_array()?,
     );
-    match plain {
+
+    match result {
         Ok(plain) => Ok(plain.into()),
         Err(_) => tlserr(CRYPTO_ERROR),
     }
@@ -301,21 +320,6 @@ pub enum SignatureScheme {
     RsaPssRsaSha256,
     EcdsaSecp256r1Sha256,
     ED25519,
-}
-
-impl SignatureScheme {
-    /// Get the libcrux signature algorithm from the [`SignatureScheme`].
-    fn libcrux_scheme(&self) -> Result<signature::Algorithm, TLSError> {
-        match self {
-            SignatureScheme::RsaPssRsaSha256 => Ok(signature::Algorithm::RsaPss(
-                signature::DigestAlgorithm::Sha256,
-            )),
-            SignatureScheme::ED25519 => Ok(signature::Algorithm::Ed25519),
-            SignatureScheme::EcdsaSecp256r1Sha256 => Ok(signature::Algorithm::EcDsaP256(
-                signature::DigestAlgorithm::Sha256,
-            )),
-        }
-    }
 }
 
 /// Sign the `input` with the provided RSA key.
@@ -340,16 +344,28 @@ pub(crate) fn sign_rsa(
         return tlserr(UNSUPPORTED_ALGORITHM);
     }
 
-    let key_size = supported_rsa_key_size(pk_modulus)?;
-    let pk =
-        RsaPssPublicKey::new(key_size, &pk_modulus.declassify()[1..]).map_err(|_| CRYPTO_ERROR)?;
+    supported_rsa_key_size(pk_modulus)?;
+    let pk = VarLenPublicKey::try_from(&pk_modulus.declassify()[1..])
+        .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
 
-    let sk = RsaPssPrivateKey::new(&pk, &sk.declassify()).map_err(|_| CRYPTO_ERROR)?;
+    let pk_modulus_vec = pk_modulus.declassify();
+    let sk_vec = sk.declassify();
+    let sk = VarLenPrivateKey::from_components(&pk_modulus_vec[1..], &sk_vec)
+        .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
 
     let msg = &input.declassify();
-    let sig = sk.sign(signature::DigestAlgorithm::Sha256, &salt, msg);
-    sig.map(|sig| sig.as_bytes().into())
-        .map_err(|_| CRYPTO_ERROR)
+    // XXX: hard coded length because of bad libcrux API
+    let mut signature = [0u8; 512];
+    sign_varlen(
+        RsaDigestAlgorithm::Sha2_256,
+        &sk,
+        &msg,
+        &salt,
+        &mut signature,
+    )
+    .map_err(|_| CRYPTO_ERROR)?;
+
+    Ok(signature.into())
 }
 
 /// Sign the bytes in `input` with the signature key `sk` and `algorithm`.
@@ -358,33 +374,36 @@ pub(crate) fn sign(
     algorithm: &SignatureScheme,
     sk: &Bytes,
     input: &Bytes,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<Bytes, TLSError> {
-    let sig = match algorithm {
-        SignatureScheme::EcdsaSecp256r1Sha256 => signature::sign(
-            algorithm.libcrux_scheme()?,
+    match algorithm {
+        SignatureScheme::EcdsaSecp256r1Sha256 => libcrux_ecdsa::p256::rand::sign(
+            EcDsaDigestAlgorithm::Sha256,
             &input.declassify(),
-            &sk.declassify(),
+            &sk.declassify()
+                .as_slice()
+                .try_into()
+                .map_err(|_| INCORRECT_ARRAY_LENGTH)?,
             rng,
-        ),
-        SignatureScheme::ED25519 => signature::sign(
-            algorithm.libcrux_scheme()?,
+        )
+        .map_err(|_| CRYPTO_ERROR)
+        .map(|s| {
+            let (r, s) = s.as_bytes();
+            Bytes::from(r).concat(Bytes::from(s))
+        }),
+
+        SignatureScheme::ED25519 => libcrux_ed25519::sign(
             &input.declassify(),
-            &sk.declassify(),
-            rng,
-        ),
+            &sk.declassify()
+                .try_into()
+                .map_err(|_| INCORRECT_ARRAY_LENGTH)?,
+        )
+        .map_err(|_| CRYPTO_ERROR)
+        .map(|s| s.into()),
+
         SignatureScheme::RsaPssRsaSha256 => {
             panic!("wrong function, use sign_rsa")
         }
-    };
-    match sig {
-        Ok(signature::Signature::Ed25519(sig)) => Ok(sig.as_bytes().into()),
-        Ok(signature::Signature::EcDsaP256(sig)) => {
-            let (r, s) = sig.as_bytes();
-            Ok(Bytes::from(r).concat(Bytes::from(s)))
-        }
-        Ok(signature::Signature::RsaPss(sig)) => panic!("wrong function, use sign_rsa"),
-        Err(_) => tlserr(CRYPTO_ERROR),
     }
 }
 
@@ -399,33 +418,26 @@ pub(crate) fn verify(
     sig: &Bytes,
 ) -> Result<(), TLSError> {
     match (alg, pk) {
-        (SignatureScheme::ED25519, PublicVerificationKey::EcDsa(pk)) => {
-            let res = signature::verify(
-                &input.declassify(),
-                &signature::Signature::Ed25519(signature::Ed25519Signature::from_bytes(
-                    sig.declassify_array()?,
-                )),
-                &pk.declassify(),
-            );
-            match res {
-                Ok(res) => Ok(res),
-                Err(_) => tlserr(INVALID_SIGNATURE),
-            }
-        }
+        (SignatureScheme::ED25519, PublicVerificationKey::EcDsa(pk)) => libcrux_ed25519::verify(
+            &input.declassify(),
+            &pk.declassify()
+                .try_into()
+                .map_err(|_| INCORRECT_ARRAY_LENGTH)?,
+            &sig.declassify_array()?,
+        )
+        .map_err(|_| INVALID_SIGNATURE),
+
         (SignatureScheme::EcdsaSecp256r1Sha256, PublicVerificationKey::EcDsa(pk)) => {
-            let res = signature::verify(
+            libcrux_ecdsa::p256::verify(
+                EcDsaDigestAlgorithm::Sha256,
                 &input.declassify(),
-                &signature::Signature::EcDsaP256(signature::EcDsaP256Signature::from_bytes(
-                    sig.declassify_array()?,
-                    signature::Algorithm::EcDsaP256(signature::DigestAlgorithm::Sha256),
-                )),
-                &pk.declassify(),
-            );
-            match res {
-                Ok(res) => Ok(res),
-                Err(_) => tlserr(INVALID_SIGNATURE),
-            }
+                &libcrux_ecdsa::p256::Signature::from_bytes(sig.declassify_array()?),
+                &libcrux_ecdsa::p256::PublicKey::try_from(&pk.declassify_array()?)
+                    .map_err(|_| CRYPTO_ERROR)?,
+            )
+            .map_err(|_| INVALID_SIGNATURE)
         }
+
         (
             SignatureScheme::RsaPssRsaSha256,
             PublicVerificationKey::Rsa(RsaVerificationKey {
@@ -436,19 +448,19 @@ pub(crate) fn verify(
             if !valid_rsa_exponent(e.declassify()) {
                 tlserr(UNSUPPORTED_ALGORITHM)
             } else {
-                let key_size = supported_rsa_key_size(n)?;
-                let pk = RsaPssPublicKey::new(key_size, &n.declassify()[1..])
-                    .map_err(|_| CRYPTO_ERROR)?;
-                let res = pk.verify(
-                    signature::DigestAlgorithm::Sha256,
-                    &sig.declassify().into(),
+                supported_rsa_key_size(n)?;
+                let n_vec = n.declassify();
+                let pk =
+                    VarLenPublicKey::try_from(&n_vec[1..]).map_err(|_| INCORRECT_ARRAY_LENGTH)?;
+
+                verify_varlen(
+                    RsaDigestAlgorithm::Sha2_256,
+                    &pk,
                     &input.declassify(),
                     32, // salt must be same length as digest ouput length
-                );
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(_) => tlserr(CRYPTO_ERROR),
-                }
+                    &sig.declassify(),
+                )
+                .map_err(|_| CRYPTO_ERROR)
             }
         }
         _ => tlserr(UNSUPPORTED_ALGORITHM),
@@ -457,17 +469,12 @@ pub(crate) fn verify(
 
 /// Determine if given modulus conforms to one of the key sizes supported by
 /// `libcrux`.
-fn supported_rsa_key_size(n: &Bytes) -> Result<RsaPssKeySize, u8> {
-    let key_size = match n.len() as u16 {
+fn supported_rsa_key_size(n: &Bytes) -> Result<(), u8> {
+    match n.len() as u16 {
         // The format includes an extra 0-byte in front to disambiguate from negative numbers
-        257 => RsaPssKeySize::N2048,
-        385 => RsaPssKeySize::N3072,
-        513 => RsaPssKeySize::N4096,
-        769 => RsaPssKeySize::N6144,
-        1025 => RsaPssKeySize::N8192,
-        _ => return tlserr(UNSUPPORTED_ALGORITHM),
-    };
-    Ok(key_size)
+        257 | 385 | 513 | 769 | 1025 => Ok(()),
+        _ => tlserr(UNSUPPORTED_ALGORITHM),
+    }
 }
 
 /// Determine if given public exponent is supported by `libcrux`, i.e. whether
@@ -733,26 +740,26 @@ impl TryFrom<&str> for Algorithms {
             "SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256" => {
                 Ok(SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256)
             }
-            "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256" => {
-                Ok(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256)
-            }
-            "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519" => {
-                Ok(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519)
-            }
-            "SHA256_Aes128Gcm_RsaPssRsaSha256_P256" => Ok(SHA256_Aes128Gcm_RsaPssRsaSha256_P256),
-            "SHA256_Aes128Gcm_RsaPssRsaSha256_X25519" => {
-                Ok(SHA256_Aes128Gcm_RsaPssRsaSha256_X25519)
-            }
-            "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256" => {
-                Ok(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256)
-            }
-            "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519" => {
-                Ok(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519)
-            }
-            "SHA384_Aes256Gcm_RsaPssRsaSha256_P256" => Ok(SHA384_Aes256Gcm_RsaPssRsaSha256_P256),
-            "SHA384_Aes256Gcm_RsaPssRsaSha256_X25519" => {
-                Ok(SHA384_Aes256Gcm_RsaPssRsaSha256_X25519)
-            }
+            // "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256" => {
+            //     Ok(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256)
+            // }
+            // "SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519" => {
+            //     Ok(SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519)
+            // }
+            // "SHA256_Aes128Gcm_RsaPssRsaSha256_P256" => Ok(SHA256_Aes128Gcm_RsaPssRsaSha256_P256),
+            // "SHA256_Aes128Gcm_RsaPssRsaSha256_X25519" => {
+            //     Ok(SHA256_Aes128Gcm_RsaPssRsaSha256_X25519)
+            // }
+            // "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256" => {
+            //     Ok(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256)
+            // }
+            // "SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519" => {
+            //     Ok(SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519)
+            // }
+            // "SHA384_Aes256Gcm_RsaPssRsaSha256_P256" => Ok(SHA384_Aes256Gcm_RsaPssRsaSha256_P256),
+            // "SHA384_Aes256Gcm_RsaPssRsaSha256_X25519" => {
+            //     Ok(SHA384_Aes256Gcm_RsaPssRsaSha256_X25519)
+            // }
             "SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00" => {
                 Ok(SHA256_Chacha20Poly1305_EcdsaSecp256r1Sha256_X25519Kyber768Draft00)
             }
@@ -776,19 +783,6 @@ impl Display for Algorithms {
         )
     }
 }
-
-/// `TLS_AES_128_GCM_SHA256`
-/// with
-/// * x25519 for key exchange
-/// * EcDSA P256 SHA256 for signatures
-pub const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Aes128Gcm,
-    SignatureScheme::EcdsaSecp256r1Sha256,
-    KemScheme::X25519,
-    false,
-    false,
-);
 
 /// `TLS_CHACHA20_POLY1305_SHA256`
 /// with
@@ -869,93 +863,108 @@ pub const SHA256_Chacha20Poly1305_RsaPssRsaSha256_P256: Algorithms = Algorithms:
     false,
 );
 
-/// `TLS_AES_128_GCM_SHA256`
-/// with
-/// * P256 for key exchange
-/// * EcDSA P256 SHA256 for signatures
-pub const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Aes128Gcm,
-    SignatureScheme::EcdsaSecp256r1Sha256,
-    KemScheme::Secp256r1,
-    false,
-    false,
-);
+// We don't support AES right now.
 
-/// `TLS_AES_128_GCM_SHA256`
-/// with
-/// * P256 for key exchange
-/// * RSA PSS SHA256 for signatures
-pub const SHA256_Aes128Gcm_RsaPssRsaSha256_P256: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Aes128Gcm,
-    SignatureScheme::RsaPssRsaSha256,
-    KemScheme::Secp256r1,
-    false,
-    false,
-);
+// /// `TLS_AES_128_GCM_SHA256`
+// /// with
+// /// * x25519 for key exchange
+// /// * EcDSA P256 SHA256 for signatures
+// pub const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA256,
+//     AeadAlgorithm::Aes128Gcm,
+//     SignatureScheme::EcdsaSecp256r1Sha256,
+//     KemScheme::X25519,
+//     false,
+//     false,
+// );
 
-/// `TLS_AES_128_GCM_SHA256`
-/// with
-/// * x25519 for key exchange
-/// * RSA PSS SHA256 for signatures
-pub const SHA256_Aes128Gcm_RsaPssRsaSha256_X25519: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA256,
-    AeadAlgorithm::Aes128Gcm,
-    SignatureScheme::RsaPssRsaSha256,
-    KemScheme::X25519,
-    false,
-    false,
-);
+// /// `TLS_AES_128_GCM_SHA256`
+// /// with
+// /// * P256 for key exchange
+// /// * EcDSA P256 SHA256 for signatures
+// pub const SHA256_Aes128Gcm_EcdsaSecp256r1Sha256_P256: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA256,
+//     AeadAlgorithm::Aes128Gcm,
+//     SignatureScheme::EcdsaSecp256r1Sha256,
+//     KemScheme::Secp256r1,
+//     false,
+//     false,
+// );
 
-/// `TLS_AES_256_GCM_SHA384`
-/// with
-/// * x25519 for key exchange
-/// * RSA PSS SHA256 for signatures
-pub const SHA384_Aes256Gcm_RsaPssRsaSha256_X25519: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA384,
-    AeadAlgorithm::Aes256Gcm,
-    SignatureScheme::RsaPssRsaSha256,
-    KemScheme::X25519,
-    false,
-    false,
-);
+// /// `TLS_AES_128_GCM_SHA256`
+// /// with
+// /// * P256 for key exchange
+// /// * RSA PSS SHA256 for signatures
+// pub const SHA256_Aes128Gcm_RsaPssRsaSha256_P256: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA256,
+//     AeadAlgorithm::Aes128Gcm,
+//     SignatureScheme::RsaPssRsaSha256,
+//     KemScheme::Secp256r1,
+//     false,
+//     false,
+// );
 
-/// `TLS_AES_256_GCM_SHA384`
-/// with
-/// * x25519 for key exchange
-/// * EcDSA P256 SHA256 for signatures
-pub const SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA384,
-    AeadAlgorithm::Aes256Gcm,
-    SignatureScheme::EcdsaSecp256r1Sha256,
-    KemScheme::X25519,
-    false,
-    false,
-);
+// /// `TLS_AES_128_GCM_SHA256`
+// /// with
+// /// * x25519 for key exchange
+// /// * RSA PSS SHA256 for signatures
+// pub const SHA256_Aes128Gcm_RsaPssRsaSha256_X25519: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA256,
+//     AeadAlgorithm::Aes128Gcm,
+//     SignatureScheme::RsaPssRsaSha256,
+//     KemScheme::X25519,
+//     false,
+//     false,
+// );
 
-/// `TLS_AES_256_GCM_SHA384`
-/// with
-/// * P256 for key exchange
-/// * RSA PSS SHA256 for signatures
-pub const SHA384_Aes256Gcm_RsaPssRsaSha256_P256: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA384,
-    AeadAlgorithm::Aes256Gcm,
-    SignatureScheme::RsaPssRsaSha256,
-    KemScheme::Secp256r1,
-    false,
-    false,
-);
+// /// `TLS_AES_256_GCM_SHA384`
+// /// with
+// /// * x25519 for key exchange
+// /// * RSA PSS SHA256 for signatures
+// pub const SHA384_Aes256Gcm_RsaPssRsaSha256_X25519: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA384,
+//     AeadAlgorithm::Aes256Gcm,
+//     SignatureScheme::RsaPssRsaSha256,
+//     KemScheme::X25519,
+//     false,
+//     false,
+// );
 
-/// `TLS_AES_256_GCM_SHA384`
-/// with
-/// * P256 for key exchange
-/// * EcDSA P256 SHA256 for signatures
-pub const SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256: Algorithms = Algorithms::new(
-    HashAlgorithm::SHA384,
-    AeadAlgorithm::Aes256Gcm,
-    SignatureScheme::EcdsaSecp256r1Sha256,
-    KemScheme::Secp256r1,
-    false,
-    false,
-);
+// /// `TLS_AES_256_GCM_SHA384`
+// /// with
+// /// * x25519 for key exchange
+// /// * EcDSA P256 SHA256 for signatures
+// pub const SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_X25519: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA384,
+//     AeadAlgorithm::Aes256Gcm,
+//     SignatureScheme::EcdsaSecp256r1Sha256,
+//     KemScheme::X25519,
+//     false,
+//     false,
+// );
+
+// /// `TLS_AES_256_GCM_SHA384`
+// /// with
+// /// * P256 for key exchange
+// /// * RSA PSS SHA256 for signatures
+// pub const SHA384_Aes256Gcm_RsaPssRsaSha256_P256: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA384,
+//     AeadAlgorithm::Aes256Gcm,
+//     SignatureScheme::RsaPssRsaSha256,
+//     KemScheme::Secp256r1,
+//     false,
+//     false,
+// );
+
+// /// `TLS_AES_256_GCM_SHA384`
+// /// with
+// /// * P256 for key exchange
+// /// * EcDSA P256 SHA256 for signatures
+// pub const SHA384_Aes256Gcm_EcdsaSecp256r1Sha256_P256: Algorithms = Algorithms::new(
+//     HashAlgorithm::SHA384,
+//     AeadAlgorithm::Aes256Gcm,
+//     SignatureScheme::EcdsaSecp256r1Sha256,
+//     KemScheme::Secp256r1,
+//     false,
+//     false,
+// );

--- a/src/tls13crypto.rs
+++ b/src/tls13crypto.rs
@@ -255,8 +255,7 @@ pub(crate) fn aead_encrypt(
     // We only support Chacha20Poly1305 right now.
     let key = k
         .bytes
-        .as_raw()
-        .try_into()
+        .declassify_array()
         .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
 
     let mut ctxt = vec![0u8; plain.len()];
@@ -294,8 +293,7 @@ pub(crate) fn aead_decrypt(
     let tag: [u8; 16] = tag.declassify_array()?;
     let key = k
         .bytes
-        .as_raw()
-        .try_into()
+        .declassify_array()
         .map_err(|_| INCORRECT_ARRAY_LENGTH)?;
     let mut ptxt = vec![0u8; ctxt.len()];
 

--- a/src/tls13formats.rs
+++ b/src/tls13formats.rs
@@ -26,7 +26,7 @@ use handshake_data::{HandshakeData, HandshakeType};
 pub use handshake_data::{HandshakeData, HandshakeType};
 
 #[cfg(feature = "hax-pv")]
-use hax_lib_macros::{pv_constructor, pv_handwritten};
+use hax_lib::{pv_constructor, pv_handwritten};
 
 // Well Known Constants
 

--- a/src/tls13formats/handshake_data.rs
+++ b/src/tls13formats/handshake_data.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "hax-pv")]
-use hax_lib_macros::{pv_constructor, pv_handwritten};
+use hax_lib::{pv_constructor, pv_handwritten};
 
 use crate::tls13utils::{
     bytes1, check_eq, encode_length_u24, eq1, length_u24_encoded, parse_failed, tlserr, Bytes,

--- a/src/tls13handshake.rs
+++ b/src/tls13handshake.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::{
     server::{lookup_db, ServerDB, ServerInfo},
@@ -261,7 +261,7 @@ fn build_client_hello(
     sn: &Bytes,
     tkt: Option<Bytes>,
     psk: Option<Psk>,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -506,7 +506,7 @@ pub fn client_init(
     sn: &Bytes,
     tkt: Option<Bytes>,
     psk: Option<Psk>,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -619,7 +619,7 @@ fn process_psk_binder_zero_rtt(
 
 fn get_server_hello(
     state: ServerPostClientHello,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<(HandshakeData, DuplexCipherStateH, ServerPostServerHello), TLSError> {
     let mut server_random = [0u8; 32];
     rng.fill_bytes(&mut server_random);
@@ -659,7 +659,7 @@ fn get_rsa_signature(
     cert: &Bytes,
     sk: &Bytes,
     sigval: &Bytes,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<Bytes, TLSError> {
     // To avoid cyclic dependencies between the modules we pull out
     // the values from the RSA certificate here.
@@ -671,7 +671,7 @@ fn get_rsa_signature(
 
 fn get_server_signature_no_psk(
     state: ServerPostServerHello,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -719,7 +719,7 @@ fn get_server_signature_no_psk(
 
 fn get_server_signature(
     state: ServerPostServerHello,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -826,7 +826,7 @@ pub fn server_init_no_psk(
     algs: Algorithms,
     ch: &HandshakeData,
     db: ServerDB,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -852,7 +852,7 @@ pub fn server_init_psk(
     algs: Algorithms,
     ch: &HandshakeData,
     db: ServerDB,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,
@@ -878,7 +878,7 @@ pub fn server_init(
     algs: Algorithms,
     ch: &HandshakeData,
     db: ServerDB,
-    rng: &mut (impl CryptoRng + RngCore),
+    rng: &mut impl CryptoRng,
 ) -> Result<
     (
         HandshakeData,

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -76,6 +76,7 @@ impl U8 {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) trait Declassify<T> {
     fn declassify(self) -> T;
 }

--- a/src/tls13utils.rs
+++ b/src/tls13utils.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 #[cfg(feature = "hax-fstar")]
-use hax_lib_macros::{attributes, requires};
+use hax_lib::{attributes, requires};
 
 use crate::std::{format, string::String, vec, vec::Vec};
 
@@ -454,7 +454,7 @@ macro_rules! bytes_concat {
 pub(crate) use bytes_concat;
 
 #[cfg(feature = "hax-pv")]
-use hax_lib_macros::{pv_constructor, pv_handwritten};
+use hax_lib::{pv_constructor, pv_handwritten};
 
 impl Bytes {
     /// Get a hex representation of self as [`String`].


### PR DESCRIPTION
This commit updates the libcrux dependency, moving to pure Rust and using the latest release.

This also disables all AES ciphersuites because libcrux doesn't support AES, and should fix the hax extraction that's currently broken.