### PR TITLE
update libcrux versions to 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,14 @@ backtrace = "0.3.0"
 rand = "0.9"
 hex = "0.4.3"
 tracing = "0.1"
-libcrux-kem = { version = "0.0.2", git = "https://github.com/cryspen/libcrux", features = [
-    "kyber",
-] }
-libcrux-sha2 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
-libcrux-hmac = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
-libcrux-hkdf = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-kem = { version = "0.0.2", features = ["kyber"] }
+libcrux-sha2 = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux" }
+libcrux-hmac = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux" }
+libcrux-hkdf = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux" }
 libcrux-chacha20poly1305 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
-libcrux-rsa = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
-libcrux-ed25519 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
-libcrux-ecdsa = { version = "0.0.2", git = "https://github.com/cryspen/libcrux", features = [
+libcrux-rsa = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux" }
+libcrux-ed25519 = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux" }
+libcrux-ecdsa = { version = "0.0.3-alpha.1", git = "https://github.com/cryspen/libcrux", features = [
     "rand",
 ] }
 hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ backtrace = "0.3.0"
 rand = "0.9"
 hex = "0.4.3"
 tracing = "0.1"
-libcrux-kem = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux", features = [
+libcrux-kem = { version = "0.0.2", git = "https://github.com/cryspen/libcrux", features = [
     "kyber",
 ] }
-libcrux-sha2 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-hmac = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-hkdf = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-chacha20poly1305 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-rsa = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-ed25519 = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux" }
-libcrux-ecdsa = { version = "0.0.2-beta.3", git = "https://github.com/cryspen/libcrux", features = [
+libcrux-sha2 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-hmac = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-hkdf = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-chacha20poly1305 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-rsa = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-ed25519 = { version = "0.0.2", git = "https://github.com/cryspen/libcrux" }
+libcrux-ecdsa = { version = "0.0.2", git = "https://github.com/cryspen/libcrux", features = [
     "rand",
 ] }
 hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax" }


### PR DESCRIPTION
Fixes https://github.com/cryspen/bertie/issues/151

## Type of change

- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Automation

## Motivation and Context

Bertie was pointing to a beta version of libcrux. This caused some CI actions to fail.
